### PR TITLE
setGraphName method for DotGraph

### DIFF
--- a/src/soot/util/dot/DotGraph.java
+++ b/src/soot/util/dot/DotGraph.java
@@ -188,6 +188,13 @@ public class DotGraph implements Renderable{
   }
 
   /**
+   * sets the graph name
+   */
+  public void setGraphName(String name){
+    this.graphname = name;
+  }
+  
+  /**
    * sets the graph label
    */
   public void setGraphLabel(String label){


### PR DESCRIPTION
Allow to set the string used as graph name, next to the "digraph" keyword when rendered.