### PR TITLE
Make classes in soot.toolkits.graph generic

### DIFF
--- a/src/soot/jimple/toolkits/infoflow/ClassInfoFlowAnalysis.java
+++ b/src/soot/jimple/toolkits/infoflow/ClassInfoFlowAnalysis.java
@@ -214,11 +214,11 @@ public class ClassInfoFlowAnalysis
 		}
 		
 		// Each accessed field, global, and parameter becomes a node in the graph
-		HashMutableDirectedGraph dataFlowGraph = new MemoryEfficientGraph();
+		HashMutableDirectedGraph<EquivalentValue> dataFlowGraph = new MemoryEfficientGraph<EquivalentValue>();
 		Iterator<EquivalentValue> accessedIt1 = fieldsStaticsParamsAccessed.iterator();
 		while(accessedIt1.hasNext())
 		{
-			Object o = accessedIt1.next();
+			EquivalentValue o = accessedIt1.next();
 			dataFlowGraph.addNode(o);
 		}
 		
@@ -284,15 +284,15 @@ public class ClassInfoFlowAnalysis
 		accessedIt1 = fieldsStaticsParamsAccessed.iterator();
 		while(accessedIt1.hasNext())
 		{
-			Object r = accessedIt1.next();
-			Ref rRef = (Ref) ((EquivalentValue) r).getValue();
+			EquivalentValue r = accessedIt1.next();
+			Ref rRef = (Ref) r.getValue();
 			if( !(rRef.getType() instanceof RefLikeType) && !dfa.includesPrimitiveInfoFlow())
 				continue;
 			Iterator<EquivalentValue> accessedIt2 = fieldsStaticsParamsAccessed.iterator();
 			while(accessedIt2.hasNext())
 			{
-				Object s = accessedIt2.next();
-				Ref sRef = (Ref) ((EquivalentValue) s).getValue();
+				EquivalentValue s = accessedIt2.next();
+				Ref sRef = (Ref) s.getValue();
 				if( rRef instanceof ThisRef && sRef instanceof InstanceFieldRef )
 					; // don't add this edge
 				else if( sRef instanceof ThisRef && rRef instanceof InstanceFieldRef )
@@ -323,9 +323,9 @@ public class ClassInfoFlowAnalysis
 		}
 		
 		// Add every relevant field of this class (static methods don't get non-static fields)
-		for(Iterator it = sm.getDeclaringClass().getFields().iterator(); it.hasNext(); )
+		for(Iterator<SootField> it = sm.getDeclaringClass().getFields().iterator(); it.hasNext(); )
 		{
-			SootField sf = (SootField) it.next();
+			SootField sf = it.next();
 			if(sf.isStatic() || !sm.isStatic())
 			{
 				EquivalentValue fieldRefEqVal = InfoFlowAnalysis.getNodeForFieldRef(sm, sf);
@@ -339,10 +339,10 @@ public class ClassInfoFlowAnalysis
 			superclass = sm.getDeclaringClass().getSuperclass();
 		while(superclass.hasSuperclass()) // we don't want to process Object
 		{
-	        Iterator scFieldsIt = superclass.getFields().iterator();
+	        Iterator<SootField> scFieldsIt = superclass.getFields().iterator();
 	        while(scFieldsIt.hasNext())
 	        {
-				SootField scField = (SootField) scFieldsIt.next();
+				SootField scField = scFieldsIt.next();
 				if(scField.isStatic() || !sm.isStatic())
 				{
 					EquivalentValue fieldRefEqVal = InfoFlowAnalysis.getNodeForFieldRef(sm, scField);
@@ -355,11 +355,11 @@ public class ClassInfoFlowAnalysis
 		// Don't add any static fields outside of the class... unsafe???
 
 		// Each field, global, and parameter becomes a node in the graph
-		HashMutableDirectedGraph dataFlowGraph = new MemoryEfficientGraph();
+		HashMutableDirectedGraph<EquivalentValue> dataFlowGraph = new MemoryEfficientGraph<EquivalentValue>();
 		Iterator<EquivalentValue> accessedIt1 = fieldsStaticsParamsAccessed.iterator();
 		while(accessedIt1.hasNext())
 		{
-			Object o = accessedIt1.next();
+			EquivalentValue o = accessedIt1.next();
 			dataFlowGraph.addNode(o);
 		}
 		
@@ -384,15 +384,15 @@ public class ClassInfoFlowAnalysis
 		accessedIt1 = fieldsStaticsParamsAccessed.iterator();
 		while(accessedIt1.hasNext())
 		{
-			Object r = accessedIt1.next();
-			Ref rRef = (Ref) ((EquivalentValue) r).getValue();
+			EquivalentValue r = accessedIt1.next();
+			Ref rRef = (Ref) r.getValue();
 			if( !(rRef.getType() instanceof RefLikeType) && !dfa.includesPrimitiveInfoFlow() )
 				continue;
 			Iterator<EquivalentValue> accessedIt2 = fieldsStaticsParamsAccessed.iterator();
 			while(accessedIt2.hasNext())
 			{
-				Object s = accessedIt2.next();
-				Ref sRef = (Ref) ((EquivalentValue) s).getValue();
+				EquivalentValue s = accessedIt2.next();
+				Ref sRef = (Ref) s.getValue();
 				if( rRef instanceof ThisRef && sRef instanceof InstanceFieldRef )
 					; // don't add this edge
 				else if( sRef instanceof ThisRef && rRef instanceof InstanceFieldRef )

--- a/src/soot/shimple/DefaultShimpleFactory.java
+++ b/src/soot/shimple/DefaultShimpleFactory.java
@@ -34,18 +34,18 @@ public class DefaultShimpleFactory implements ShimpleFactory
     protected Body body;
     protected BlockGraph bg;
     protected UnitGraph ug;
-    protected DominatorsFinder dFinder;
-    protected DominatorTree dTree;
-    protected DominanceFrontier dFrontier;
+    protected DominatorsFinder<Block> dFinder;
+    protected DominatorTree<Block> dTree;
+    protected DominanceFrontier<Block> dFrontier;
     protected PointsToAnalysis pta;
     protected CallGraph cg;
     protected SideEffectAnalysis sea;
     protected GlobalValueNumberer gvn;
 
-    protected ReversibleGraph rbg;
-    protected DominatorTree rdTree;
-    protected DominanceFrontier rdFrontier;
-    protected DominatorsFinder rdFinder;
+    protected ReversibleGraph<Block> rbg;
+    protected DominatorTree<Block> rdTree;
+    protected DominanceFrontier<Block> rdFrontier;
+    protected DominatorsFinder<Block> rdFinder;
     
     public DefaultShimpleFactory()
     {
@@ -82,41 +82,41 @@ public class DefaultShimpleFactory implements ShimpleFactory
         return body;
     }
 
-    public ReversibleGraph getReverseBlockGraph()
+    public ReversibleGraph<Block> getReverseBlockGraph()
     {
         if(rbg != null)
             return rbg;
         
         BlockGraph bg = getBlockGraph();
-        rbg = new HashReversibleGraph(bg);
+        rbg = new HashReversibleGraph<Block>(bg);
         rbg.reverse();
         return rbg;
     }
 
-    public DominatorsFinder getReverseDominatorsFinder()
+    public DominatorsFinder<Block> getReverseDominatorsFinder()
     {
         if(rdFinder != null)
             return rdFinder;
 
-        rdFinder = new SimpleDominatorsFinder(getReverseBlockGraph());
+        rdFinder = new SimpleDominatorsFinder<Block>(getReverseBlockGraph());
         return rdFinder;
     }
 
-    public DominatorTree getReverseDominatorTree()
+    public DominatorTree<Block> getReverseDominatorTree()
     {
         if(rdTree != null)
             return rdTree;
 
-        rdTree = new DominatorTree(getReverseDominatorsFinder());
+        rdTree = new DominatorTree<Block>(getReverseDominatorsFinder());
         return rdTree;
     }
 
-    public DominanceFrontier getReverseDominanceFrontier()
+    public DominanceFrontier<Block> getReverseDominanceFrontier()
     {
         if(rdFrontier != null)
             return rdFrontier;
 
-        rdFrontier = new CytronDominanceFrontier(getReverseDominatorTree());
+        rdFrontier = new CytronDominanceFrontier<Block>(getReverseDominatorTree());
         return rdFrontier;
     }
     
@@ -141,30 +141,30 @@ public class DefaultShimpleFactory implements ShimpleFactory
         return ug;
     }
     
-    public DominatorsFinder getDominatorsFinder()
+    public DominatorsFinder<Block> getDominatorsFinder()
     {
         if(dFinder != null)
             return dFinder;
 
-        dFinder = new SimpleDominatorsFinder(getBlockGraph());
+        dFinder = new SimpleDominatorsFinder<Block>(getBlockGraph());
         return dFinder;
     }
 
-    public DominatorTree getDominatorTree()
+    public DominatorTree<Block> getDominatorTree()
     {
         if(dTree != null)
             return dTree;
 
-        dTree = new DominatorTree(getDominatorsFinder());
+        dTree = new DominatorTree<Block>(getDominatorsFinder());
         return dTree;
     }
     
-    public DominanceFrontier getDominanceFrontier()
+    public DominanceFrontier<Block> getDominanceFrontier()
     {
         if(dFrontier != null)
             return dFrontier;
 
-        dFrontier = new CytronDominanceFrontier(getDominatorTree());
+        dFrontier = new CytronDominanceFrontier<Block>(getDominatorTree());
         return dFrontier;
     }
 

--- a/src/soot/shimple/ShimpleFactory.java
+++ b/src/soot/shimple/ShimpleFactory.java
@@ -43,13 +43,13 @@ public interface ShimpleFactory
 
     public UnitGraph getUnitGraph();
     public BlockGraph getBlockGraph();
-    public DominatorsFinder getDominatorsFinder();
-    public DominatorTree getDominatorTree();
-    public DominanceFrontier getDominanceFrontier();
+    public DominatorsFinder<Block> getDominatorsFinder();
+    public DominatorTree<Block> getDominatorTree();
+    public DominanceFrontier<Block> getDominanceFrontier();
 
     public GlobalValueNumberer getGlobalValueNumberer();
-    public ReversibleGraph getReverseBlockGraph();
-    public DominatorsFinder getReverseDominatorsFinder();
-    public DominatorTree getReverseDominatorTree();
-    public DominanceFrontier getReverseDominanceFrontier();
+    public ReversibleGraph<Block> getReverseBlockGraph();
+    public DominatorsFinder<Block> getReverseDominatorsFinder();
+    public DominatorTree<Block> getReverseDominatorTree();
+    public DominanceFrontier<Block> getReverseDominanceFrontier();
 }

--- a/src/soot/shimple/internal/SHashMultiMap.java
+++ b/src/soot/shimple/internal/SHashMultiMap.java
@@ -26,20 +26,20 @@ import soot.util.*;
  *
  * @author Navindra Umanee
  **/
-public class SHashMultiMap extends HashMultiMap
+public class SHashMultiMap<K,V> extends HashMultiMap<K,V>
 {
     public SHashMultiMap()
     {
         super();
     }
 
-    public SHashMultiMap(MultiMap m)
+    public SHashMultiMap(MultiMap<K,V> m)
     {
 	super( m );
     }
 
-    protected Set newSet()
+    protected Set<V> newSet()
     {
-	return new LinkedHashSet(4);
+	return new LinkedHashSet<V>(4);
     }
 }

--- a/src/soot/shimple/internal/SPatchingChain.java
+++ b/src/soot/shimple/internal/SPatchingChain.java
@@ -143,7 +143,7 @@ public class SPatchingChain extends PatchingChain<Unit>
                     }
                 }
                     
-                if(needsPatching.booleanValue()){
+                if(needsPatching){
                     box.setUnit((Unit)toInsert);
                     box.setUnitChanged(false);
                 }
@@ -375,17 +375,17 @@ public class SPatchingChain extends PatchingChain<Unit>
         }
     }
 
-    public Iterator iterator()
+    public Iterator<Unit> iterator()
     {
         return new SPatchingIterator(innerChain);
     }
 
-    public Iterator iterator(Unit u)
+    public Iterator<Unit> iterator(Unit u)
     {
         return new SPatchingIterator(innerChain, u);
     }
 
-    public Iterator iterator(Unit head, Unit tail)
+    public Iterator<Unit> iterator(Unit head, Unit tail)
     {
         return new SPatchingIterator(innerChain, head, tail);
     }

--- a/src/soot/shimple/internal/ShimpleBodyBuilder.java
+++ b/src/soot/shimple/internal/ShimpleBodyBuilder.java
@@ -59,7 +59,7 @@ public class ShimpleBodyBuilder
 {
     protected ShimpleBody body;
     protected ShimpleFactory sf;
-    protected DominatorTree dt;
+    protected DominatorTree<Block> dt;
     protected BlockGraph cfg;
     
     /**
@@ -173,7 +173,7 @@ public class ShimpleBodyBuilder
     protected Map<Local,Local> newLocalsToOldLocal;
 
     protected int[] assignmentCounters;
-    protected Stack[] namingStacks;
+    protected Stack<Integer>[] namingStacks;
     
     /**
      * Variable Renaming Algorithm from Cytron et al 91, P26-8,
@@ -190,17 +190,17 @@ public class ShimpleBodyBuilder
         namingStacks = new Stack[origLocals.size()];
 
         for(int i = 0; i < namingStacks.length; i++)
-            namingStacks[i] = new Stack();
+            namingStacks[i] = new Stack<Integer>();
 
-        List heads = cfg.getHeads();
+        List<Block> heads = cfg.getHeads();
 
-        if(heads.size() == 0)
+        if(heads.isEmpty())
             return;
 
         if(heads.size() != 1)
             throw new RuntimeException("Assertion failed:  Only one head expected.");
         
-        Block entry = (Block) heads.get(0);
+        Block entry = heads.get(0);
         renameLocalsSearch(entry);
     }
 
@@ -222,15 +222,15 @@ public class ShimpleBodyBuilder
 
                 // Step 1/2 of 1
                 {
-                    List useBoxes = new ArrayList();
+                    List<ValueBox> useBoxes = new ArrayList();
 
                     if(!Shimple.isPhiNode(unit))
                         useBoxes.addAll(unit.getUseBoxes());
 
-                    Iterator useBoxesIt = useBoxes.iterator();
+                    Iterator<ValueBox> useBoxesIt = useBoxes.iterator();
                 
                     while(useBoxesIt.hasNext()){
-                        ValueBox useBox = (ValueBox) useBoxesIt.next();
+                        ValueBox useBox = useBoxesIt.next();
                         Value use = useBox.getValue();
 
                         int localIndex = indexOfLocal(use);
@@ -244,7 +244,7 @@ public class ShimpleBodyBuilder
                         if(namingStacks[localIndex].empty())
                             continue;
 
-                        Integer subscript = (Integer) namingStacks[localIndex].peek();
+                        Integer subscript = namingStacks[localIndex].peek();
 
                         Local renamedLocal = fetchNewLocal(localUse, subscript);
                         useBox.setValue(renamedLocal);
@@ -274,7 +274,7 @@ public class ShimpleBodyBuilder
                     if(localIndex == -1)
                         throw new RuntimeException("Assertion failed.");
                 
-                    Integer subscript = new Integer(assignmentCounters[localIndex]);
+                    Integer subscript = assignmentCounters[localIndex];
 
                     Local newLhsLocal = fetchNewLocal(lhsLocal, subscript);
                     lhsLocalBox.setValue(newLhsLocal);
@@ -288,15 +288,15 @@ public class ShimpleBodyBuilder
 
         // Step 2 of 4 -- Rename Phi node uses in Successors
         {
-            Iterator succsIt = cfg.getSuccsOf(block).iterator();
+            Iterator<Block> succsIt = cfg.getSuccsOf(block).iterator();
 
             while(succsIt.hasNext()){
-                Block succ = (Block) succsIt.next();
+                Block succ = succsIt.next();
 
-                Iterator unitsIt = succ.iterator();
+                Iterator<Unit> unitsIt = succ.iterator();
 
                 while(unitsIt.hasNext()){
-                    Unit unit = (Unit) unitsIt.next();
+                    Unit unit = unitsIt.next();
 
                     PhiExpr phiExpr = Shimple.getPhiExpr(unit);
 
@@ -319,7 +319,7 @@ public class ShimpleBodyBuilder
                     if(namingStacks[localIndex].empty())
                         continue;
 
-                    Integer subscript = (Integer) namingStacks[localIndex].peek();
+                    Integer subscript = namingStacks[localIndex].peek();
                     
                     Local newPhiArg = fetchNewLocal(phiArg, subscript);
                     phiArgBox.setValue(newPhiArg);
@@ -329,16 +329,16 @@ public class ShimpleBodyBuilder
 
         // Step 3 of 4 -- Recurse over children.
         {
-            DominatorNode node = dt.getDode(block);
+            DominatorNode<Block> node = dt.getDode(block);
 
             // now we recurse over children
 
-            Iterator childrenIt = dt.getChildrenOf(node).iterator();
+            Iterator<DominatorNode<Block>> childrenIt = dt.getChildrenOf(node).iterator();
 
             while(childrenIt.hasNext()){
-                DominatorNode childNode = (DominatorNode) childrenIt.next();
+                DominatorNode<Block> childNode = childrenIt.next();
 
-                renameLocalsSearch((Block) childNode.getGode());
+                renameLocalsSearch(childNode.getGode());
             }
         }
 
@@ -423,10 +423,10 @@ public class ShimpleBodyBuilder
         }
 
         Set<String> localNames = new HashSet<String>();
-        Iterator localsIt = body.getLocals().iterator();
+        Iterator<Local> localsIt = body.getLocals().iterator();
 
         while(localsIt.hasNext()){
-            Local local = (Local) localsIt.next();
+            Local local = localsIt.next();
             String localName = local.getName();
             
             if(localNames.contains(localName)){

--- a/src/soot/toolkits/graph/CytronDominanceFrontier.java
+++ b/src/soot/toolkits/graph/CytronDominanceFrontier.java
@@ -31,20 +31,20 @@ import java.util.*;
  * Computing Static Single Assignment Form and the Control Dependence
  * Graph</a>
  **/
-public class CytronDominanceFrontier implements DominanceFrontier
+public class CytronDominanceFrontier<N> implements DominanceFrontier<N>
 {
-    protected DominatorTree dt;
-    protected Map<DominatorNode, List<DominatorNode>> nodeToFrontier;
+    protected DominatorTree<N> dt;
+    protected Map<DominatorNode<N>, List<DominatorNode<N>>> nodeToFrontier;
     
-    public CytronDominanceFrontier(DominatorTree dt)
+    public CytronDominanceFrontier(DominatorTree<N> dt)
     {
         this.dt = dt;
-        nodeToFrontier = new HashMap<DominatorNode, List<DominatorNode>>();
-        for (DominatorNode head : dt.getHeads()) {
+        nodeToFrontier = new HashMap<DominatorNode<N>, List<DominatorNode<N>>>();
+        for (DominatorNode<N> head : dt.getHeads()) {
             bottomUpDispatch(head);
         }
-        for(Object gode : dt.graph) {
-            DominatorNode dode = dt.fetchDode(gode);
+        for(N gode : dt.graph) {
+            DominatorNode<N> dode = dt.fetchDode(gode);
             if (dode == null) {
                 throw new RuntimeException("dode == null");
             } else if (!isFrontierKnown(dode)) {
@@ -56,15 +56,15 @@ public class CytronDominanceFrontier implements DominanceFrontier
         }
     }
 
-    public List<DominatorNode> getDominanceFrontierOf(DominatorNode node)
+    public List<DominatorNode<N>> getDominanceFrontierOf(DominatorNode<N> node)
     {
-        List<DominatorNode> frontier = nodeToFrontier.get(node);
+        List<DominatorNode<N>> frontier = nodeToFrontier.get(node);
         if(frontier == null)
             throw new RuntimeException("Frontier not defined for node: " + node);
-        return new ArrayList<DominatorNode>(frontier);
+        return new ArrayList<DominatorNode<N>>(frontier);
     }
 
-    protected boolean isFrontierKnown(DominatorNode node)
+    protected boolean isFrontierKnown(DominatorNode<N> node)
     {
         return nodeToFrontier.containsKey(node);
     }
@@ -73,7 +73,7 @@ public class CytronDominanceFrontier implements DominanceFrontier
      * Make sure we visit children first.  This is reverse topological
      * order.
      **/
-    protected void bottomUpDispatch(DominatorNode node)
+    protected void bottomUpDispatch(DominatorNode<N> node)
     {
         // *** FIXME: It's annoying that this algorithm is so
         // *** inefficient in that in traverses the tree from the head
@@ -82,7 +82,7 @@ public class CytronDominanceFrontier implements DominanceFrontier
         if(isFrontierKnown(node))
             return;
 
-        for (DominatorNode child : dt.getChildrenOf(node)) {
+        for (DominatorNode<N> child : dt.getChildrenOf(node)) {
             if(!isFrontierKnown(child))
                 bottomUpDispatch(child);
         }
@@ -109,16 +109,16 @@ public class CytronDominanceFrontier implements DominanceFrontier
      *      end
      * </pre>
      **/
-    protected void processNode(DominatorNode node)
+    protected void processNode(DominatorNode<N> node)
     {
-        List<DominatorNode> dominanceFrontier = new ArrayList<DominatorNode>();
+        List<DominatorNode<N>> dominanceFrontier = new ArrayList<DominatorNode<N>>();
         
         // local
         {
-            Iterator<DominatorNode> succsIt = dt.getSuccsOf(node).iterator();
+            Iterator<DominatorNode<N>> succsIt = dt.getSuccsOf(node).iterator();
             
             while(succsIt.hasNext()){
-                DominatorNode succ = succsIt.next();
+                DominatorNode<N> succ = succsIt.next();
                 
                 if(!dt.isImmediateDominatorOf(node, succ))
                     dominanceFrontier.add(succ);
@@ -127,10 +127,11 @@ public class CytronDominanceFrontier implements DominanceFrontier
 
         // up
         {
-        	for (DominatorNode child : dt.getChildrenOf(node)) {
-        		for (DominatorNode childFront : getDominanceFrontierOf(child)) {
-                    if(!dt.isImmediateDominatorOf(node, childFront))
+            for (DominatorNode<N> child : dt.getChildrenOf(node)) {
+                for (DominatorNode<N> childFront : getDominanceFrontierOf(child)) {
+                    if(!dt.isImmediateDominatorOf(node, childFront)){
                         dominanceFrontier.add(childFront);
+                    }
                 }
             }
         }

--- a/src/soot/toolkits/graph/DominanceFrontier.java
+++ b/src/soot/toolkits/graph/DominanceFrontier.java
@@ -27,8 +27,8 @@ import java.util.*;
  *
  * @author Navindra Umanee
  **/
-public interface DominanceFrontier
+public interface DominanceFrontier<N>
 {
-    public List getDominanceFrontierOf(DominatorNode node);
+    public List<DominatorNode<N>> getDominanceFrontierOf(DominatorNode<N> node);
 }
 

--- a/src/soot/toolkits/graph/DominatorNode.java
+++ b/src/soot/toolkits/graph/DominatorNode.java
@@ -29,23 +29,23 @@ import java.util.*;
  *
  * @author Navindra Umanee
  **/
-public class DominatorNode
+public class DominatorNode<N>
 {
-    protected Object gode;
-    protected DominatorNode parent;
-    protected List<DominatorNode> children;
+    protected N gode;
+    protected DominatorNode<N> parent;
+    protected List<DominatorNode<N>> children;
 
-    protected DominatorNode(Object gode)
+    protected DominatorNode(N gode)
     {
         this.gode = gode;
-        children = new ArrayList<DominatorNode>();
+        children = new ArrayList<DominatorNode<N>>();
     }
 
     /**
      * Sets the parent of this node in the DominatorTree.  Usually
      * called internally.
      **/
-    public void setParent(DominatorNode parent)
+    public void setParent(DominatorNode<N> parent)
     {
         this.parent = parent;
     }
@@ -54,7 +54,7 @@ public class DominatorNode
      * Adds a child to the internal list of children of this node in
      * tree.  Usually called internally.
      **/
-    public boolean addChild(DominatorNode child)
+    public boolean addChild(DominatorNode<N> child)
     {
         if(children.contains(child)){
             return false;
@@ -69,7 +69,7 @@ public class DominatorNode
      * Returns the node (from the original DirectedGraph) encapsulated
      * by this DominatorNode.
      **/
-    public Object getGode()
+    public N getGode()
     {
         return gode;
     }
@@ -77,7 +77,7 @@ public class DominatorNode
     /**
      * Returns the parent of the node in the DominatorTree.
      **/
-    public DominatorNode getParent()
+    public DominatorNode<N> getParent()
     {
         return parent;
     }
@@ -86,7 +86,7 @@ public class DominatorNode
      * Returns a backed list of the children of this node in the
      * DominatorTree.
      **/
-    public List<DominatorNode> getChildren()
+    public List<DominatorNode<N>> getChildren()
     {
         return children;
     }
@@ -96,10 +96,7 @@ public class DominatorNode
      **/
     public boolean isHead()
     {
-        if(parent == null)
-            return true;
-        else
-            return false;
+        return parent == null;
     }
 
     /**
@@ -107,10 +104,7 @@ public class DominatorNode
      **/
     public boolean isTail()
     {
-        if(children.size() == 0)
-            return true;
-        else
-            return false;
+        return children.isEmpty();
     }
 
     public String toString()

--- a/src/soot/toolkits/graph/DominatorTree.java
+++ b/src/soot/toolkits/graph/DominatorTree.java
@@ -39,18 +39,18 @@ import java.util.*;
  *
  * @author Navindra Umanee
  **/
-public class DominatorTree {
+public class DominatorTree<N> implements Iterable<DominatorNode<N>>{
 
-    protected DominatorsFinder dominators;
-    protected DirectedGraph graph;
-    protected List<DominatorNode> heads;
-    protected List<DominatorNode> tails;
+    protected DominatorsFinder<N> dominators;
+    protected DirectedGraph<N> graph;
+    protected List<DominatorNode<N>> heads;
+    protected List<DominatorNode<N>> tails;
     
     /**
      * "gode" is a node in the original graph, "dode" is a node in the
      * dominator tree.
      **/
-    protected Map<Object, DominatorNode> godeToDode;
+    protected Map<N, DominatorNode<N>> godeToDode;
 
     public DominatorTree(DominatorsFinder dominators) {
         // if(Options.v().verbose())
@@ -60,111 +60,104 @@ public class DominatorTree {
         this.dominators = dominators;
         this.graph = dominators.getGraph();
 
-        heads = new ArrayList<DominatorNode>();
-        tails = new ArrayList<DominatorNode>();
-        godeToDode = new HashMap<Object, DominatorNode>();
+        heads = new ArrayList<DominatorNode<N>>();
+        tails = new ArrayList<DominatorNode<N>>();
+        godeToDode = new HashMap<N, DominatorNode<N>>();
 
         buildTree();
     }
 
     /**
-     * Returns the original graph to which the Dominator tree
-     * pertains.
+     * @return  the original graph to which the DominatorTree pertains
      **/
-    public DirectedGraph getGraph() {
+    public DirectedGraph<N> getGraph() {
         return dominators.getGraph();
     }
 
     /**
-     * Returns the root of the dominator tree.
+     * @return  the root of the dominator tree.
      **/
-    public List<DominatorNode> getHeads() {
-        return new ArrayList<DominatorNode>(heads);
+    public List<DominatorNode<N>> getHeads() {
+        return new ArrayList<DominatorNode<N>>(heads);
     }
     
     /**
      * Gets the first head of the dominator tree. This function is implemented 
      * for single-headed trees and mainly for backwards compatibility.
-     * @return The first head of the dominator tree
+     * @return  The first head of the dominator tree
      */
-    public DominatorNode getHead() {
+    public DominatorNode<N> getHead() {
         return heads.isEmpty() ? null : heads.get(0);
     }
 
     /**
-     * Returns a list of the tails of the dominator tree.
+     * @return  list of the tails of the dominator tree.
      **/
-    public List<DominatorNode> getTails() {
-        return new ArrayList<DominatorNode>(tails);
+    public List<DominatorNode<N>> getTails() {
+        return new ArrayList<DominatorNode<N>>(tails);
     }
 
     /**
-     * Returns the parent of node in the tree, null if the node is at
+     * @return  the parent of {@code node} in the tree, null if the node is at
      * the root.
      **/
-    public DominatorNode getParentOf(DominatorNode node) {
+    public DominatorNode<N> getParentOf(DominatorNode<N> node) {
         return node.getParent();
     }
 
     /**
-     * Returns the children of node in the tree.
+     * @return  the children of node in the tree.
      **/
-    public List<DominatorNode> getChildrenOf(DominatorNode node) {
-        return new ArrayList<DominatorNode>(node.getChildren());
+    public List<DominatorNode<N>> getChildrenOf(DominatorNode<N> node) {
+        return new ArrayList<DominatorNode<N>>(node.getChildren());
     }
 
     /**
-     * Finds all the predecessors of node in the original
-     * DirectedGraph and returns a list of the corresponding
-     * DominatorNodes.
+     * @return  list of the DominatorNodes corresponding to the predecessors
+     * of {@code node} in the original DirectedGraph
      **/
-    public List<DominatorNode> getPredsOf(DominatorNode node) {
-        List preds = graph.getPredsOf(node.getGode());
-
-        List<DominatorNode> predNodes = new ArrayList<DominatorNode>();
-        for(Iterator<DominatorNode> predsIt = preds.iterator(); predsIt.hasNext();){
-            Object pred = predsIt.next();
+    public List<DominatorNode<N>> getPredsOf(DominatorNode<N> node) {
+        List<N> preds = graph.getPredsOf(node.getGode());
+        List<DominatorNode<N>> predNodes = new ArrayList<DominatorNode<N>>();
+        for (N pred : preds) {
             predNodes.add(getDode(pred));
         }
-
         return predNodes;
     }
 
     /**
-     * Finds all the successors of node in the original DirectedGraph
-     * and returns a list of the corresponding DominatorNodes.
+     * @return  list of the DominatorNodes corresponding to the successors
+     * of {@code node} in the original DirectedGraph
      **/
-    public List<DominatorNode> getSuccsOf(DominatorNode node) {
-        List succs = graph.getSuccsOf(node.getGode());
-        List<DominatorNode> succNodes = new ArrayList<DominatorNode>();
-        for(Iterator<DominatorNode> succsIt = succs.iterator(); succsIt.hasNext();){
-            Object succ = succsIt.next();
+    public List<DominatorNode<N>> getSuccsOf(DominatorNode<N> node) {
+        List<N> succs = graph.getSuccsOf(node.getGode());
+        List<DominatorNode<N>> succNodes = new ArrayList<DominatorNode<N>>();
+        for (N succ : succs) {
             succNodes.add(getDode(succ));
         }
         return succNodes;
     }
 
     /**
-     * Returns true if idom immediately dominates node.
+     * @return  true if idom immediately dominates node.
      **/
-    public boolean isImmediateDominatorOf(DominatorNode idom, DominatorNode node) {
+    public boolean isImmediateDominatorOf(DominatorNode<N> idom, DominatorNode<N> node) {
         // node.getParent() could be null
         return (node.getParent() == idom);
     }
 
     /**
-     * Returns true if dom dominates node.
+     * @return  true if dom dominates node.
      **/
-    public boolean isDominatorOf(DominatorNode dom, DominatorNode node) {
+    public boolean isDominatorOf(DominatorNode<N> dom, DominatorNode<N> node) {
         return dominators.isDominatedBy(node.getGode(), dom.getGode());
     }
 
     /**
-     * Returns the DominatorNode for a given node in the original
-     * DirectedGraph.
+     * @return  DominatorNode for a given node in the original DirectedGraph.
      **/
-    public DominatorNode getDode(Object gode) {
-        DominatorNode dode = (DominatorNode)godeToDode.get(gode);
+    public DominatorNode<N> getDode(N gode) {
+        DominatorNode<N> dode = godeToDode.get(gode);
 
         if (dode == null) {
             throw new RuntimeException("Assertion failed: Dominator tree does not have a corresponding dode for gode (" + gode + ")");
@@ -174,15 +167,14 @@ public class DominatorTree {
     }
 
     /**
-     * Returns an iterator over the nodes in the tree.  No ordering is
-     * implied.
+     * @return  iterator over the nodes in the tree.  No ordering is implied.
      **/
-    public Iterator<DominatorNode> iterator() {
+    public Iterator<DominatorNode<N>> iterator() {
         return godeToDode.values().iterator();
     }
 
     /**
-     * Returns the number of nodes in the tree.
+     * @return  the number of nodes in the tree
      **/
     public int size() {
         return godeToDode.size();
@@ -194,11 +186,9 @@ public class DominatorTree {
      **/
     protected void buildTree() {
         // hook up children with parents and vice-versa
-        for(Iterator godesIt = graph.iterator(); godesIt.hasNext();) {
-            Object gode = godesIt.next();
-
-            DominatorNode dode = fetchDode(gode);
-            DominatorNode parent = fetchParent(gode);
+        for (N gode : graph) {
+            DominatorNode<N> dode = fetchDode(gode);
+            DominatorNode<N> parent = fetchParent(gode);
 
             if (parent == null) {
                 heads.add(dode);
@@ -209,8 +199,7 @@ public class DominatorTree {
         }
 
         // identify the tail nodes
-        for(Iterator<DominatorNode> dodesIt = this.iterator(); dodesIt.hasNext(); ) {
-            DominatorNode dode = dodesIt.next();
+        for (DominatorNode dode : this) {
             if(dode.isTail()) {
                 tails.add(dode);
             }
@@ -221,11 +210,11 @@ public class DominatorTree {
      * Convenience method, ensures we don't create more than one
      * DominatorNode for a given block.
      **/
-    protected DominatorNode fetchDode(Object gode) {
-        DominatorNode dode;
+    protected DominatorNode<N> fetchDode(N gode) {
+        DominatorNode<N> dode;
 
         if (godeToDode.containsKey(gode)) {
-            dode = (DominatorNode) godeToDode.get(gode);
+            dode = godeToDode.get(gode);
         } else {
             dode = new DominatorNode(gode);
             godeToDode.put(gode, dode);
@@ -234,8 +223,8 @@ public class DominatorTree {
         return dode;
     }
 
-    protected DominatorNode fetchParent(Object gode) {
-        Object immediateDominator = dominators.getImmediateDominator(gode);
+    protected DominatorNode<N> fetchParent(N gode) {
+        N immediateDominator = dominators.getImmediateDominator(gode);
 
         if (immediateDominator == null) {
             return null;

--- a/src/soot/toolkits/graph/DominatorTreeAdapter.java
+++ b/src/soot/toolkits/graph/DominatorTreeAdapter.java
@@ -31,36 +31,36 @@ import java.util.*;
  *
  * @author Navindra Umanee
  **/
-public class DominatorTreeAdapter implements DirectedGraph<DominatorNode>
+public class DominatorTreeAdapter<N> implements DirectedGraph<DominatorNode<N>>
 {
-    DominatorTree dt;
+    DominatorTree<N> dt;
     
-    public DominatorTreeAdapter(DominatorTree dt)
+    public DominatorTreeAdapter(DominatorTree<N> dt)
     {
         this.dt = dt;
     }
 
-    public List<DominatorNode> getHeads()
+    public List<DominatorNode<N>> getHeads()
     {
         return dt.getHeads();
     }
 
-    public List<DominatorNode> getTails()
+    public List<DominatorNode<N>> getTails()
     {
         return dt.getTails();
     }
 
-    public List<DominatorNode> getPredsOf(DominatorNode node)
+    public List<DominatorNode<N>> getPredsOf(DominatorNode<N> node)
     {
         return Collections.singletonList(dt.getParentOf(node));
     }
 
-    public List<DominatorNode> getSuccsOf(DominatorNode node)
+    public List<DominatorNode<N>> getSuccsOf(DominatorNode<N> node)
     {
         return dt.getChildrenOf(node);
     }
 
-    public Iterator<DominatorNode> iterator()
+    public Iterator<DominatorNode<N>> iterator()
     {
         return dt.iterator();
     }

--- a/src/soot/toolkits/graph/HashReversibleGraph.java
+++ b/src/soot/toolkits/graph/HashReversibleGraph.java
@@ -26,25 +26,25 @@ import java.util.*;
  *
  * @author Navindra Umanee
  **/
-public class HashReversibleGraph extends HashMutableDirectedGraph
-    implements ReversibleGraph
+public class HashReversibleGraph<N> extends HashMutableDirectedGraph<N>
+    implements ReversibleGraph<N>
 {
     protected boolean reversed;
 
-    public HashReversibleGraph(DirectedGraph dg)
+    public HashReversibleGraph(DirectedGraph<N> dg)
     {
         this();
 
-        for(Iterator i = dg.iterator(); i.hasNext();){
-            Object s = i.next();
+        for(Iterator<N> i = dg.iterator(); i.hasNext();){
+            N s = i.next();
             addNode(s);
         }
 
-        for(Iterator i = dg.iterator(); i.hasNext();){
-            Object s = i.next();
-            List succs = dg.getSuccsOf(s);
-            for(Iterator succsIt = succs.iterator(); succsIt.hasNext();){
-                Object t = succsIt.next();
+        for(Iterator<N> i = dg.iterator(); i.hasNext();){
+            N s = i.next();
+            List<N> succs = dg.getSuccsOf(s);
+            for(Iterator<N> succsIt = succs.iterator(); succsIt.hasNext();){
+                N t = succsIt.next();
                 addEdge(s, t);
             }
         }
@@ -68,13 +68,13 @@ public class HashReversibleGraph extends HashMutableDirectedGraph
         return reversed;
     }
 
-    public ReversibleGraph reverse()
+    public ReversibleGraph<N> reverse()
     {   
         reversed = !reversed;
         return this;
     }
 
-    public void addEdge(Object from, Object to)
+    public void addEdge(N from, N to)
     {
         if(reversed)
             super.addEdge(to, from);
@@ -82,7 +82,7 @@ public class HashReversibleGraph extends HashMutableDirectedGraph
             super.addEdge(from, to);
     }
 
-    public void removeEdge(Object from, Object to)
+    public void removeEdge(N from, N to)
     {
         if(reversed)
             super.removeEdge(to, from);
@@ -90,27 +90,27 @@ public class HashReversibleGraph extends HashMutableDirectedGraph
             super.removeEdge(from, to);
     }
 
-    public boolean containsEdge(Object from, Object to)
+    public boolean containsEdge(N from, N to)
     {
         return reversed ? super.containsEdge(to, from) : super.containsEdge(from, to);
     }
 
-    public List getHeads()
+    public List<N> getHeads()
     {
         return reversed ? super.getTails() : super.getHeads();
     }
 
-    public List getTails()
+    public List<N> getTails()
     {
         return reversed ? super.getHeads() : super.getTails();
     }   
 
-    public List getPredsOf(Object s)
+    public List<N> getPredsOf(N s)
     {
         return reversed ? super.getSuccsOf(s) : super.getPredsOf(s);
     }
     
-    public List getSuccsOf(Object s)
+    public List<N> getSuccsOf(N s)
     {
         return reversed ? super.getPredsOf(s) : super.getSuccsOf(s);
     }

--- a/src/soot/toolkits/graph/MemoryEfficientGraph.java
+++ b/src/soot/toolkits/graph/MemoryEfficientGraph.java
@@ -38,22 +38,22 @@ import java.util.*;
  * process of adding edges.
  */
 
-public class MemoryEfficientGraph extends HashMutableDirectedGraph
+public class MemoryEfficientGraph<N> extends HashMutableDirectedGraph<N>
 {
 
-    HashMap<Object, Object> self = new HashMap<Object, Object>();
+    HashMap<N, N> self = new HashMap<N, N>();
 
-    public void addNode(Object o) {
+    public void addNode(N o) {
         super.addNode(o);
         self.put(o,o);
     }
 
-    public void removeNode(Object o) {
+    public void removeNode(N o) {
         super.removeNode(o);
         self.remove(o);
     }
 
-    public void addEdge(Object from, Object to) {
+    public void addEdge(N from, N to) {
         if (containsNode(from) && containsNode(to))
             super.addEdge(self.get(from), self.get(to));
         else if (!containsNode(from))
@@ -62,7 +62,7 @@ public class MemoryEfficientGraph extends HashMutableDirectedGraph
             throw new RuntimeException(to.toString() + " not in graph!");
     }
 
-    public void removeEdge(Object from, Object to) {
+    public void removeEdge(N from, N to) {
         if (containsNode(from) && containsNode(to))
             super.removeEdge(self.get(from), self.get(to));
         else if (!containsNode(from))

--- a/src/soot/toolkits/graph/SlowPseudoTopologicalOrderer.java
+++ b/src/soot/toolkits/graph/SlowPseudoTopologicalOrderer.java
@@ -22,7 +22,6 @@
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
-
 package soot.toolkits.graph;
 
 import java.util.HashMap;
@@ -39,308 +38,300 @@ import soot.Singletons;
  * functionality as PseudoTopologicalOrderer; however, this class considers the
  * order of successors. It runs slower but more precise. Currently it was only
  * used by ArrayBoundsCheckerAnalysis to reduce the iteration numbers.
- * 
+ *
  * @see: PseudoTopologicalOrderer
  */
+public class SlowPseudoTopologicalOrderer<N> implements Orderer<N> {
 
-public class SlowPseudoTopologicalOrderer implements Orderer {
-	public SlowPseudoTopologicalOrderer(Singletons.Global g) {
-	}
+    public SlowPseudoTopologicalOrderer(Singletons.Global g) {
+    }
 
-	public static SlowPseudoTopologicalOrderer v() {
-		return G.v().soot_toolkits_graph_SlowPseudoTopologicalOrderer();
-	}
+    public static SlowPseudoTopologicalOrderer v() {
+        return G.v().soot_toolkits_graph_SlowPseudoTopologicalOrderer();
+    }
 
-	public SlowPseudoTopologicalOrderer() {
-	}
+    public SlowPseudoTopologicalOrderer() {
+    }
 
-	public SlowPseudoTopologicalOrderer(boolean isReversed) {
-		mIsReversed = isReversed;
-	}
+    public SlowPseudoTopologicalOrderer(boolean isReversed) {
+        mIsReversed = isReversed;
+    }
 
-	private Map<Object,Integer> stmtToColor;
+    private Map<N, Integer> stmtToColor;
+
+    private static final int WHITE = 0, GRAY = 1, BLACK = 2;
 
-	private static final int WHITE = 0, GRAY = 1, BLACK = 2;
+    private LinkedList<N> order;
 
-	private LinkedList order;
+    private boolean mIsReversed = false;
 
-	private boolean mIsReversed = false;
+    private DirectedGraph<N> graph;
 
-	private DirectedGraph graph;
+    private List<N> reverseOrder;
 
-	private List<Object> reverseOrder;
+    private final HashMap<N, List<N>> succsMap = new HashMap<N, List<N>>();
 
-	private final HashMap<Object,List> succsMap = new HashMap<Object,List>();
+    /**
+     * {@inheritDoc}
+     */
+    public List<N> newList(DirectedGraph<N> g, boolean reverse) {
+        mIsReversed = reverse;
+        return computeOrder(g);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public List newList(DirectedGraph g, boolean reverse) {
-		mIsReversed = reverse;
-		return computeOrder(g);
-	}
+    /**
+     * Orders in pseudo-topological order.
+     *
+     * @param g a DirectedGraph instance we want to order the nodes for.
+     * @return an ordered list of the graph's nodes.
+     */
+    LinkedList<N> computeOrder(DirectedGraph<N> g) {
+        stmtToColor = new HashMap<N, Integer>();
 
-	/**
-	 * Orders in pseudo-topological order.
-	 * 
-	 * @param g
-	 *            a DirectedGraph instance we want to order the nodes for.
-	 * @return an ordered list of the graph's nodes.
-	 */
-	LinkedList computeOrder(DirectedGraph g) {
-		stmtToColor = new HashMap();
+        order = new LinkedList<N>();
+        graph = g;
 
-		order = new LinkedList();
-		graph = g;
+        PseudoTopologicalReverseOrderer<N> orderer = new PseudoTopologicalReverseOrderer<N>();
 
-		PseudoTopologicalReverseOrderer orderer = new PseudoTopologicalReverseOrderer();
+        reverseOrder = orderer.newList(g);
 
-		reverseOrder = orderer.newList(g);
+        // Color all nodes white
+        {
 
-		// Color all nodes white
-		{
+            Iterator<N> stmtIt = g.iterator();
+            while (stmtIt.hasNext()) {
+                N s = stmtIt.next();
+                stmtToColor.put(s, WHITE);
+            }
+        }
 
-			Iterator stmtIt = g.iterator();
-			while (stmtIt.hasNext()) {
-				Object s = stmtIt.next();
+        // Visit each node
+        {
+            Iterator<N> stmtIt = g.iterator();
+            while (stmtIt.hasNext()) {
+                N s = stmtIt.next();
+                if (stmtToColor.get(s) == WHITE) {
+                    visitNode(s);
+                }
+            }
+        }
 
-				stmtToColor.put(s, new Integer(WHITE));
-			}
-		}
+        return order;
+    }
 
-		// Visit each node
-		{
-			Iterator stmtIt = g.iterator();
+    // Unfortunately, the nice recursive solution fails because of stack
+    // overflows. Fill in the 'order' list with a pseudo topological order
+    // (possibly reversed) list of statements starting at s.
+    // Simulates recursion with a stack.
+    private void visitNode(N startStmt) {
+        LinkedList<N> stmtStack = new LinkedList<N>();
+        LinkedList<Integer> indexStack = new LinkedList<Integer>();
 
-			while (stmtIt.hasNext()) {
-				Object s = stmtIt.next();
+        stmtToColor.put(startStmt, GRAY);
 
-				if (stmtToColor.get(s).intValue() == WHITE)
-					visitNode(s);
-			}
-		}
+        stmtStack.addLast(startStmt);
+        indexStack.addLast(-1);
 
-		return order;
-	}
+        while (!stmtStack.isEmpty()) {
+            int toVisitIndex = indexStack.removeLast();
+            N toVisitNode = stmtStack.getLast();
 
-	// Unfortunately, the nice recursive solution fails
-	// because of stack overflows
+            toVisitIndex++;
 
-	// Fill in the 'order' list with a pseudo topological order (possibly
-	// reversed)
-	// list of statements starting at s. Simulates recursion with a stack.
+            indexStack.addLast(toVisitIndex);
 
-	private void visitNode(Object startStmt) {
-		LinkedList stmtStack = new LinkedList();
-		LinkedList<Integer> indexStack = new LinkedList<Integer>();
+            if (toVisitIndex >= graph.getSuccsOf(toVisitNode).size()) {
+                // Visit this node now that we ran out of children
+                if (mIsReversed) {
+                    order.addLast(toVisitNode);
+                } else {
+                    order.addFirst(toVisitNode);
+                }
+
+                stmtToColor.put(toVisitNode, BLACK);
+
+                // Pop this node off
+                stmtStack.removeLast();
+                indexStack.removeLast();
+            } else {
+                List<N> orderedSuccs = succsMap.get(toVisitNode);
+                if (orderedSuccs == null) {
+                    orderedSuccs = new LinkedList<N>();
+                    succsMap.put(toVisitNode, orderedSuccs);
+                    /* make ordered succs */
 
-		stmtToColor.put(startStmt, new Integer(GRAY));
+                    List<N> allsuccs = graph.getSuccsOf(toVisitNode);
 
-		stmtStack.addLast(startStmt);
-		indexStack.addLast(new Integer(-1));
+                    for (int i = 0; i < allsuccs.size(); i++) {
+                        N cur = allsuccs.get(i);
 
-		while (!stmtStack.isEmpty()) {
-			int toVisitIndex = indexStack.removeLast().intValue();
-			Object toVisitNode = stmtStack.getLast();
+                        int j = 0;
 
-			toVisitIndex++;
+                        for (; j < orderedSuccs.size(); j++) {
+                            N comp = orderedSuccs.get(j);
 
-			indexStack.addLast(new Integer(toVisitIndex));
+                            int idx1 = reverseOrder.indexOf(cur);
+                            int idx2 = reverseOrder.indexOf(comp);
 
-			if (toVisitIndex >= graph.getSuccsOf(toVisitNode).size()) {
-				// Visit this node now that we ran out of children
-				if (mIsReversed)
-					order.addLast(toVisitNode);
-				else
-					order.addFirst(toVisitNode);
+                            if (idx1 < idx2) {
+                                break;
+                            }
+                        }
 
-				stmtToColor.put(toVisitNode, new Integer(BLACK));
+                        orderedSuccs.add(j, cur);
+                    }
+                }
 
-				// Pop this node off
-				stmtStack.removeLast();
-				indexStack.removeLast();
-			} else {
-				List<Object> orderedSuccs = succsMap.get(toVisitNode);
-				if (orderedSuccs == null) {
-					orderedSuccs = new LinkedList<Object>();
-					succsMap.put(toVisitNode, orderedSuccs);
-					/* make ordered succs */
+                N childNode = orderedSuccs.get(toVisitIndex);
 
-					List allsuccs = graph.getSuccsOf(toVisitNode);
+                // Visit this child next if not already visited (or on stack)
+                if (stmtToColor.get(childNode) == WHITE) {
+                    stmtToColor.put(childNode, GRAY);
 
-					for (int i = 0; i < allsuccs.size(); i++) {
-						Object cur = allsuccs.get(i);
+                    stmtStack.addLast(childNode);
+                    indexStack.addLast(-1);
+                }
+            }
+        }
+    }
+
+    private class PseudoTopologicalReverseOrderer<N> {
+
+        private Map<N, Integer> stmtToColor;
+
+        private static final int WHITE = 0, GRAY = 1, BLACK = 2;
 
-						int j = 0;
-
-						for (; j < orderedSuccs.size(); j++) {
-							Object comp = orderedSuccs.get(j);
-
-							int idx1 = reverseOrder.indexOf(cur);
-							int idx2 = reverseOrder.indexOf(comp);
-
-							if (idx1 < idx2)
-								break;
-						}
-
-						orderedSuccs.add(j, cur);
-					}
-				}
-
-				Object childNode = orderedSuccs.get(toVisitIndex);
-
-				// Visit this child next if not already visited (or on stack)
-				if (stmtToColor.get(childNode).intValue() == WHITE) {
-					stmtToColor.put(childNode, new Integer(GRAY));
-
-					stmtStack.addLast(childNode);
-					indexStack.addLast(new Integer(-1));
-				}
-			}
-		}
-	}
-
-	private class PseudoTopologicalReverseOrderer {
-		private Map<Object, Integer> stmtToColor;
-
-		private static final int WHITE = 0, GRAY = 1, BLACK = 2;
-
-		private LinkedList<Object> order;
-
-		private final boolean mIsReversed = false;
-
-		private DirectedGraph graph;
-
-		/**
-		 * @param g
-		 *            a DirectedGraph instance whose nodes we which to order.
-		 * @return a pseudo-topologically ordered list of the graph's nodes.
-		 */
-		List<Object> newList(DirectedGraph g) {
-			return computeOrder(g);
-		}
-
-		/**
-		 * Orders in pseudo-topological order.
-		 * 
-		 * @param g
-		 *            a DirectedGraph instance we want to order the nodes for.
-		 * @return an ordered list of the graph's nodes.
-		 */
-		LinkedList<Object> computeOrder(DirectedGraph g) {
-			stmtToColor = new HashMap<Object, Integer>();
-
-			order = new LinkedList<Object>();
-			graph = g;
-
-			// Color all nodes white
-			{
-				Iterator stmtIt = g.iterator();
-				while (stmtIt.hasNext()) {
-					Object s = stmtIt.next();
-
-					stmtToColor.put(s, new Integer(WHITE));
-				}
-			}
-
-			// Visit each node
-			{
-				Iterator stmtIt = g.iterator();
-
-				while (stmtIt.hasNext()) {
-					Object s = stmtIt.next();
-
-					if (stmtToColor.get(s).intValue() == WHITE)
-						visitNode(s);
-				}
-			}
-
-			return order;
-		}
-
-		private void visitNode(Object startStmt) {
-			LinkedList<Object> stmtStack = new LinkedList<Object>();
-			LinkedList<Integer> indexStack = new LinkedList<Integer>();
-
-			stmtToColor.put(startStmt, new Integer(GRAY));
-
-			stmtStack.addLast(startStmt);
-			indexStack.addLast(new Integer(-1));
-
-			while (!stmtStack.isEmpty()) {
-				int toVisitIndex = indexStack.removeLast()
-						.intValue();
-				Object toVisitNode = stmtStack.getLast();
-
-				toVisitIndex++;
-
-				indexStack.addLast(new Integer(toVisitIndex));
-
-				if (toVisitIndex >= graph.getPredsOf(toVisitNode).size()) {
-					// Visit this node now that we ran out of children
-					if (mIsReversed)
-						order.addLast(toVisitNode);
-					else
-						order.addFirst(toVisitNode);
-
-					stmtToColor.put(toVisitNode, new Integer(BLACK));
-
-					// Pop this node off
-					stmtStack.removeLast();
-					indexStack.removeLast();
-				} else {
-					Object childNode = graph.getPredsOf(toVisitNode).get(
-							toVisitIndex);
-
-					// Visit this child next if not already visited (or on
-					// stack)
-					if (stmtToColor.get(childNode).intValue() == WHITE) {
-						stmtToColor.put(childNode, new Integer(GRAY));
-
-						stmtStack.addLast(childNode);
-						indexStack.addLast(new Integer(-1));
-					}
-				}
-			}
-		}
-
-	}
-
-	// deprecated methods follow
-	/**
-	 * @param g
-	 *            a DirectedGraph instance whose nodes we wish to order.
-	 * @return a pseudo-topologically ordered list of the graph's nodes.
-	 * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
-	 */
-	@Deprecated
-	public List newList(DirectedGraph g) {
-		return computeOrder(g);
-	}
-
-	/**
-	 * Set the ordering for the orderer.
-	 * 
-	 * @param isReverse
-	 *            specify if we want reverse pseudo-topological ordering, or
-	 *            not.
-	 * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
-	 */
-	@Deprecated
-	public void setReverseOrder(boolean isReversed) {
-		mIsReversed = isReversed;
-	}
-
-	/**
-	 * Check the ordering for the orderer.
-	 * 
-	 * @return true if we have reverse pseudo-topological ordering, false
-	 *         otherwise.
-	 * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
-	 */
-	@Deprecated
-	public boolean isReverseOrder() {
-		return mIsReversed;
-	}
+        private LinkedList<N> order;
+
+        private final boolean mIsReversed = false;
+
+        private DirectedGraph<N> graph;
+
+        /**
+         * @param g a DirectedGraph instance whose nodes we which to order.
+         * @return a pseudo-topologically ordered list of the graph's nodes.
+         */
+        List<N> newList(DirectedGraph<N> g) {
+            return computeOrder(g);
+        }
+
+        /**
+         * Orders in pseudo-topological order.
+         *
+         * @param g a DirectedGraph instance we want to order the nodes for.
+         * @return an ordered list of the graph's nodes.
+         */
+        LinkedList<N> computeOrder(DirectedGraph<N> g) {
+            stmtToColor = new HashMap<N, Integer>();
+
+            order = new LinkedList<N>();
+            graph = g;
+
+            // Color all nodes white
+            {
+                Iterator<N> stmtIt = g.iterator();
+                while (stmtIt.hasNext()) {
+                    N s = stmtIt.next();
+
+                    stmtToColor.put(s, WHITE);
+                }
+            }
+
+            // Visit each node
+            {
+                Iterator<N> stmtIt = g.iterator();
+
+                while (stmtIt.hasNext()) {
+                    N s = stmtIt.next();
+
+                    if (stmtToColor.get(s) == WHITE) {
+                        visitNode(s);
+                    }
+                }
+            }
+
+            return order;
+        }
+
+        private void visitNode(N startStmt) {
+            LinkedList<N> stmtStack = new LinkedList<N>();
+            LinkedList<Integer> indexStack = new LinkedList<Integer>();
+
+            stmtToColor.put(startStmt, GRAY);
+
+            stmtStack.addLast(startStmt);
+            indexStack.addLast(-1);
+
+            while (!stmtStack.isEmpty()) {
+                int toVisitIndex = indexStack.removeLast();
+                N toVisitNode = stmtStack.getLast();
+
+                toVisitIndex++;
+
+                indexStack.addLast(toVisitIndex);
+
+                if (toVisitIndex >= graph.getPredsOf(toVisitNode).size()) {
+                    // Visit this node now that we ran out of children
+                    if (mIsReversed) {
+                        order.addLast(toVisitNode);
+                    } else {
+                        order.addFirst(toVisitNode);
+                    }
+
+                    stmtToColor.put(toVisitNode, BLACK);
+
+                    // Pop this node off
+                    stmtStack.removeLast();
+                    indexStack.removeLast();
+                } else {
+                    N childNode = graph.getPredsOf(toVisitNode).get(toVisitIndex);
+
+                    // Visit this child next if not already visited (or on stack)
+                    if (stmtToColor.get(childNode) == WHITE) {
+                        stmtToColor.put(childNode, GRAY);
+
+                        stmtStack.addLast(childNode);
+                        indexStack.addLast(-1);
+                    }
+                }
+            }
+        }
+
+    }
+
+    // deprecated methods follow
+    /**
+     * @param g a DirectedGraph instance whose nodes we wish to order.
+     * @return a pseudo-topologically ordered list of the graph's nodes.
+     * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
+     */
+    @Deprecated
+    public List<N> newList(DirectedGraph<N> g) {
+        return computeOrder(g);
+    }
+
+    /**
+     * Set the ordering for the orderer.
+     *
+     * @param isReverse specify if we want reverse pseudo-topological ordering,
+     * or not.
+     * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
+     */
+    @Deprecated
+    public void setReverseOrder(boolean isReversed) {
+        mIsReversed = isReversed;
+    }
+
+    /**
+     * Check the ordering for the orderer.
+     *
+     * @return true if we have reverse pseudo-topological ordering, false
+     * otherwise.
+     * @deprecated use {@link #newList(DirectedGraph, boolean))} instead
+     */
+    @Deprecated
+    public boolean isReverseOrder() {
+        return mIsReversed;
+    }
 
 }

--- a/src/soot/toolkits/graph/pdg/EnhancedUnitGraph.java
+++ b/src/soot/toolkits/graph/pdg/EnhancedUnitGraph.java
@@ -183,8 +183,8 @@ public class EnhancedUnitGraph extends UnitGraph {
 	
 	protected void handleExplicitThrowEdges()
 	{
-		MHGDominatorTree dom = new MHGDominatorTree(new MHGDominatorsFinder<Unit>(this));
-		MHGDominatorTree pdom = new MHGDominatorTree(new MHGPostDominatorsFinder<Unit>(this));
+		MHGDominatorTree<Unit> dom = new MHGDominatorTree<Unit>(new MHGDominatorsFinder<Unit>(this));
+		MHGDominatorTree<Unit> pdom = new MHGDominatorTree<Unit>(new MHGPostDominatorsFinder<Unit>(this));
 		
 		//this keeps a map from the entry of a try-catch-block to a selected merge point 
 		Hashtable<Unit, Unit> x2mergePoint = new Hashtable<Unit, Unit>();
@@ -198,12 +198,12 @@ public class EnhancedUnitGraph extends UnitGraph {
 			if(!(tail instanceof ThrowStmt))
 				continue;
 			
-			DominatorNode x = dom.getDode(tail);
-			DominatorNode parentOfX = dom.getParentOf(x);
-			Object xgode = x.getGode();
-			DominatorNode xpdomDode = pdom.getDode(xgode);
-			Object parentXGode = parentOfX.getGode();
-			DominatorNode parentpdomDode = pdom.getDode(parentXGode);
+			DominatorNode<Unit> x = dom.getDode(tail);
+			DominatorNode<Unit> parentOfX = dom.getParentOf(x);
+			Unit xgode = x.getGode();
+			DominatorNode<Unit> xpdomDode = pdom.getDode(xgode);
+			Unit parentXGode = parentOfX.getGode();
+			DominatorNode<Unit> parentpdomDode = pdom.getDode(parentXGode);
 			//while x post-dominates its dominator (parent in dom)
 			while(pdom.isDominatorOf(xpdomDode, parentpdomDode))
 			{
@@ -236,28 +236,28 @@ public class EnhancedUnitGraph extends UnitGraph {
 			{
 				//Now get all the children of x in the dom
 				
-				List<DominatorNode> domChilds = dom.getChildrenOf(x);
+				List<DominatorNode<Unit>> domChilds = dom.getChildrenOf(x);
 								
-				Object child1god = null;
-				Object child2god = null;
+				Unit child1god = null;
+				Unit child2god = null;
 				
-				for(Iterator<DominatorNode> domItr = domChilds.iterator(); domItr.hasNext(); )
+				for(Iterator<DominatorNode<Unit>> domItr = domChilds.iterator(); domItr.hasNext(); )
 				{
-					DominatorNode child = domItr.next();
-					Object childGode = child.getGode();
-					DominatorNode childpdomDode = pdom.getDode(childGode);
+					DominatorNode<Unit> child = domItr.next();
+					Unit childGode = child.getGode();
+					DominatorNode<Unit> childpdomDode = pdom.getDode(childGode);
 					
 					
 					//we don't want to make a loop! 
-					List<Unit> path = this.getExtendedBasicBlockPathBetween((Unit)childGode, tail);
+					List<Unit> path = this.getExtendedBasicBlockPathBetween(childGode, tail);
 					
 					//if(dom.isDominatorOf(child, dom.getDode(tail)))
-					if(!(path == null || path.size() == 0))
+					if(!(path == null || path.isEmpty()))
 						continue;
 					
 					if(pdom.isDominatorOf(childpdomDode, xpdomDode))
 					{
-						mergePoint = (Unit) child.getGode();				
+						mergePoint = child.getGode();				
 						break;
 					}					
 									
@@ -273,16 +273,16 @@ public class EnhancedUnitGraph extends UnitGraph {
 				{
 					if(child1god != null && child2god != null)
 					{
-						DominatorNode child1 = pdom.getDode(child1god);
-						DominatorNode child2 = pdom.getDode(child2god);
+						DominatorNode<Unit> child1 = pdom.getDode(child1god);
+						DominatorNode<Unit> child2 = pdom.getDode(child2god);
 	
 						//go up the pdom tree and find the common parent of child1 and child2
-						DominatorNode comParent = child1.getParent();
+						DominatorNode<Unit> comParent = child1.getParent();
 						while(comParent != null)
 						{
 							if(pdom.isDominatorOf(comParent, child2))
 							{
-								mergePoint = (Unit) comParent.getGode();
+								mergePoint = comParent.getGode();
 								break;
 							}
 							comParent = comParent.getParent();
@@ -290,7 +290,7 @@ public class EnhancedUnitGraph extends UnitGraph {
 					}
 					else if(child1god != null || child2god != null){
 					
-						DominatorNode y = null;
+						DominatorNode<Unit> y = null;
 						
 						if(child1god != null)
 							y = pdom.getDode(child1god);
@@ -298,8 +298,8 @@ public class EnhancedUnitGraph extends UnitGraph {
 							y = pdom.getDode(child2god);
 						
 							
-						DominatorNode initialY = dom.getDode(y.getGode());
-						DominatorNode yDodeInDom = initialY;
+						DominatorNode<Unit> initialY = dom.getDode(y.getGode());
+						DominatorNode<Unit> yDodeInDom = initialY;
 						
 						while(dom.isDominatorOf(x, yDodeInDom))
 						{
@@ -314,9 +314,9 @@ public class EnhancedUnitGraph extends UnitGraph {
 							yDodeInDom = dom.getDode(y.getGode());
 						}
 						if(y != null)
-							mergePoint = (Unit) y.getGode();
+							mergePoint = y.getGode();
 						else
-							mergePoint = (Unit) initialY.getGode();
+							mergePoint = initialY.getGode();
 					}
 				}
 				
@@ -343,7 +343,7 @@ public class EnhancedUnitGraph extends UnitGraph {
 							continue;
 						
 						
-						DominatorNode y = pdom.getDode(u);
+						DominatorNode<Unit> y = pdom.getDode(u);
 						
 						while(dom.isDominatorOf(x, y))
 						{
@@ -355,7 +355,7 @@ public class EnhancedUnitGraph extends UnitGraph {
 								continue TailsLoop;
 							}
 						}
-						mergePoint = (Unit) y.getGode();
+						mergePoint = y.getGode();
 						break;
 					}
 				}
@@ -367,7 +367,7 @@ public class EnhancedUnitGraph extends UnitGraph {
 				if(mergePoint == null)
 					continue TailsLoop;
 				
-				x2mergePoint.put((Unit) xgode, mergePoint);
+				x2mergePoint.put(xgode, mergePoint);
 			}
 			//add an edge from the tail (throw) to the merge point
 			
@@ -378,7 +378,7 @@ public class EnhancedUnitGraph extends UnitGraph {
 			throwSuccs.add(mergePoint);
 			
 			List<Unit> mergePreds = this.unitToPreds.get(mergePoint);
-			mergePreds.add(tail);	
+			mergePreds.add(tail);
 			
 		}
 

--- a/src/soot/toolkits/graph/pdg/HashMutablePDG.java
+++ b/src/soot/toolkits/graph/pdg/HashMutablePDG.java
@@ -143,8 +143,8 @@ public class HashMutablePDG extends HashMutableEdgeLabelledDirectedGraph<PDGNode
 	protected void constructPDG()
 	{
 		Hashtable<Block, Region> block2region = this.m_regionAnalysis.getBlock2RegionMap();
-		DominatorTree pdom = this.m_regionAnalysis.getPostDominatorTree();
-		DominatorTree dom = this.m_regionAnalysis.getDominatorTree();
+		DominatorTree<Block> pdom = this.m_regionAnalysis.getPostDominatorTree();
+		DominatorTree<Block> dom = this.m_regionAnalysis.getDominatorTree();
 				
 		List<Region> regions2process = new LinkedList<Region>();
 		Region topLevelRegion = this.m_regionAnalysis.getTopLevelRegion();
@@ -218,17 +218,17 @@ public class HashMutablePDG extends HashMutableEdgeLabelledDirectedGraph<PDGNode
 						throw new RuntimeException("PDG construction: A and B are not supposed to be the same node!");
 					
 					
-					DominatorNode aDode = pdom.getDode(a);
-					DominatorNode bDode = pdom.getDode(b);
+					DominatorNode<Block> aDode = pdom.getDode(a);
+					DominatorNode<Block> bDode = pdom.getDode(b);
 					
 					//If B post-dominates A, go to the next successor.
 					if(pdom.isDominatorOf(bDode, aDode))
 						continue;
 					
 					//FIXME: what if the parent is null?!!
-					DominatorNode aParentDode = aDode.getParent();
+					DominatorNode<Block> aParentDode = aDode.getParent();
 					
-					DominatorNode dode = bDode;
+					DominatorNode<Block> dode = bDode;
 					while(dode != aParentDode)
 					{
 						dependents.add((Block)dode.getGode());
@@ -472,8 +472,8 @@ public class HashMutablePDG extends HashMutableEdgeLabelledDirectedGraph<PDGNode
 										Region succR = (Region) succRPDGNode.getNode();
 										Block h = succR.getBlocks().get(0);
 										
-										DominatorNode hdode = dom.getDode(h);
-										DominatorNode adode = dom.getDode(a);
+										DominatorNode<Block> hdode = dom.getDode(h);
+										DominatorNode<Block> adode = dom.getDode(a);
 										
 										if(dom.isDominatorOf(hdode, adode))
 										{

--- a/src/soot/toolkits/graph/pdg/MHGDominatorTree.java
+++ b/src/soot/toolkits/graph/pdg/MHGDominatorTree.java
@@ -35,9 +35,9 @@ import soot.toolkits.graph.DominatorsFinder;
  * March 2009
  * 
  **/
-public class MHGDominatorTree extends DominatorTree {
+public class MHGDominatorTree<N> extends DominatorTree<N> {
 	
-    public MHGDominatorTree(DominatorsFinder dominators) {
+    public MHGDominatorTree(DominatorsFinder<N> dominators) {
         super(dominators);
     }
     

--- a/src/soot/util/HashMultiMap.java
+++ b/src/soot/util/HashMultiMap.java
@@ -61,11 +61,11 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
         return false;
     }
 
-    protected Set newSet() {
-        return new HashSet(4);
+    protected Set<V> newSet() {
+        return new HashSet<V>(4);
     }
     private Set findSet( K key ) {
-        Set s = m.get( key );
+        Set<V> s = m.get( key );
         if( s == null ) {
             s = newSet();
             m.put( key, s );
@@ -86,7 +86,7 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
 
     @Override
     public boolean remove( K key, V value ) {
-        Set s = m.get( key );
+        Set<V> s = m.get( key );
         if( s == null ) return false;
         boolean ret = s.remove( value );
         if( s.isEmpty() ) {
@@ -102,7 +102,7 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
 
     @Override
     public boolean removeAll( K key, Set<V> values ) {
-        Set s = m.get( key );
+        Set<V> s = m.get( key );
         if( s == null ) return false;
         boolean ret = s.removeAll( values );
         if( s.isEmpty() ) {
@@ -112,8 +112,8 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
     }
 
     @Override
-    public Set get( K o ) {
-        Set ret = m.get( o );
+    public Set<V> get( K o ) {
+        Set<V> ret = m.get( o );
         if( ret == null ) return Collections.EMPTY_SET;
         return Collections.unmodifiableSet(ret);
     }
@@ -125,7 +125,7 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
 
     @Override
     public Set<V> values() {
-        Set ret = new HashSet(0);
+        Set<V> ret = new HashSet(0);
         for (Set<V> s : m.values())
             ret.addAll(s);
         return ret;
@@ -136,10 +136,10 @@ public class HashMultiMap<K,V> implements MultiMap<K,V> {
         if( ! (o instanceof MultiMap) ) return false;
         MultiMap mm = (MultiMap) o;
         if( !keySet().equals( mm.keySet() ) ) return false;
-        Iterator it = m.entrySet().iterator();
+        Iterator<Map.Entry<K, Set<V>>> it = m.entrySet().iterator();
         while( it.hasNext() ) {
-            Map.Entry e = (Map.Entry) it.next();
-            Set s = (Set) e.getValue();
+            Map.Entry<K, Set<V>> e = it.next();
+            Set<V> s = e.getValue();
             if( !s.equals( mm.get( e.getKey() ) ) ) return false;
         }
         return true;

--- a/src/soot/util/cfgcmd/CFGToDotGraph.java
+++ b/src/soot/util/cfgcmd/CFGToDotGraph.java
@@ -27,6 +27,7 @@ import soot.toolkits.graph.DirectedGraph;
 import soot.toolkits.graph.BlockGraph;
 import soot.toolkits.graph.ExceptionalGraph;
 import soot.toolkits.graph.Block;
+import soot.toolkits.graph.DominatorNode;
 import soot.toolkits.graph.ExceptionalGraph.ExceptionDest;
 import soot.toolkits.graph.UnitGraph;
 import soot.util.dot.DotGraph;
@@ -491,6 +492,10 @@ public class CFGToDotGraph {
       N node = nodesIt.next();
       DotGraphNode dotnode = canvas.getNode(namer.getName(node));
       String nodeLabel = null;
+      
+      if(node instanceof DominatorNode){
+          node = ((DominatorNode<N>)node).getGode();
+      }
 
       if (printer == null) {
 	nodeLabel = node.toString();

--- a/src/soot/util/cfgcmd/CFGToDotGraph.java
+++ b/src/soot/util/cfgcmd/CFGToDotGraph.java
@@ -27,6 +27,7 @@ import soot.toolkits.graph.DirectedGraph;
 import soot.toolkits.graph.BlockGraph;
 import soot.toolkits.graph.ExceptionalGraph;
 import soot.toolkits.graph.Block;
+import soot.toolkits.graph.ExceptionalGraph.ExceptionDest;
 import soot.toolkits.graph.UnitGraph;
 import soot.util.dot.DotGraph;
 import soot.util.dot.DotGraphAttribute;
@@ -209,13 +210,13 @@ public class CFGToDotGraph {
    * @return An iterator which presents the elements of <code>coll</code> 
    * in the order specified by <code>comp</code>.
    */
-  private static Iterator sortedIterator(Collection coll, Comparator comp) {
+  private static <T> Iterator<T> sortedIterator(Collection<T> coll, Comparator<T> comp) {
     if (coll.size() <= 1) {
       return coll.iterator();
     } else {
-      Object array[] = coll.toArray();
-      Arrays.sort(array, comp);
-      return Arrays.asList(array).iterator();
+      ArrayList<T> list = new ArrayList<T>(coll);
+      Collections.sort(list, comp);
+      return list.iterator();
     }
   }
 
@@ -223,18 +224,18 @@ public class CFGToDotGraph {
    * Comparator used to order a list of nodes by the order in 
    * which they were labeled.
    */
-  private static class NodeComparator implements java.util.Comparator {
-    private DotNamer namer;
+  private static class NodeComparator<T> implements Comparator<T> {
+    private DotNamer<T> namer;
 
-    NodeComparator(DotNamer namer) {
+    NodeComparator(DotNamer<T> namer) {
       this.namer = namer;
     }
 
-    public int compare(Object o1, Object o2) {
+    public int compare(T o1, T o2) {
       return (namer.getNumber(o1) - namer.getNumber(o2));
     }
 
-    public boolean equal(Object o1, Object o2) {
+    public boolean equal(T o1, T o2) {
       return (namer.getNumber(o1) == namer.getNumber(o2));
     }
   }
@@ -244,15 +245,15 @@ public class CFGToDotGraph {
    * Comparator used to order a list of ExceptionDests by the order in
    * which their handler nodes were labeled.
    */
-  private static class ExceptionDestComparator implements java.util.Comparator {
-    private DotNamer namer;
+  private static class ExceptionDestComparator<T> implements Comparator<ExceptionDest<T>> {
+    private DotNamer<T> namer;
 
-    ExceptionDestComparator(DotNamer namer) {
+    ExceptionDestComparator(DotNamer<T> namer) {
       this.namer = namer;
     }
 
-    private int getValue(Object o) {
-      Object handler = ((ExceptionalGraph.ExceptionDest) o).getHandlerNode();
+    private int getValue(ExceptionDest<T> o) {
+      T handler = o.getHandlerNode();
       if (handler == null) {
 	return Integer.MAX_VALUE;
       } else {
@@ -260,11 +261,11 @@ public class CFGToDotGraph {
       }
     }
 
-    public int compare(Object o1, Object o2) {
+    public int compare(ExceptionDest<T> o1, ExceptionDest<T> o2) {
       return (getValue(o1) - getValue(o2));
     }
 
-    public boolean equal(Object o1, Object o2) {
+    public boolean equal(ExceptionDest<T> o1, ExceptionDest<T> o2) {
       return (getValue(o1) == getValue(o2));
     }
   }
@@ -285,26 +286,26 @@ public class CFGToDotGraph {
    *
    * @return a visualization of <code>graph</code>.
    */
-  public DotGraph drawCFG(DirectedGraph graph, Body body) {
+  public <N> DotGraph drawCFG(DirectedGraph<N> graph, Body body) {
     DotGraph canvas = initDotGraph(body);
-    DotNamer namer = new DotNamer((int)(graph.size()/0.7f), 0.7f);
-    NodeComparator comparator = new NodeComparator(namer);
+    DotNamer<N> namer = new DotNamer<N>((int)(graph.size()/0.7f), 0.7f);
+    NodeComparator<N> comparator = new NodeComparator<N>(namer);
 
     // To facilitate comparisons between different graphs of the same
     // method, prelabel the nodes in the order they appear
     // in the iterator, rather than the order that they appear in the
     // graph traversal (so that corresponding nodes are more likely
     // to have the same label in different graphs of a given method).
-    for (Iterator nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
-      String junk = namer.getName(nodesIt.next());
+    for (Iterator<N> nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
+      namer.getName(nodesIt.next());
     }
 
-    for (Iterator nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
-      Object node = nodesIt.next();
+    for (Iterator<N> nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
+      N node = nodesIt.next();
       canvas.drawNode(namer.getName(node));
-      for (Iterator succsIt = sortedIterator(graph.getSuccsOf(node), comparator);
+      for (Iterator<N> succsIt = sortedIterator(graph.getSuccsOf(node), comparator);
 	   succsIt.hasNext(); ) {
-	Object succ = succsIt.next();
+	N succ = succsIt.next();
 	canvas.drawEdge(namer.getName(node), namer.getName(succ));
       }
     }
@@ -337,8 +338,8 @@ public class CFGToDotGraph {
 
     // Prelabel nodes in iterator order, to facilitate
     // comparisons between graphs of a given method.
-    for (Iterator nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
-      String junk = namer.getName(nodesIt.next());
+    for (Iterator<N> nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
+      namer.getName(nodesIt.next());
     }
 
     for (Iterator<N> nodesIt = graph.iterator(); nodesIt.hasNext(); ) {
@@ -346,30 +347,29 @@ public class CFGToDotGraph {
 
       canvas.drawNode(namer.getName(node));
 
-      for (Iterator succsIt = sortedIterator(graph.getUnexceptionalSuccsOf(node),
+      for (Iterator<N> succsIt = sortedIterator(graph.getUnexceptionalSuccsOf(node),
 					     nodeComparator); 
 	   succsIt.hasNext(); ) {
-        Object succ = succsIt.next();
+        N succ = succsIt.next();
         DotGraphEdge edge = canvas.drawEdge(namer.getName(node), 
 					    namer.getName(succ));
 	edge.setAttribute(unexceptionalControlFlowAttr);
       }
 
-      for (Iterator succsIt = sortedIterator(graph.getExceptionalSuccsOf(node),
+      for (Iterator<N> succsIt = sortedIterator(graph.getExceptionalSuccsOf(node),
 					     nodeComparator); 
 	   succsIt.hasNext(); ) {
-	Object succ = succsIt.next();
+	N succ = succsIt.next();
 	DotGraphEdge edge = canvas.drawEdge(namer.getName(node),
 					    namer.getName(succ));
 	edge.setAttribute(exceptionalControlFlowAttr);
       }
 
       if (showExceptions) {
-	for (Iterator destsIt = sortedIterator(graph.getExceptionDests(node),
-					       new ExceptionDestComparator(namer));
+	for (Iterator<ExceptionDest<N>> destsIt =
+                sortedIterator(graph.getExceptionDests(node), new ExceptionDestComparator(namer));
 	     destsIt.hasNext(); ) {
-	  ExceptionalGraph.ExceptionDest dest
-	    = (ExceptionalGraph.ExceptionDest) destsIt.next();
+	  ExceptionDest<N> dest = destsIt.next();
 	  Object handlerStart = dest.getHandlerNode();
 	  if (handlerStart == null) {
 	    // Giving each escaping exception its own, invisible
@@ -401,7 +401,7 @@ public class CFGToDotGraph {
     return canvas;
   }
 
-
+  
   /**
    * A utility method that initializes a DotGraph object for use in any 
    * variety of drawCFG().
@@ -448,19 +448,19 @@ public class CFGToDotGraph {
     String getName(N node) {
       Integer index = this.get(node);
       if (index == null) {
-	index = new Integer(nodecount++);
+	index = nodecount++;
 	this.put(node, index);
       }
       return index.toString();
     }
 
     int getNumber(N node) {
-      Integer index = (Integer)this.get(node);
+      Integer index = this.get(node);
       if (index == null) {
-	index = new Integer(nodecount++);
+	index = nodecount++;
 	this.put(node, index);
       }
-      return index.intValue();
+      return index;
     }
   }
 


### PR DESCRIPTION
Added generics to classes in soot.toolkits.graph that were missing them. Also added generics to several classes which use these. Finally, updated CFGToDotGraph to allow printing of DominatorTrees with full body text rather than just block number.