### PR TITLE
Fix class loading for classes with leading L

### DIFF
--- a/src/soot/asm/AsmUtil.java
+++ b/src/soot/asm/AsmUtil.java
@@ -52,9 +52,20 @@ class AsmUtil {
 		if (internal.charAt(0) == '['){ 
 			/* [Ljava/lang/Object; */
 			internal = internal.substring(internal.lastIndexOf('[')+1, internal.length());
-			if(internal.charAt(internal.length()-1)==';')
-				internal = internal.substring(0, internal.length()-1);
 			/* Ljava/lang/Object */
+		}
+		if(internal.charAt(internal.length()-1)==';') {
+			internal = internal.substring(0, internal.length()-1);
+			// we need to have this guarded by a ; check as you can have a situation
+			// were a call is called Lxxxxx with now leading package name. Rare, but it
+			// happens. However, you need to strip the leading L it will always be
+			// followed by a ; per
+			// http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html
+			if (internal.charAt(0) == 'L') {
+				internal = internal.substring(1, internal.length());
+			}
+			internal = toQualifiedName(internal);
+			return RefType.v(internal);
 		}
 		switch (internal.charAt(0)) {
 		case 'Z':
@@ -73,13 +84,9 @@ class AsmUtil {
 			return LongType.v();
 		case 'D':
 			return DoubleType.v();
-		case 'L':
-			internal = internal.substring(1, internal.length());
-			internal = toQualifiedName(internal);
-			return RefType.v(internal);
 		default:
 			internal = toQualifiedName(internal);
-			return RefType.v(internal);	
+			return RefType.v(internal);
 		}
 	}
 	


### PR DESCRIPTION
@StevenArzt Now that I am done teaching for a while I am back to working on research as of today. I went to update my library to the newest soot and found that it broke on some of my subject programs. I found the cause via git bisect and fixed it. Let me know what you think, this is actually a pretty tricky issue.

---------------------

## Commit Message

A while ago there was a commit which broke loading classes when they had
a leading L.

bad commit => 1a1b13bd75d50c050291c564f3b4d596d07b9bfc

    commit 1a1b13bd75d50c050291c564f3b4d596d07b9bfc
    Refs: refs/bisect/bad, FlowDroid_1.0-483-g1a1b13b
    Author:     Samuel <Samuel9743@hotmail.com>
    AuthorDate: Mon Apr 14 15:23:48 2014 +0200
    Commit:     Samuel <Samuel9743@hotmail.com>
    CommitDate: Mon Apr 14 15:23:48 2014 +0200

        Change method toBaseQualifiedName to toBaseType which return now a Type
        instead of a String
    ---
     src/soot/asm/AsmUtil.java       | 41 +++++++++++++++++++++++++++++++------
     src/soot/asm/MethodBuilder.java |  3 ++-
     2 files changed, 37 insertions(+), 7 deletions(-)

This commit changed significantly how

     public static Type toBaseType(String internal)

functioned. It tried to make things smarter but in general it failed to follow
the JVM spec for type specifiers. Specifically if you give it

    Lxxxxxxxx

It will return

    xxxxxxxx

The correct behavior should be

    Lxxxxxxxx

It sees the leading L and strips it mangling the valid class name. This
is admitably an uncommon occurance to have a unpackaged class with a
leading L but it does happen.

This function on a whole seem like a bad idea as it accepts both JVM
type specifiers and class names of the form `xxx/xxx/xxx`. It should
either take class names or type specifiers not both. However, that is
definitely a larger issue than this commit.

The Fix
-------

To fix this I only strip the L if there is a ;. This follows the JVM
spec fairly closely. I have tested it on some of my subject programs, it
may need further testing for edge cases I have not thought of.

Signed-off-by: Tim Henderson <tim.tadh@gmail.com>