### PR TITLE
Fast LocalDefs

### DIFF
--- a/src/soot/baf/toolkits/base/LoadStoreOptimizer.java
+++ b/src/soot/baf/toolkits/base/LoadStoreOptimizer.java
@@ -82,7 +82,6 @@ class Instance {
     // Instance vars.
     private Chain<Unit> mUnits;
     private Body mBody;
-    private ExceptionalUnitGraph mExceptionalUnitGraph;
     private LocalDefs mLocalDefs;
     private LocalUses mLocalUses;
     private Map<Unit, Block> mUnitToBlockMap;     // maps a unit it's containing block
@@ -162,9 +161,8 @@ class Instance {
     
     private void computeLocalDefsAndLocalUsesInfo() 
     {        
-        mExceptionalUnitGraph =  new ExceptionalUnitGraph(mBody);
-        mLocalDefs = new SmartLocalDefs(mExceptionalUnitGraph, new SimpleLiveLocals(mExceptionalUnitGraph));
-        mLocalUses = new SimpleLocalUses(mExceptionalUnitGraph, mLocalDefs);
+        mLocalDefs = LocalDefs.Factory.newLocalDefs(mBody);
+        mLocalUses = LocalUses.Factory.newLocalUses(mBody, mLocalDefs);
     }
    
 

--- a/src/soot/dexpler/DexBody.java
+++ b/src/soot/dexpler/DexBody.java
@@ -475,17 +475,20 @@ public class DexBody  {
          */
 
         Debug.printDbg("body before any transformation : \n", jBody);
+
+        Debug.printDbg("\nbefore splitting");
+        Debug.printDbg("",(Body)jBody);
+        
+        // split first to find undefined uses
+        getLocalSplitter().transform(jBody);
         
 		// Remove dead code and the corresponding locals before assigning types
 		getUnreachableCodeEliminator().transform(jBody);
 		DeadAssignmentEliminator.v().transform(jBody);
 		UnusedLocalEliminator.v().transform(jBody);
 
-        Debug.printDbg("\nbefore splitting");
-        Debug.printDbg("",(Body)jBody);
         
-        DexReturnInliner.v().transform(jBody);        
-        getLocalSplitter().transform(jBody);
+        DexReturnInliner.v().transform(jBody);    
         
         Debug.printDbg("\nafter splitting");
         Debug.printDbg("",(Body)jBody);

--- a/src/soot/dexpler/DexIfTransformer.java
+++ b/src/soot/dexpler/DexIfTransformer.java
@@ -63,11 +63,8 @@ import soot.jimple.StringConstant;
 import soot.jimple.ThrowStmt;
 import soot.jimple.internal.AbstractInstanceInvokeExpr;
 import soot.jimple.internal.AbstractInvokeExpr;
-import soot.toolkits.graph.UnitGraph;
+import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.LocalUses;
-import soot.toolkits.scalar.SimpleLocalUses;
-import soot.toolkits.scalar.SmartLocalDefs;
-import soot.toolkits.scalar.SmartLocalDefsPool;
 import soot.toolkits.scalar.UnitValueBoxPair;
 
 /**
@@ -92,10 +89,9 @@ public class DexIfTransformer extends AbstractNullTransformer {
 
 	Local l = null;
 
-	protected void internalTransform(final Body body, String phaseName, @SuppressWarnings("rawtypes") Map options) {
-        SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(body);
-        UnitGraph g = localDefs.getGraph();
-		final LocalUses localUses = new SimpleLocalUses(g, localDefs);
+	protected void internalTransform(final Body body, String phaseName, Map<String,String> options) {
+		final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(body);
+		final LocalUses localUses = LocalUses.Factory.newLocalUses(body, localDefs);
 
 		Set<IfStmt> ifSet = getNullIfCandidates(body);
 		for (IfStmt ifs : ifSet) {

--- a/src/soot/dexpler/DexNullArrayRefTransformer.java
+++ b/src/soot/dexpler/DexNullArrayRefTransformer.java
@@ -70,7 +70,7 @@ public class DexNullArrayRefTransformer extends BodyTransformer {
 
 	protected void internalTransform(final Body body, String phaseName, Map<String, String> options) {		
 		final ExceptionalUnitGraph g = new ExceptionalUnitGraph(body, DalvikThrowAnalysis.v());
-		final LocalDefs defs = new SmartLocalDefs(g, new SimpleLiveLocals(g));
+		final LocalDefs defs = LocalDefs.Factory.newLocalDefs(g);
 		final LocalCreation lc = new LocalCreation(body.getLocals(), "ex");
 		
 		boolean changed = false;
@@ -150,7 +150,7 @@ public class DexNullArrayRefTransformer extends BodyTransformer {
 				Collections.singletonList((Type) RefType.v("java.lang.String")));
 		
 		// Create the exception instance
-		Stmt newExStmt = Jimple.v().newAssignStmt(lcEx, Jimple.v().newNewExpr(tp));
+		Stmt newExStmt = Jimple.v().newNewStmt(lcEx, tp);
 		body.getUnits().insertBefore(newExStmt, oldStmt);
 		Stmt invConsStmt = Jimple.v().newInvokeStmt(Jimple.v().newVirtualInvokeExpr(lcEx,
 				constructorRef, Collections.singletonList(StringConstant.v(

--- a/src/soot/dexpler/DexNullArrayRefTransformer.java
+++ b/src/soot/dexpler/DexNullArrayRefTransformer.java
@@ -46,8 +46,6 @@ import soot.jimple.toolkits.scalar.LocalCreation;
 import soot.jimple.toolkits.scalar.UnreachableCodeEliminator;
 import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.scalar.LocalDefs;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SmartLocalDefs;
 
 /**
  * If Dalvik bytecode contains statements using a base array which is always
@@ -150,7 +148,7 @@ public class DexNullArrayRefTransformer extends BodyTransformer {
 				Collections.singletonList((Type) RefType.v("java.lang.String")));
 		
 		// Create the exception instance
-		Stmt newExStmt = Jimple.v().newNewStmt(lcEx, tp);
+		Stmt newExStmt = Jimple.v().newAssignStmt(lcEx, Jimple.v().newNewExpr(tp));
 		body.getUnits().insertBefore(newExStmt, oldStmt);
 		Stmt invConsStmt = Jimple.v().newInvokeStmt(Jimple.v().newVirtualInvokeExpr(lcEx,
 				constructorRef, Collections.singletonList(StringConstant.v(

--- a/src/soot/dexpler/DexNullTransformer.java
+++ b/src/soot/dexpler/DexNullTransformer.java
@@ -67,10 +67,8 @@ import soot.jimple.StringConstant;
 import soot.jimple.ThrowStmt;
 import soot.jimple.internal.AbstractInstanceInvokeExpr;
 import soot.jimple.internal.AbstractInvokeExpr;
-import soot.toolkits.graph.UnitGraph;
-import soot.toolkits.scalar.SimpleLocalUses;
-import soot.toolkits.scalar.SmartLocalDefs;
-import soot.toolkits.scalar.SmartLocalDefsPool;
+import soot.toolkits.scalar.LocalDefs;
+import soot.toolkits.scalar.LocalUses;
 import soot.toolkits.scalar.UnitValueBoxPair;
 
 /**
@@ -92,11 +90,9 @@ public class DexNullTransformer extends AbstractNullTransformer {
 
 	private Local l = null;
 
-	protected void internalTransform(final Body body, String phaseName,
-			@SuppressWarnings("rawtypes") Map options) {
-        SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(body);
-        UnitGraph g = localDefs.getGraph();
-		final SimpleLocalUses localUses = new SimpleLocalUses(g, localDefs);
+	protected void internalTransform(final Body body, String phaseName, Map<String,String> options) {
+        final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(body);
+		final LocalUses localUses = LocalUses.Factory.newLocalUses(body, localDefs);
 		
 		for (Local loc : getNullCandidates(body)) {
 			Debug.printDbg("\n[null candidate] ", loc);

--- a/src/soot/dexpler/DexNumTransformer.java
+++ b/src/soot/dexpler/DexNumTransformer.java
@@ -56,11 +56,8 @@ import soot.jimple.LengthExpr;
 import soot.jimple.LongConstant;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.ReturnStmt;
-import soot.toolkits.graph.ExceptionalUnitGraph;
+import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.LocalUses;
-import soot.toolkits.scalar.SimpleLocalUses;
-import soot.toolkits.scalar.SmartLocalDefs;
-import soot.toolkits.scalar.SmartLocalDefsPool;
 import soot.toolkits.scalar.UnitValueBoxPair;
 
 /**
@@ -111,11 +108,9 @@ public class DexNumTransformer extends DexTransformer {
 
 	Local l = null;
 
-	protected void internalTransform(final Body body, String phaseName,
-			@SuppressWarnings("rawtypes") Map options) {
-        final SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(body);
-        final ExceptionalUnitGraph g = (ExceptionalUnitGraph) localDefs.getGraph();
-		final LocalUses localUses = new SimpleLocalUses(g, localDefs);
+	protected void internalTransform(final Body body, String phaseName, Map<String,String> options) {
+        final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(body);
+		final LocalUses localUses = LocalUses.Factory.newLocalUses(body, localDefs);
 		
         for (Local loc : getNumCandidates(body)) {
             Debug.printDbg("\n[num candidate] ", loc);
@@ -156,7 +151,7 @@ public class DexNumTransformer extends DexTransformer {
 							Type arType = ar.getType();
 							Debug.printDbg("ar: ", r, " ", arType);
 							if (arType instanceof UnknownType) {
-								Type t = findArrayType(g, localDefs, localUses,
+								Type t = findArrayType(/*g,*/ localDefs, localUses,
 										stmt, 0, Collections.<Unit> emptySet()); // TODO:
 																					// check
 																					// where

--- a/src/soot/dexpler/DexReturnValuePropagator.java
+++ b/src/soot/dexpler/DexReturnValuePropagator.java
@@ -21,9 +21,6 @@ import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.graph.UnitGraph;
 import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.LocalUses;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SimpleLocalUses;
-import soot.toolkits.scalar.SmartLocalDefs;
 
 public class DexReturnValuePropagator extends BodyTransformer {
 	
@@ -34,7 +31,7 @@ public class DexReturnValuePropagator extends BodyTransformer {
 	@Override
 	protected void internalTransform(Body body, String phaseName, Map<String, String> options) {
         ExceptionalUnitGraph graph = new ExceptionalUnitGraph(body, DalvikThrowAnalysis.v(), true);
-        LocalDefs localDefs = new SmartLocalDefs(graph, new SimpleLiveLocals(graph));
+        LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(graph);
         LocalUses localUses = null;
         LocalCreation localCreation = null;
         
@@ -66,7 +63,7 @@ public class DexReturnValuePropagator extends BodyTransformer {
 						// we rename the local to help splitting
 						else if (rightOp instanceof FieldRef) {
 							if (localUses == null)
-								localUses = new SimpleLocalUses(body, localDefs);
+								localUses = LocalUses.Factory.newLocalUses(body, localDefs);
 							if (localUses.getUsesOf(assign).size() == 1) {
 								if (localCreation == null)
 									localCreation = new LocalCreation(body.getLocals(), "ret");

--- a/src/soot/dexpler/DexTransformer.java
+++ b/src/soot/dexpler/DexTransformer.java
@@ -43,7 +43,6 @@ import soot.jimple.IdentityStmt;
 import soot.jimple.InvokeExpr;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.Stmt;
-import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.LocalUses;
 import soot.toolkits.scalar.UnitValueBoxPair;
@@ -125,7 +124,7 @@ public abstract class DexTransformer extends BodyTransformer {
 		return defs;
 	}
 
-	protected Type findArrayType(ExceptionalUnitGraph g,
+	protected Type findArrayType(/*ExceptionalUnitGraph g,*/
 			LocalDefs localDefs, LocalUses localUses,
 			Stmt arrayStmt, int depth, Set<Unit> alreadyVisitedDefs) {
 		ArrayRef aRef = null;
@@ -147,7 +146,7 @@ public abstract class DexTransformer extends BodyTransformer {
 		}
 
 		List<Unit> defsOfaBaseList = localDefs.getDefsOfAt(aBase, arrayStmt);
-		if (defsOfaBaseList == null || defsOfaBaseList.size() == 0) {
+		if (defsOfaBaseList == null || defsOfaBaseList.isEmpty()) {
 			throw new RuntimeException("ERROR: no def statement found for array base local "
 							+ arrayStmt);
 		}
@@ -187,7 +186,7 @@ public abstract class DexTransformer extends BodyTransformer {
 																			// ar.getType())
 																			// {
 						System.out.println("second round from stmt: " + stmt);
-						Type t = findArrayType(g, localDefs, localUses, stmt,
+						Type t = findArrayType(/*g,*/ localDefs, localUses, stmt,
 								++depth, newVisitedDefs); // TODO: which type should be
 											// returned?
 						if (t instanceof ArrayType) {
@@ -252,7 +251,7 @@ public abstract class DexTransformer extends BodyTransformer {
 				// information associated with the alias.
 				} else if (r instanceof Local) {
 					Debug.printDbg("atype alias: ", stmt);
-					Type t = findArrayType(g, localDefs, localUses, stmt,
+					Type t = findArrayType(/*g,*/ localDefs, localUses, stmt,
 							++depth, newVisitedDefs);
 					if (depth == 0) {
 						aType = t;

--- a/src/soot/dexpler/typing/Validate.java
+++ b/src/soot/dexpler/typing/Validate.java
@@ -35,9 +35,7 @@ import soot.jimple.StringConstant;
 import soot.jimple.toolkits.scalar.DeadAssignmentEliminator;
 import soot.jimple.toolkits.scalar.NopEliminator;
 import soot.jimple.toolkits.scalar.UnreachableCodeEliminator;
-import soot.toolkits.graph.ExceptionalUnitGraph;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SmartLocalDefs;
+import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.UnusedLocalEliminator;
 
 public class Validate {
@@ -62,8 +60,7 @@ public class Validate {
             }
         }
         
-        final ExceptionalUnitGraph g = new ExceptionalUnitGraph(b);
-        final SmartLocalDefs localDefs = new SmartLocalDefs(g, new SimpleLiveLocals(g));
+        final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(b);
         
         Set<Unit> toReplace = new HashSet<Unit>();
         

--- a/src/soot/dexpler/typing/Validate.java
+++ b/src/soot/dexpler/typing/Validate.java
@@ -60,7 +60,7 @@ public class Validate {
             }
         }
         
-        final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(b);
+        final LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(b, true);
         
         Set<Unit> toReplace = new HashSet<Unit>();
         

--- a/src/soot/grimp/toolkits/base/ConstructorFolder.java
+++ b/src/soot/grimp/toolkits/base/ConstructorFolder.java
@@ -77,10 +77,8 @@ public class ConstructorFolder extends BodyTransformer
       stmtList.addAll(units);
 
       Iterator<Unit> it = stmtList.iterator();
-
-      SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(b);
-      UnitGraph graph = localDefs.getGraph();
-      LocalUses localUses = new SimpleLocalUses(graph, localDefs);
+      
+      LocalUses localUses = LocalUses.Factory.newLocalUses(b);
 
       /* fold in NewExpr's with specialinvoke's */
       while (it.hasNext())

--- a/src/soot/jimple/JasminClass.java
+++ b/src/soot/jimple/JasminClass.java
@@ -32,7 +32,9 @@ import soot.tagkit.LineNumberTag;
 import soot.toolkits.graph.*;
 import soot.toolkits.scalar.*;
 import soot.util.*;
+
 import java.util.*;
+
 import soot.grimp.*;
 
 /** Methods for producing Jasmin code from Jimple. */
@@ -116,8 +118,9 @@ public class JasminClass extends AbstractJasminClass
         if (!disablePeephole)
         {
             stmtGraph = new ExceptionalUnitGraph(body);
-            ld = new SmartLocalDefs(stmtGraph, new SimpleLiveLocals(stmtGraph));
-            lu = new SimpleLocalUses(stmtGraph, ld);
+            ld =  LocalDefs.Factory.newLocalDefs(stmtGraph);
+            lu = LocalUses.Factory.newLocalUses(body, ld);
+            
         }
 
         int stackLimitIndex = -1;

--- a/src/soot/jimple/internal/JimpleLocal.java
+++ b/src/soot/jimple/internal/JimpleLocal.java
@@ -23,129 +23,101 @@
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
 
-
 package soot.jimple.internal;
 
-import soot.tagkit.*;
 import soot.*;
 import soot.jimple.*;
 import soot.baf.*;
 import soot.util.*;
+
 import java.util.*;
 
-public class JimpleLocal implements Local, ConvertToBaf
-{
-    String name;
-    Type type;
+public class JimpleLocal implements Local, ConvertToBaf {
+	String name;
+	Type type;
 
-    int fixedHashCode;
-    boolean isHashCodeChosen;
+	/** Constructs a JimpleLocal of the given name and type. */
+	public JimpleLocal(String name, Type type) {
+		setName(name);
+		setType(type);
+		Scene.v().getLocalNumberer().add(this);
+	}
 
-    /** Constructs a JimpleLocal of the given name and type. */
-    public JimpleLocal(String name, Type type)
-    {
-        setName(name);
-        setType(type);
-        Scene.v().getLocalNumberer().add( this );
-    }
+	/** Returns true if the given object is structurally equal to this one. */
+	public boolean equivTo(Object o) {
+		return this.equals(o);
+	}
 
-    /** Returns true if the given object is structurally equal to this one. */
-    public boolean equivTo(Object o)
-    {
-        return this.equals( o );
-    }
+	/**
+	 * Returns a hash code for this object, consistent with structural equality.
+	 */
+	public int equivHashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
 
-    /** Returns a hash code for this object, consistent with structural equality. */
-    public int equivHashCode() 
-    {
-        return name.hashCode() * 101 + type.hashCode() * 17;
-    }
+	/** Returns a clone of the current JimpleLocal. */
+	public Object clone() {
+		// do not intern the name again
+		JimpleLocal local = new JimpleLocal(null, type);
+		local.name = name;
+		return local;
+	}
 
-    /** Returns a clone of the current JimpleLocal. */
-    public Object clone()
-    {
-    	// do not intern the name again
-        JimpleLocal local = new JimpleLocal(null, type);
-        local.name = name;
-        return local;
-    }
+	/** Returns the name of this object. */
+	public String getName() {
+		return name;
+	}
 
-    /** Returns the name of this object. */
-    public String getName()
-    {
-        return name;
-    }
+	/** Sets the name of this object as given. */
+	public void setName(String name) {
+		this.name = (name == null) ? null : name.intern();
+	}
 
-    /** Sets the name of this object as given. */
-    public void setName(String name)
-    {
-    	this.name = (name == null) ? null : name.intern();
-    }
+	/** Returns the type of this local. */
+	public Type getType() {
+		return type;
+	}
 
-    /** Returns a hashCode consistent with object equality. */
-    public int hashCode()
-    {
-        if(!isHashCodeChosen)
-        {
-            // Set the hash code for this object
-            
-            if(name != null & type != null)
-                fixedHashCode = name.hashCode() + 19 * type.hashCode();
-            else if(name != null)
-                fixedHashCode = name.hashCode();
-            else if(type != null)
-                fixedHashCode = type.hashCode();
-            else
-                fixedHashCode = 1;
-                
-            isHashCodeChosen = true;
-        }
-        
-        return fixedHashCode;
-    }
-    
-    /** Returns the type of this local. */
-    public Type getType()
-    {
-        return type;
-    }
+	/** Sets the type of this local. */
+	public void setType(Type t) {
+		this.type = t;
+	}
 
-    /** Sets the type of this local. */
-    public void setType(Type t)
-    {
-        this.type = t;
-    }
+	public String toString() {
+		return getName();
+	}
 
-    public String toString()
-    {
-        return getName();
-    }
-    
-    public void toString(UnitPrinter up) {
-        up.local(this);
-    }
+	public void toString(UnitPrinter up) {
+		up.local(this);
+	}
 
-    @Override
-    public final List<ValueBox> getUseBoxes()
-    {
-        return Collections.emptyList();
-    }
+	@Override
+	public final List<ValueBox> getUseBoxes() {
+		return Collections.emptyList();
+	}
 
-    public void apply(Switch sw)
-    {
-        ((JimpleValueSwitch) sw).caseLocal(this);
-    }
+	public void apply(Switch sw) {
+		((JimpleValueSwitch) sw).caseLocal(this);
+	}
 
-    public void convertToBaf(JimpleToBafContext context, List<Unit> out)
-    {
-    	Unit u = Baf.v().newLoadInst(getType(), context.getBafLocalOfJimpleLocal(this));
-    	u.addAllTagsOf(context.getCurrentUnit());
-        out.add(u);
-    }
-    
-    public final int getNumber() { return number; }
-    public final void setNumber( int number ) { this.number = number; }
+	public void convertToBaf(JimpleToBafContext context, List<Unit> out) {
+		Unit u = Baf.v().newLoadInst(getType(),
+				context.getBafLocalOfJimpleLocal(this));
+		u.addAllTagsOf(context.getCurrentUnit());
+		out.add(u);
+	}
 
-    private int number = 0;
+	public final int getNumber() {
+		return number;
+	}
+
+	public final void setNumber(int number) {
+		this.number = number;
+	}
+
+	private int number = 0;
 }
-

--- a/src/soot/jimple/toolkits/annotation/arraycheck/ClassFieldAnalysis.java
+++ b/src/soot/jimple/toolkits/annotation/arraycheck/ClassFieldAnalysis.java
@@ -28,7 +28,6 @@ import soot.options.*;
 import soot.*;
 import soot.jimple.*;
 import soot.toolkits.scalar.*;
-import soot.toolkits.graph.*;
 
 import java.util.*;
 
@@ -227,8 +226,7 @@ public class ClassFieldAnalysis
 
 	/* build D/U web, find the value of each candidate */
 	{
-            UnitGraph g = new ExceptionalUnitGraph(body);
-	    LocalDefs localDefs = new SmartLocalDefs(g, new SimpleLiveLocals(g));
+	    LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(body);
 	    
 	    Set<Map.Entry<Stmt,SootField>> entries = stmtfield.entrySet();
 

--- a/src/soot/jimple/toolkits/annotation/defs/ReachingDefsTagger.java
+++ b/src/soot/jimple/toolkits/annotation/defs/ReachingDefsTagger.java
@@ -21,42 +21,37 @@ package soot.jimple.toolkits.annotation.defs;
 
 import soot.*;
 import soot.toolkits.scalar.*;
-import soot.toolkits.graph.*;
 import soot.tagkit.*;
 
 import java.util.*;
 
-import soot.jimple.*;
-
 public class ReachingDefsTagger extends BodyTransformer {
 
+	public ReachingDefsTagger(Singletons.Global g) {
+	}
 
-    public ReachingDefsTagger(Singletons.Global g) {}
-    public static ReachingDefsTagger v() { return G.v().soot_jimple_toolkits_annotation_defs_ReachingDefsTagger();}
+	public static ReachingDefsTagger v() {
+		return G.v().soot_jimple_toolkits_annotation_defs_ReachingDefsTagger();
+	}
 
-    protected void internalTransform(Body b, String phaseName, Map options){
-    
-        SmartLocalDefs sld = SmartLocalDefsPool.v().getSmartLocalDefsFor(b);
-        UnitGraph g = sld.getGraph();
+	protected void internalTransform(Body b, String phaseName, Map<String, String> options) {
 
-        Iterator it = b.getUnits().iterator();
-        while (it.hasNext()){
-            Stmt s = (Stmt)it.next();
-            //System.out.println("stmt: "+s);
-            Iterator usesIt = s.getUseBoxes().iterator();
-            while (usesIt.hasNext()){
-                ValueBox vbox = (ValueBox)usesIt.next();
-                if (vbox.getValue() instanceof Local) {
-                    Local l = (Local)vbox.getValue();
-                    //System.out.println("local: "+l);
-                    Iterator<Unit> rDefsIt = sld.getDefsOfAt(l, s).iterator();
-                    while (rDefsIt.hasNext()){
-                        Stmt next = (Stmt)rDefsIt.next();
-                        String info = l+" has reaching def: "+next.toString();
-                        s.addTag(new LinkTag(info, next, b.getMethod().getDeclaringClass().getName(), "Reaching Defs"));
-                    }
-                }
-            }
-        }
-    }
-}   
+		LocalDefs ld = LocalDefs.Factory.newLocalDefs(b);
+
+		for (Unit s : b.getUnits()) {
+			// System.out.println("stmt: "+s);
+			for (ValueBox vbox : s.getUseBoxes()) {
+				Value v = vbox.getValue();
+				if (v instanceof Local) {
+					Local l = (Local) v;
+					// System.out.println("local: "+l);
+					for (Unit next : ld.getDefsOfAt(l, s)) {
+						String info = l + " has reaching def: " + next;
+						String className =  b.getMethod().getDeclaringClass().getName();
+						s.addTag(new LinkTag(info, next, className, "Reaching Defs"));
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/soot/jimple/toolkits/base/PartialConstructorFolder.java
+++ b/src/soot/jimple/toolkits/base/PartialConstructorFolder.java
@@ -33,7 +33,6 @@ import soot.options.*;
 import soot.*;
 import soot.toolkits.scalar.*;
 import soot.jimple.*;
-import soot.toolkits.graph.*;
 import soot.util.*;
 
 import java.util.*;
@@ -43,20 +42,20 @@ public class PartialConstructorFolder extends BodyTransformer
     //public JimpleConstructorFolder( Singletons.Global g ) {}
     //public static JimpleConstructorFolder v() { return G.v().JimpleConstructorFolder(); }
 
-    private List types;
+    private List<Type> types;
 
-    public void setTypes(List t){
+    public void setTypes(List<Type> t){
         types = t;
     }
 
-    public List getTypes(){
+    public List<Type> getTypes(){
         return types;
     }
     
     /** This method pushes all newExpr down to be the stmt directly before every
      * invoke of the init only if they are in the types list*/
     
-    public void internalTransform(Body b, String phaseName, Map options)
+    public void internalTransform(Body b, String phaseName, Map<String,String> options)
     {
         JimpleBody body = (JimpleBody)b;
 
@@ -64,7 +63,7 @@ public class PartialConstructorFolder extends BodyTransformer
             G.v().out.println("[" + body.getMethod().getName() +
                 "] Folding Jimple constructors...");
 
-        Chain units = body.getUnits();
+        Chain<Unit> units = body.getUnits();
         List<Unit> stmtList = new ArrayList<Unit>();
         stmtList.addAll(units);
 
@@ -73,9 +72,7 @@ public class PartialConstructorFolder extends BodyTransformer
         // start ahead one
         nextStmtIt.next();
         
-        SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(body);
-        UnitGraph graph = localDefs.getGraph();
-        LocalUses localUses = new SimpleLocalUses(graph, localDefs);
+        LocalUses localUses = LocalUses.Factory.newLocalUses(body);
 
         /* fold in NewExpr's with specialinvoke's */
         while (it.hasNext())
@@ -118,13 +115,13 @@ public class PartialConstructorFolder extends BodyTransformer
             // check if new is in the types list - only process these
             if (!types.contains(((NewExpr)rhs).getType())) continue;
             
-            List lu = localUses.getUsesOf(s);
-            Iterator luIter = lu.iterator();
+            List<UnitValueBoxPair> lu = localUses.getUsesOf(s);
+            Iterator<UnitValueBoxPair> luIter = lu.iterator();
             boolean MadeNewInvokeExpr = false;
           
             while (luIter.hasNext())
             {
-                Unit use = ((UnitValueBoxPair)(luIter.next())).unit;
+                Unit use = ((luIter.next())).unit;
                 if (!(use instanceof InvokeStmt))
                     continue;
                 InvokeStmt is = (InvokeStmt)use;

--- a/src/soot/jimple/toolkits/scalar/ConstantPropagatorAndFolder.java
+++ b/src/soot/jimple/toolkits/scalar/ConstantPropagatorAndFolder.java
@@ -27,11 +27,12 @@
 
 package soot.jimple.toolkits.scalar;
 import soot.options.*;
-
 import soot.*;
 import soot.toolkits.scalar.*;
 import soot.jimple.*;
+
 import java.util.*;
+
 import soot.toolkits.graph.*;
 
 /** Does constant propagation and folding. 
@@ -51,13 +52,14 @@ public class ConstantPropagatorAndFolder extends BodyTransformer
             G.v().out.println("[" + b.getMethod().getName() +
                                "] Propagating and folding constants...");
 
-        SmartLocalDefs localDefs = SmartLocalDefsPool.v().getSmartLocalDefsFor(b);
+        UnitGraph g = new ExceptionalUnitGraph(b);
+        LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(g);
 
         // Perform a constant/local propagation pass.
         Orderer<Unit> orderer = new PseudoTopologicalOrderer<Unit>();
         
         // go through each use box in each statement
-        for (Unit u : orderer.newList(localDefs.getGraph(), false)) {
+        for (Unit u : orderer.newList(g, false)) {
 
             // propagation pass
             for (ValueBox useBox : u.getUseBoxes()) {

--- a/src/soot/jimple/toolkits/scalar/CopyPropagator.java
+++ b/src/soot/jimple/toolkits/scalar/CopyPropagator.java
@@ -102,15 +102,17 @@ public class CopyPropagator extends BodyTransformer {
 					localToDefCount.put(l, new Integer(localToDefCount.get(l).intValue() + 1));
 			}
 		}
+		
+        if (throwAnalysis == null)
+        	throwAnalysis = Scene.v().getDefaultThrowAnalysis();
+        
+        if (forceOmitExceptingUnitEdges == false)
+        	forceOmitExceptingUnitEdges = Options.v().omit_excepting_unit_edges();
+        
+        // Go through the definitions, building the webs
+    	UnitGraph graph = new ExceptionalUnitGraph(stmtBody, throwAnalysis, forceOmitExceptingUnitEdges);
 
-		if (this.throwAnalysis == null)
-			this.throwAnalysis = Scene.v().getDefaultThrowAnalysis();
-		ExceptionalUnitGraph graph = new ExceptionalUnitGraph(stmtBody, throwAnalysis,
-				forceOmitExceptingUnitEdges || Options.v().omit_excepting_unit_edges());
-
-		LocalDefs localDefs;
-
-		localDefs = new SmartLocalDefs(graph, new SimpleLiveLocals(graph));
+		LocalDefs localDefs = LocalDefs.Factory.newLocalDefs(graph);
 
 		// Perform a local propagation pass.
 		{
@@ -250,8 +252,6 @@ public class CopyPropagator extends BodyTransformer {
 
 		if (Options.v().time())
 			Timers.v().propagatorTimer.end();
-		
-		SmartLocalDefsPool.v().invalidate(b);
 	}
 
 }

--- a/src/soot/jimple/toolkits/scalar/FastAvailableExpressionsAnalysis.java
+++ b/src/soot/jimple/toolkits/scalar/FastAvailableExpressionsAnalysis.java
@@ -52,7 +52,7 @@ public class FastAvailableExpressionsAnalysis extends ForwardFlowAnalysis
         this.st = st;
 
         ExceptionalUnitGraph g = (ExceptionalUnitGraph)dg;
-        LocalDefs ld = new SmartLocalDefs(g, new SimpleLiveLocals(g));
+        //LocalDefs ld = new SmartLocalDefs(g, new SimpleLiveLocals(g));
 
         // maps an rhs to its containing stmt.  object equality in rhs.
         rhsToContainingStmt = new HashMap<Value, Unit>();

--- a/src/soot/jimple/toolkits/thread/synchronization/LockAllocator.java
+++ b/src/soot/jimple/toolkits/thread/synchronization/LockAllocator.java
@@ -617,17 +617,17 @@ public class LockAllocator extends SceneTransformer
 			CriticalSection tn = tnAIt.next();
 			if(tn.setNumber <= 0)
 				continue;
-			ExceptionalUnitGraph egraph = new ExceptionalUnitGraph(tn.method.retrieveActiveBody());
-			SmartLocalDefs sld = new SmartLocalDefs(egraph, new SimpleLiveLocals(egraph));
+			
+			LocalDefs ld = LocalDefs.Factory.newLocalDefs(tn.method.retrieveActiveBody());
+			
 			if(tn.origLock == null || !(tn.origLock instanceof Local)) // || tn.begin == null)
 				continue;
-			List<Unit> rDefs = sld.getDefsOfAt( (Local) tn.origLock , tn.entermonitor );
+			List<Unit> rDefs = ld.getDefsOfAt( (Local) tn.origLock , tn.entermonitor );
 			if(rDefs == null)
 				continue;
-			Iterator<Unit> rDefsIt = rDefs.iterator();
-			while (rDefsIt.hasNext())
+			for (Unit u : rDefs)
 			{
-				Stmt next = (Stmt) rDefsIt.next();
+				Stmt next = (Stmt) u;
 				if(next instanceof DefinitionStmt)
 				{
 					Value rightOp = ((DefinitionStmt) next).getRightOp();

--- a/src/soot/jimple/toolkits/typing/TypeAssigner.java
+++ b/src/soot/jimple/toolkits/typing/TypeAssigner.java
@@ -218,8 +218,9 @@ public class TypeAssigner extends BodyTransformer {
 			b.getUnits().remove(u);
 		}
 
-		DeadAssignmentEliminator.v().transform(b);
-		UnusedLocalEliminator.v().transform(b);
+		// should be done on a separate phase
+		//DeadAssignmentEliminator.v().transform(b);
+		//UnusedLocalEliminator.v().transform(b);
 
 	}
 	

--- a/src/soot/jimple/toolkits/typing/TypeAssigner.java
+++ b/src/soot/jimple/toolkits/typing/TypeAssigner.java
@@ -219,8 +219,8 @@ public class TypeAssigner extends BodyTransformer {
 		}
 
 		// should be done on a separate phase
-		//DeadAssignmentEliminator.v().transform(b);
-		//UnusedLocalEliminator.v().transform(b);
+		DeadAssignmentEliminator.v().transform(b);
+		UnusedLocalEliminator.v().transform(b);
 
 	}
 	

--- a/src/soot/jimple/toolkits/typing/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/TypeResolver.java
@@ -968,8 +968,7 @@ public class TypeResolver
 
   private void split_new()
   {
-    ExceptionalUnitGraph graph = new ExceptionalUnitGraph(stmtBody);
-    LocalDefs defs = new SmartLocalDefs(graph,new SimpleLiveLocals(graph));
+	LocalDefs defs = LocalDefs.Factory.newLocalDefs(stmtBody);
     PatchingChain<Unit> units = stmtBody.getUnits();
     Stmt[] stmts = new Stmt[units.size()];
 

--- a/src/soot/jimple/toolkits/typing/TypeResolverBV.java
+++ b/src/soot/jimple/toolkits/typing/TypeResolverBV.java
@@ -1002,8 +1002,7 @@ public class TypeResolverBV
 
   private void split_new()
   {
-    ExceptionalUnitGraph graph = new ExceptionalUnitGraph(stmtBody);
-    LocalDefs defs = new SmartLocalDefs(graph, new SimpleLiveLocals(graph));
+	LocalDefs defs = LocalDefs.Factory.newLocalDefs(stmtBody);
     PatchingChain<Unit> units = stmtBody.getUnits();
     Stmt[] stmts = new Stmt[units.size()];
 

--- a/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -55,10 +55,7 @@ import soot.jimple.NewExpr;
 import soot.jimple.SpecialInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.toolkits.typing.Util;
-import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.scalar.LocalDefs;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SmartLocalDefs;
 
 /**
  * New Type Resolver by Ben Bellamy (see 'Efficient Local Type Inference'
@@ -87,7 +84,7 @@ public class TypeResolver
 	{
 		this.jb = jb;
 
-		this.assignments = new LinkedList<DefinitionStmt>();
+		this.assignments = new ArrayList<DefinitionStmt>();
 		this.depends = new HashMap<Local, BitSet>();
 		for ( Local v : this.jb.getLocals() )
 			this.addLocal(v);
@@ -106,8 +103,8 @@ public class TypeResolver
 		Value lhs = ds.getLeftOp(), rhs = ds.getRightOp();
 		if ( lhs instanceof Local || lhs instanceof ArrayRef)
 		{
+			int assignmentIdx = this.assignments.size();
 			this.assignments.add(ds);
-			int assignmentIdx = this.assignments.indexOf(ds);
 			
 			if ( rhs instanceof Local )
 				this.addDepend((Local)rhs, assignmentIdx);
@@ -564,9 +561,8 @@ public class TypeResolver
 	/* Taken from the soot.jimple.toolkits.typing.TypeResolver class of Soot
 	version 2.2.5. */
 	private void split_new()
-	{
-		ExceptionalUnitGraph graph = new ExceptionalUnitGraph(this.jb);
-		LocalDefs defs = new SmartLocalDefs(graph,new SimpleLiveLocals(graph));
+	{		
+		LocalDefs defs = LocalDefs.Factory.newLocalDefs(jb);
 		PatchingChain<Unit> units = this.jb.getUnits();
 		Stmt[] stmts = new Stmt[units.size()];
 		

--- a/src/soot/jimple/toolkits/typing/fast/UseChecker.java
+++ b/src/soot/jimple/toolkits/typing/fast/UseChecker.java
@@ -21,7 +21,6 @@
 package soot.jimple.toolkits.typing.fast;
 
 import java.util.Iterator;
-import java.util.List;
 
 import soot.ArrayType;
 import soot.BooleanType;
@@ -84,13 +83,8 @@ import soot.jimple.TableSwitchStmt;
 import soot.jimple.ThrowStmt;
 import soot.jimple.UshrExpr;
 import soot.jimple.XorExpr;
-import soot.toolkits.graph.ExceptionalUnitGraph;
-import soot.toolkits.graph.UnitGraph;
 import soot.toolkits.scalar.LocalDefs;
 import soot.toolkits.scalar.LocalUses;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SimpleLocalUses;
-import soot.toolkits.scalar.SmartLocalDefs;
 import soot.toolkits.scalar.UnitValueBoxPair;
 
 /**
@@ -130,7 +124,7 @@ public class UseChecker extends AbstractStmtSwitch
 		{
 			if ( uv.finish() )
 				return;
-			((Stmt)i.next()).apply(this);
+			i.next().apply(this);
 		}
 	}
 
@@ -284,15 +278,12 @@ public class UseChecker extends AbstractStmtSwitch
 					if (rt.getSootClass().getName().equals("java.lang.Object")
 							|| rt.getSootClass().getName().equals("java.io.Serializable")
 							|| rt.getSootClass().getName().equals("java.lang.Cloneable")) {
-						if (this.defs == null) {
-							UnitGraph graph = new ExceptionalUnitGraph(jb);
-					        this.defs = new SmartLocalDefs(graph,
-									new SimpleLiveLocals(graph));
-							this.uses = new SimpleLocalUses(graph, this.defs);
+						if (defs == null) {
+					        defs = LocalDefs.Factory.newLocalDefs(jb);
+							uses = LocalUses.Factory.newLocalUses(jb, defs);
 						}
 						
-						List<UnitValueBoxPair> usePairs = this.uses.getUsesOf(stmt);
-						outer: for (UnitValueBoxPair usePair : usePairs) {
+						outer: for (UnitValueBoxPair usePair : uses.getUsesOf(stmt)) {
 							Stmt useStmt = (Stmt) usePair.getUnit();
 							if (useStmt.containsInvokeExpr())
 								for (int i = 0; i < useStmt.getInvokeExpr().getArgCount(); i++)

--- a/src/soot/toolkits/exceptions/TrapTightener.java
+++ b/src/soot/toolkits/exceptions/TrapTightener.java
@@ -77,8 +77,7 @@ public final class TrapTightener extends TrapTransformer {
 		Chain<Trap> trapChain = body.getTraps();
 		Chain<Unit> unitChain = body.getUnits();
 		if (trapChain.size() > 0) {
-			ExceptionalUnitGraph graph = new ExceptionalUnitGraph(body, throwAnalysis,
-					Options.v().omit_excepting_unit_edges());
+			ExceptionalUnitGraph graph = new ExceptionalUnitGraph(body, throwAnalysis);
 			Set<Unit> unitsWithMonitor = getUnitsWithMonitor(graph);
 
 			for (Iterator<Trap> trapIt = trapChain.iterator(); trapIt.hasNext();) {

--- a/src/soot/toolkits/scalar/AbstractFlowSet.java
+++ b/src/soot/toolkits/scalar/AbstractFlowSet.java
@@ -159,6 +159,18 @@ public abstract class AbstractFlowSet<T> implements FlowSet<T> {
 		dest.remove(obj);
 	}
 
+	@Override
+	public boolean isSubSet(FlowSet<T> other) {
+		if (other == this)
+			return true;
+		
+		for (T t : other) {
+			if (!contains(t))
+				return false;
+		}
+		return true;
+	}
+
 	public abstract boolean contains(T obj);
 
 	public abstract Iterator<T> iterator();
@@ -187,7 +199,7 @@ public abstract class AbstractFlowSet<T> implements FlowSet<T> {
 
 	public String toString() {
 		StringBuffer buffer = new StringBuffer("{");
-		
+
 		boolean isFirst = true;
 		for (T t : this) {
 			if (!isFirst)

--- a/src/soot/toolkits/scalar/ArrayPackedSet.java
+++ b/src/soot/toolkits/scalar/ArrayPackedSet.java
@@ -164,7 +164,22 @@ public class ArrayPackedSet<T> extends AbstractBoundedFlowSet<T>
     {
     	bits.clear(map.getInt(obj));
     }
-
+    
+	@Override
+	public boolean isSubSet(FlowSet<T> other) {
+		if (other == this)
+			return true;
+		if (sameType(other)) {
+	          ArrayPackedSet<T> o = (ArrayPackedSet<T>) other;
+	          
+	          BitSet tmp = (BitSet) o.bits.clone();
+	          tmp.andNot(bits);
+	          return tmp.isEmpty();
+		}
+		return super.isSubSet(other);
+	}
+	
+	
     public void union(FlowSet<T> otherFlow, FlowSet<T> destFlow)
     {
       if (sameType(otherFlow) &&
@@ -262,10 +277,11 @@ public class ArrayPackedSet<T> extends AbstractBoundedFlowSet<T>
     }
 
 	@Override
-	public Iterator<T> iterator() {		
+	public Iterator<T> iterator() {
 		return new Iterator<T>() {
 			
 			int i = bits.nextSetBit(0);		
+			T t;
 			
 			@Override
 			public boolean hasNext() {
@@ -276,14 +292,17 @@ public class ArrayPackedSet<T> extends AbstractBoundedFlowSet<T>
 			public T next() {
 				if (i < 0)
 					throw new NoSuchElementException();
-				T t = map.getObject(i);				
+				t = map.getObject(i);				
 				i = bits.nextSetBit(i+1);					
 				return t;
 			}
 
 			@Override
 			public void remove() {
+				if (t == null)
+					throw new IllegalStateException();
 		        bits.clear(i);
+		        t = null;
 			}
 			
 		};

--- a/src/soot/toolkits/scalar/BackwardFlowAnalysis.java
+++ b/src/soot/toolkits/scalar/BackwardFlowAnalysis.java
@@ -36,27 +36,21 @@ public abstract class BackwardFlowAnalysis<N, A> extends FlowAnalysis<N, A> {
 	 * Construct the analysis from a DirectedGraph representation of a Body.
 	 */
 	public BackwardFlowAnalysis(DirectedGraph<N> graph) {
-		super(graph, GraphView.BACKWARD, InteractionFlowHandler.BACKWARD);
+		super(graph);
 	}
 
+    /** 
+     * Returns <code>false</code> 
+     * @return false
+     **/
 	@Override
 	protected boolean isForward() {
 		return false;
 	}
 
 	@Override
-	A getInFlow(N s) {
-		return getFlowAfter(s);
-	}
-
-	@Override
-	A getOutFlow(N s) {
-		return getFlowBefore(s);
-	}
-
-	@Override
 	protected void doAnalysis() {
-		super.doAnalysis();
+		doAnalysis(GraphView.BACKWARD, InteractionFlowHandler.BACKWARD, unitToAfterFlow, unitToBeforeFlow);
 
 		// soot.Timers.v().totalFlowNodes += graph.size();
 		// soot.Timers.v().totalFlowComputations += numComputations;

--- a/src/soot/toolkits/scalar/FlowAnalysis.java
+++ b/src/soot/toolkits/scalar/FlowAnalysis.java
@@ -25,9 +25,12 @@
 
 package soot.toolkits.scalar;
 
-import java.util.Collection;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,11 +38,12 @@ import java.util.Queue;
 
 import soot.options.Options;
 import soot.toolkits.graph.DirectedGraph;
-import soot.toolkits.graph.Orderer;
-import soot.toolkits.graph.PseudoTopologicalOrderer;
 import soot.toolkits.graph.interaction.FlowInfo;
 import soot.toolkits.graph.interaction.InteractionHandler;
+import soot.util.Numberable;
 import soot.util.PriorityQueue;
+import static soot.toolkits.scalar.FlowAnalysis.StronglyConnectedComponents.newUniverse;
+
 
 /** 
  * An abstract class providing a framework for carrying out dataflow analysis.
@@ -49,40 +53,201 @@ import soot.util.PriorityQueue;
  */
 public abstract class FlowAnalysis<N,A> extends AbstractFlowAnalysis<N,A>
 {
+	static class Entry<D,F> implements Numberable {
+		final D data;
+		int number;
+		int min;
+		boolean isStronglyConnected;
+		Entry<D,F>[] in;
+		Entry<D,F>[] out;
+		F inFlow;
+		F outFlow;
+		
+		@SuppressWarnings("unchecked")
+		Entry(D u, Entry<D,F> pred) {
+			in = (Entry<D,F>[]) new Entry[] {pred};
+			data = u;
+			min = Integer.MIN_VALUE;
+			isStronglyConnected = false;
+		}		
+		
+		@Override
+		public String toString() {
+			return data.toString();
+		}
+
+		@Override
+		public void setNumber(int n) {
+			this.number = n;			
+		}
+
+		@Override
+		public int getNumber() {
+			return number;
+		}
+	}
+
+	static class StronglyConnectedComponents {			
+		private StronglyConnectedComponents() {}
+		static <D,F> List<Entry<D,F>> newUniverse(DirectedGraph<D> g, GraphView gv, F entryFlow) {
+			final int n = g.size();
+			Deque<Entry<D,F>> s = new ArrayDeque<Entry<D,F>>(n);
+			Deque<Entry<D,F>> q = new ArrayDeque<Entry<D,F>>(n);
+			List<Entry<D,F>> universe = new ArrayList<Entry<D,F>>(n);
+			Map<D, Entry<D,F>> visited = new HashMap<D, Entry<D,F>>((n*3)/2+7);
+			
+			Entry<D,F>superEntry = new Entry<D,F>(null, null);
+			superEntry.outFlow = entryFlow;		
+			
+			q.addAll(Arrays.asList(visitEntry(visited, superEntry, gv.getEntries(g))));
+			
+			for (;;) {
+				if (q.isEmpty()) {
+					Collections.reverse(universe);
+					return universe;
+				}
+				
+				Entry<D,F> v = q.peekLast();		
+				
+				// already finished
+				if (v.min == Integer.MAX_VALUE) {
+					q.removeLast();
+					continue;
+				}
+				
+				if (sccPush(s, v)) {					
+					boolean foundNew = false;
+					for (Entry<D,F> e : visitEntry(visited, v, gv.getOut(g, v.data))) {
+						if (e.min == Integer.MIN_VALUE) {
+							q.addLast(e);
+							foundNew = true;
+						}						
+					}
+					if (foundNew)
+						continue;
+				}
+
+				universe.add(v);
+				sccPop(s, v);
+				q.removeLast();
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		private static <D,F> Entry<D,F>[] visitEntry(Map<D, Entry<D,F>> visited, Entry<D,F> v, List<D> out) {		
+			int n = out.size();
+			v.out = new Entry[n];
+			
+			// reverse output-order for a better visit-order!
+			for (int i = 0; i < n; i++) {
+				v.out[n-1-i] = getEntryOf(visited, out.get(i), v);
+			}
+			
+			return v.out;
+		}
+		
+		private static <D,F> Entry<D,F> getEntryOf(Map<D, Entry<D,F>> visited, D n, Entry<D,F> head) {
+			Entry<D,F> me = visited.get(n);
+			if (me == null) {
+				visited.put(n, me = new Entry<D,F>(n, head));	
+			} else {
+				// adding self ref (at least strongly connected with itself)
+				if (me == head)
+					me.isStronglyConnected = true;
+				
+				// merge nodes are uncommon, so this is ok
+				int l = me.in.length;
+				me.in = Arrays.copyOf(me.in, l+1);
+				me.in[l] = head;					
+			}
+			return me;
+		}
+
+		private static <D,F> boolean sccPush(Deque<Entry<D,F>> stack, Entry<D,F> e) {
+			// push node to stack, if it hasn't been visited 
+			if (e.min == Integer.MIN_VALUE) {
+				e.min = stack.size();
+				stack.push(e);			
+				return true;
+			}
+			return false;
+		}
+		
+		private static <D,F> void sccPop(Deque<Entry<D,F>> stack, Entry<D,F> v) {
+			int min = v.min;
+			
+			for (Entry<D,F> e : v.out) {
+				min = Math.min(min, e.min);
+			}
+			
+			// not our SCC 
+			if (min < v.min) {
+				v.min = min;
+				return;
+			}
+			
+			// we only want real SCCs
+			
+			Entry<D,F> w = stack.pop();
+			w.min = Integer.MAX_VALUE;		
+			if (w == v) {	
+				return;		
+			}
+			w.isStronglyConnected = true; 
+			for (;;) {
+				w = stack.pop();
+				w.isStronglyConnected = true; 
+				w.min = Integer.MAX_VALUE;
+				if (w == v) {	
+					return;		
+				}
+			}	
+		}
+	}
+	
+	
 	enum InteractionFlowHandler {
 		NONE,
 		FORWARD {
 			@Override
 			public <A,N> void handleFlowIn(FlowAnalysis<N,A> a, N s) {
-				A inFlow = a.getInFlow(s);
-				FlowInfo<A, N> fi = a.newFlowInfo(s, inFlow, a.filterUnitToBeforeFlow, true);
-				handleStop(s).handleBeforeAnalysisEvent(fi);	
+				beforeEvent(stop(s), a, s);
 			}
 			
 			@Override
 			public <A,N> void handleFlowOut(FlowAnalysis<N,A> a, N s) {
-				A outFlow = a.getOutFlow(s);
-				FlowInfo<A, N> fi = a.newFlowInfo(s, outFlow, a.filterUnitToAfterFlow, false);
-				InteractionHandler.v().handleAfterAnalysisEvent(fi);				
+				afterEvent(InteractionHandler.v(), a, s);
 			}
 		},
 		BACKWARD {
 			@Override
 			public <A,N> void handleFlowIn(FlowAnalysis<N,A> a, N s) {
-				A inFlow = a.getInFlow(s);
-				FlowInfo<A, N> fi = a.newFlowInfo(s, inFlow, a.filterUnitToAfterFlow, false);
-				handleStop(s).handleAfterAnalysisEvent(fi);
+				afterEvent(stop(s), a, s);
 			}
 			
 			@Override
 			public <A,N> void handleFlowOut(FlowAnalysis<N,A> a, N s) {
-				A outFlow = a.getOutFlow(s);
-				FlowInfo<A, N> fi = a.newFlowInfo(s, outFlow, a.filterUnitToBeforeFlow, true);			
-				InteractionHandler.v().handleBeforeAnalysisEvent(fi);
+				beforeEvent(InteractionHandler.v(), a, s);
 			}
 		};
-
-		InteractionHandler handleStop(Object s) {
+		
+		<A,N> void beforeEvent(InteractionHandler i, FlowAnalysis<N,A> a, N s) {
+			A savedFlow = a.filterUnitToBeforeFlow.get(s);
+			if (savedFlow == null)
+				savedFlow = a.newInitialFlow();
+			a.copy(a.unitToBeforeFlow.get(s), savedFlow);
+			i.handleBeforeAnalysisEvent(new FlowInfo<A, N>(savedFlow, s, true));
+		}	
+		
+		<A,N> void afterEvent(InteractionHandler i, FlowAnalysis<N,A> a, N s) {
+			A savedFlow = a.filterUnitToAfterFlow.get(s);
+			if (savedFlow == null)
+				savedFlow = a.newInitialFlow();
+			a.copy(a.unitToAfterFlow.get(s), savedFlow);
+			i.handleAfterAnalysisEvent(new FlowInfo<A, N>(savedFlow, s, false));
+		}
+	
+		InteractionHandler stop(Object s) {
 			InteractionHandler h = InteractionHandler.v();
 			List<?> stopList = h.getStopUnitList();
 			if (stopList != null && stopList.contains(s)) {
@@ -103,24 +268,9 @@ public abstract class FlowAnalysis<N,A> extends AbstractFlowAnalysis<N,A>
 			}
 
 			@Override
-			<N> List<N> getExits(DirectedGraph<N> g) {
-				return g.getHeads();
-			}
-
-			@Override
-			<N> List<N> getIn(DirectedGraph<N> g, N s) {
-				return g.getSuccsOf(s);
-			}
-
-			@Override
 			<N> List<N> getOut(DirectedGraph<N> g, N s) {
 				return g.getPredsOf(s);
 			}
-
-			@Override
-			<N> List<N> newList(DirectedGraph<N> g, Orderer<N> o) {
-				return o.newList(g, false);
-			}		
 		},
 		FORWARD {
 			@Override
@@ -129,56 +279,27 @@ public abstract class FlowAnalysis<N,A> extends AbstractFlowAnalysis<N,A>
 			}
 
 			@Override
-			<N> List<N> getExits(DirectedGraph<N> g) {
-				return g.getTails();
-			}
-
-			@Override
-			<N> List<N> getIn(DirectedGraph<N> g, N s) {
-				return g.getPredsOf(s);
-			}
-
-			@Override
 			<N> List<N> getOut(DirectedGraph<N> g, N s) {
 				return g.getSuccsOf(s);
 			}
-
-			@Override
-			<N> List<N> newList(DirectedGraph<N> g, Orderer<N> o) {
-				return o.newList(g, true);
-			}		
 		};
 
 		abstract <N> List<N> getEntries(DirectedGraph<N> g);
-		abstract <N> List<N> getExits(DirectedGraph<N> g);
-		
-		abstract <N> List<N> getIn(DirectedGraph<N> g, N s);
 		abstract <N> List<N> getOut(DirectedGraph<N> g, N s);
-
-		abstract <N> List<N> newList(DirectedGraph<N> g, Orderer<N> o);
-	}
-	
-	final GraphView graphView;
-	
-    final InteractionFlowHandler interactiveFlow;
-    
-    int numComputations = 0;
+	}		    
     
     /** Maps graph nodes to OUT sets. */
     protected Map<N, A> unitToAfterFlow;
 
     /** Filtered: Maps graph nodes to OUT sets. */
-    protected Map<N, A> filterUnitToAfterFlow;
+    protected Map<N, A> filterUnitToAfterFlow = Collections.emptyMap();
 
     /** Constructs a flow analysis on the given <code>DirectedGraph</code>. */
-    public FlowAnalysis(DirectedGraph<N> graph, GraphView graphView, InteractionFlowHandler interactionFlowHandler)
+    public FlowAnalysis(DirectedGraph<N> graph)
     {
         super(graph);
-    	assert graphView != null;
-    	assert interactionFlowHandler != null;
-        this.graphView = graphView;
-        this.interactiveFlow = Options.v().interactive_mode() ? interactionFlowHandler : InteractionFlowHandler.NONE;
-        this.unitToAfterFlow = new IdentityHashMap<N, A>(graph.size() * 2 + 1);
+        
+        unitToAfterFlow = new IdentityHashMap<N, A>(graph.size() * 2 + 1);
     }
     
     /** 
@@ -192,112 +313,140 @@ public abstract class FlowAnalysis<N,A> extends AbstractFlowAnalysis<N,A>
      * backward analysis), and the third parameter is always the result
      * of the flow function (i.e. it is the "out" set in a forward
      * analysis and the "in" set in a backward analysis).
-     * */
+     *
+     * @param in the input flow
+     * @param d the current node
+     * @param out the returned flow
+     **/
     protected abstract void flowThrough(A in, N d, A out);
 
     /** Accessor function returning value of OUT set for s. */
+    
     public A getFlowAfter(N s)
     {
-        return unitToAfterFlow.get(s);
+        A a = unitToAfterFlow.get(s);
+        return a == null ? newInitialFlow() : a;
     }
     
+    @Override
+    public A getFlowBefore(N s)
+    {
+        A a = unitToBeforeFlow.get(s);
+        return a == null ? newInitialFlow() : a;
+    }
+		
+	private void initFlow(Iterable<Entry<N,A>> universe, Map<N, A> in, Map<N, A> out) {	
+    	assert universe != null;	
+    	assert in != null;
+    	assert out != null;	
+		
+		for (Entry<N, A> n : universe) {
+			boolean omitable = omissible(n.data);
+			if (n.in.length > 1) {
+				// make sure no loop-entry will omitted
+				if (omitable && n.isStronglyConnected) {
+					for (Entry<N, A> p : n.in) {
+						// this node has at least one back-edge 
+						if (p.outFlow == null) {
+							omitable = false;
+							break;
+						}
+					}
+				}
+				
+				n.inFlow = newInitialFlow();
+			} else {
+				assert n.in.length == 1 : "missing superhead";
+				n.inFlow = n.in[0].outFlow;	
+				assert n.inFlow != null : "topological order is broken";
+			}
+			
+			if (omitable) {
+				n.outFlow = n.inFlow;		
+			} else {
+				n.outFlow = newInitialFlow();
+			}
+
+			// for legacy api
+			in.put(n.data, n.inFlow);
+			out.put(n.data, n.outFlow);
+		}
+	}
+	
 	/**
-	 * Default implementation constructing a PseudoTopologicalOrderer. 
-	 * @return an Orderer to order the nodes for the fixed-point iteration 
+	 * If a flow node can be omitted return <code>true</code>, otherwise <code>false</code>.
+	 * There is no guarantee an node will be omitted.
+	 * 
+	 * If you are unsure, dont't overwrite this method 
+	 * 
+	 * @param n the node to check
+	 * @return <code>false</code>
 	 */
-	protected Orderer<N> constructOrderer() {
-		return new PseudoTopologicalOrderer<N>();
+	protected boolean omissible(N n) {
+		return false;
 	}
 	
 	
-	protected FlowInfo<A, N> newFlowInfo(N s, A flow, Map<N,A> filterFlow, boolean b) {
-		A savedFlow = null;
-		if (filterFlow != null) 
-			savedFlow = filterFlow.get(s);
-		if (savedFlow == null)
-			savedFlow = newInitialFlow();
-		copy(flow, savedFlow);
-		return new FlowInfo<A, N>(savedFlow, s, b);
-	}	
-	
-
-	abstract A getInFlow(N s);
-	abstract A getOutFlow(N s);
-	
-	@Override
-    protected A entryInitialFlow() {
-    	return null;
-    }
-	
-	@Override
-	protected void doAnalysis() {
-		numComputations = 0;
-				
-		for (N s : graph) {
-			// Set initial Flows
-			unitToBeforeFlow.put(s, newInitialFlow());
-			unitToAfterFlow.put(s, newInitialFlow());
-		}
-				
-		// Feng Qian: March 07, 2002
-		// init entry points
-		final A e = entryInitialFlow();
-		final Collection<N> entries;
-		if (e == null) {
-			entries = Collections.emptySet();
-		} else {
-			entries = new HashSet<N>(graphView.getEntries(graph));
-			for (N s : entries) {	
-				copy(e, getInFlow(s));
-			}
-		}
+	final int doAnalysis(GraphView graphView, InteractionFlowHandler interactiveHandler, Map<N, A> inFlow, Map<N, A> outFlow) {
+    	assert graphView != null;
+    	assert interactiveHandler != null;
+    	
+    	interactiveHandler = Options.v().interactive_mode() 
+    			? interactiveHandler 
+    			: InteractionFlowHandler.NONE
+    			;
+    	
+    	final List<Entry<N,A>> universe = newUniverse(graph, graphView, entryInitialFlow());
 		
-		// int numComputations = 0;
+    	initFlow(universe, inFlow, outFlow);
+    	
+		Queue<Entry<N,A>> q = PriorityQueue.of(universe, true);
 
+	    int numComputations = 0;
 		// Perform fixed point flow analysis
-		for (Queue<N> q = PriorityQueue.of(graphView.newList(graph, constructOrderer()));;) {
-			N s = q.poll();
-			if (s == null)
-				return;
-
-			A inFlow = getInFlow(s);				
+		for (numComputations = 0;;numComputations++) {
+			Entry<N,A> e = q.poll();
+			if (e == null)
+				break;
 			
-			// Compute and store afterFlow
-			boolean isFirst = true;
-			for (N in : graphView.getIn(graph, s)) {
-				if (isFirst) {
-					isFirst = false;
-					copy(getOutFlow(in), inFlow);
-					
-					// optional entry initial flow
-					if (entries.contains(s)) {
-						mergeInto(s, inFlow, e);
-					}
-					continue;
-				}
-
-				mergeInto(s, inFlow, getOutFlow(in));
+			Entry<N,A>[] in = e.in;
+			if (in.length > 1) {
+				copy(in[0].outFlow, e.inFlow);			
+				for (int i = 1; i < in.length; i++) {
+					mergeInto(e.data, e.inFlow, in[i].outFlow);
+				}		
 			}
-							
+			
 			// Compute beforeFlow and store it.
-			interactiveFlow.handleFlowIn(this, s);
-			boolean hasChanged = flow(inFlow, s, getOutFlow(s));
-			interactiveFlow.handleFlowOut(this, s);			
+			interactiveHandler.handleFlowIn(this, e.data);
+			boolean hasChanged = flowThrough(e);
+			interactiveHandler.handleFlowOut(this, e.data);			
 
 			// Update queue appropriately
 			if ( hasChanged ) {
-				q.addAll(graphView.getOut(graph, s));
+				q.addAll(Arrays.asList(e.out));
 			}
-
-			numComputations++;
 		}
+		return numComputations;
 	}
 	
-	protected boolean flow(A in, N d, A out) {
-		A previous = newInitialFlow();
-		copy(out, previous);
-		flowThrough(in, d, out);
-		return !previous.equals(out);
+	private boolean flowThrough(Entry<N,A> d) {
+		if (d.inFlow == d.outFlow)
+			return true;
+		
+		if (d.isStronglyConnected) {
+			A out = newInitialFlow();
+			flowThrough(d.inFlow, d.data, out);
+			if (out.equals(d.outFlow)) {
+				return false;
+			}
+			// copy back the result, as it has changed
+			copy(out, d.outFlow);
+			return true;
+		}			
+		
+		flowThrough(d.inFlow, d.data, d.outFlow);
+		return true;
 	}
 	
 }

--- a/src/soot/toolkits/scalar/FlowSet.java
+++ b/src/soot/toolkits/scalar/FlowSet.java
@@ -137,6 +137,11 @@ public interface FlowSet<T> extends Iterable<T> {
   public boolean contains(T obj);
 
   /**
+   * Returns true if the <code>other</code> FlowSet is a subset of <code>this</code> FlowSet.
+   */
+  public boolean isSubSet(FlowSet<T> other);
+  
+  /**
    * returns an iterator over the elements of the flowSet. Note that the
    * iterator might be backed, and hence be faster in the creation, than doing
    * <code>toList().iterator()</code>.

--- a/src/soot/toolkits/scalar/ForwardFlowAnalysis.java
+++ b/src/soot/toolkits/scalar/ForwardFlowAnalysis.java
@@ -37,7 +37,7 @@ public abstract class ForwardFlowAnalysis<N, A> extends FlowAnalysis<N, A> {
 	 * Construct the analysis from a DirectedGraph representation of a Body.
 	 */
 	public ForwardFlowAnalysis(DirectedGraph<N> graph) {
-		super(graph, GraphView.FORWARD, InteractionFlowHandler.FORWARD);
+		super(graph);
 	}
 
 	@Override
@@ -46,20 +46,10 @@ public abstract class ForwardFlowAnalysis<N, A> extends FlowAnalysis<N, A> {
 	}
 
 	@Override
-	A getInFlow(N s) {
-		return getFlowBefore(s);
-	}
-
-	@Override
-	A getOutFlow(N s) {
-		return getFlowAfter(s);
-	}
-
-	@Override
 	protected void doAnalysis() {
-		super.doAnalysis();
+		int i = doAnalysis(GraphView.FORWARD, InteractionFlowHandler.FORWARD, unitToBeforeFlow, unitToAfterFlow);
 
 		soot.Timers.v().totalFlowNodes += graph.size();
-		soot.Timers.v().totalFlowComputations += numComputations;
+		soot.Timers.v().totalFlowComputations += i;
 	}
 }

--- a/src/soot/toolkits/scalar/LiveLocals.java
+++ b/src/soot/toolkits/scalar/LiveLocals.java
@@ -31,6 +31,8 @@
 package soot.toolkits.scalar;
 
 import soot.*;
+import soot.toolkits.graph.UnitGraph;
+
 import java.util.*;
 
 
@@ -40,7 +42,13 @@ import java.util.*;
  */
 public interface LiveLocals
 {
-    
+	static final public class Factory {
+		private Factory() {}
+		public static LiveLocals newLiveLocals(UnitGraph graph) {
+			return new SimpleLiveLocals(graph);
+		}
+	}
+	
     /**
      *   Returns the list of Locals that are live before the specified
      *   Unit. 

--- a/src/soot/toolkits/scalar/LocalDefs.java
+++ b/src/soot/toolkits/scalar/LocalDefs.java
@@ -38,7 +38,6 @@ import soot.Unit;
 import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.graph.UnitGraph;
 
-
 /**
  *   Provides an interface for querying for the definitions of a Local
  *   at a given Unit in a method.
@@ -52,17 +51,53 @@ public interface LocalDefs
 		 * Creates a new LocalDefs analysis based on a {@code ExceptionalUnitGraph}
 		 * 
 		 * @see soot.toolkits.graph.ExceptionalUnitGraph#ExceptionalUnitGraph(Body)
+		 * @see soot.validation.UsesValidator
 		 * @param body
-		 * @return
+		 * @return a new LocalDefs instance
 		 */
 		public static LocalDefs newLocalDefs(Body body) {
-			return newLocalDefs(new ExceptionalUnitGraph(body));
+			return newLocalDefs(body, false);
 		}
-
+		
+		/**
+		 * Creates a new LocalDefs analysis based on a {@code ExceptionalUnitGraph}
+		 * If you don't trust the input you should set <code>expectUndefined</code>
+		 * to <code>true</code>
+		 * 
+		 * @see soot.toolkits.graph.ExceptionalUnitGraph#ExceptionalUnitGraph(Body)
+		 * @param body
+		 * @param expectUndefinedUses if you expect uses of locals that are undefined
+		 * @return a new LocalDefs instance
+		 */
+		public static LocalDefs newLocalDefs(Body body, boolean expectUndefined) {
+			return newLocalDefs(new ExceptionalUnitGraph(body), expectUndefined);
+		}
+		
+		/**
+		 * Creates a new LocalDefs analysis based on a given {@code UnitGraph}
+		 * 
+		 * @see soot.toolkits.graph.UnitGraph#UnitGraph(Body)
+		 * @param graph the graph to work with
+		 * @return a new LocalDefs instance
+		 */
 		public static LocalDefs newLocalDefs(UnitGraph graph) {
+			return newLocalDefs(graph, false);
+		}
+		
+		/**
+		 * Creates a new LocalDefs analysis based on a given {@code UnitGraph}.
+		 * If you don't trust the input you should set <code>expectUndefined</code>
+		 * to <code>true</code>
+		 * 
+		 * @see soot.toolkits.graph.UnitGraph#UnitGraph(Body)
+		 * @see soot.validation.UsesValidator
+		 * @param graph the graph to work with
+		 * @param expectUndefined if you expect uses of locals that are undefined
+		 * @return a new LocalDefs instance
+		 */
+		public static LocalDefs newLocalDefs(UnitGraph graph, boolean expectUndefined) {
 			//return new SmartLocalDefs(graph, LiveLocals.Factory.newLiveLocals(graph)); 
-			//return new SimpleLocalDefs(graph, true); // run in panic mode
-			return new SimpleLocalDefs(graph);
+			return new SimpleLocalDefs(graph, expectUndefined);
 		}
 	}
 	
@@ -70,11 +105,13 @@ public interface LocalDefs
      *   Returns the definition sites for a Local at a certain
      *   point (Unit) in a method. 
      *
+     *	 You can assume this method never returns {@code null}.
+     *
      *   @param l the Local in question.
      *   @param s  a unit that specifies the method context (location) 
      *             to query for the definitions of the Local. 
      *   @return a list of Units where the local is defined in the current
-     *            method context.         
+     *            method context. If there are no uses an empty list will returned.
      */
     public List<Unit> getDefsOfAt(Local l, Unit s);
     

--- a/src/soot/toolkits/scalar/LocalDefs.java
+++ b/src/soot/toolkits/scalar/LocalDefs.java
@@ -30,10 +30,13 @@
 
 package soot.toolkits.scalar;
 
-import soot.*;
-import java.util.*;
+import java.util.List;
 
-
+import soot.Body;
+import soot.Local;
+import soot.Unit;
+import soot.toolkits.graph.ExceptionalUnitGraph;
+import soot.toolkits.graph.UnitGraph;
 
 
 /**
@@ -42,6 +45,27 @@ import java.util.*;
  */
 public interface LocalDefs
 {
+	static final public class Factory {
+		private Factory() {}
+		
+		/**
+		 * Creates a new LocalDefs analysis based on a {@code ExceptionalUnitGraph}
+		 * 
+		 * @see soot.toolkits.graph.ExceptionalUnitGraph#ExceptionalUnitGraph(Body)
+		 * @param body
+		 * @return
+		 */
+		public static LocalDefs newLocalDefs(Body body) {
+			return newLocalDefs(new ExceptionalUnitGraph(body));
+		}
+
+		public static LocalDefs newLocalDefs(UnitGraph graph) {
+			//return new SmartLocalDefs(graph, LiveLocals.Factory.newLiveLocals(graph)); 
+			//return new SimpleLocalDefs(graph, true); // run in panic mode
+			return new SimpleLocalDefs(graph);
+		}
+	}
+	
     /**
      *   Returns the definition sites for a Local at a certain
      *   point (Unit) in a method. 
@@ -53,5 +77,5 @@ public interface LocalDefs
      *            method context.         
      */
     public List<Unit> getDefsOfAt(Local l, Unit s);
-
+    
 }

--- a/src/soot/toolkits/scalar/LocalSplitter.java
+++ b/src/soot/toolkits/scalar/LocalSplitter.java
@@ -29,11 +29,8 @@
 
 package soot.toolkits.scalar;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,12 +47,12 @@ import soot.ValueBox;
 import soot.options.Options;
 import soot.toolkits.exceptions.ThrowAnalysis;
 import soot.toolkits.graph.ExceptionalUnitGraph;
-import soot.util.Chain;
 
 /**
  *    A BodyTransformer that attemps to indentify and separate uses of a local
- *    varible that are independent of each other. Conceptually the inverse transform
- *    with respect to the LocalPacker transform.
+ *    variable that are independent of each other. Conceptually the inverse transform
+ *    with respect to the LocalPacker transform. 
+ *    
  *
  *    For example the code:
  *
@@ -67,6 +64,7 @@ import soot.util.Chain;
  *    for(int j; j < k; j++);
  *
  *
+ *
  *    @see BodyTransformer
  *    @see LocalPacker
  *    @see Body 
@@ -74,144 +72,120 @@ import soot.util.Chain;
 public class LocalSplitter extends BodyTransformer
 {
 	
-	protected ThrowAnalysis throwAnalysis = null;
-	protected boolean forceOmitExceptingUnitEdges = false;
+	protected ThrowAnalysis throwAnalysis;
+	protected boolean omitExceptingUnitEdges;
 
 	public LocalSplitter( Singletons.Global g ) {
 	}
 	
 	public LocalSplitter( ThrowAnalysis ta ) {
-		this.throwAnalysis = ta;
+		this(ta, false);
 	}
 
-	public LocalSplitter( ThrowAnalysis ta, boolean forceOmitExceptingUnitEdges ) {
+	public LocalSplitter( ThrowAnalysis ta, boolean omitExceptingUnitEdges ) {
 		this.throwAnalysis = ta;
-		this.forceOmitExceptingUnitEdges = forceOmitExceptingUnitEdges;
+		this.omitExceptingUnitEdges = omitExceptingUnitEdges;
 	}
 	
 	public static LocalSplitter v() { return G.v().soot_toolkits_scalar_LocalSplitter(); }
     
 	@Override
     protected void internalTransform(Body body, String phaseName, Map<String, String> options)
-    {
-		if (this.throwAnalysis == null)
-			this.throwAnalysis = Scene.v().getDefaultThrowAnalysis();
-		
-        Chain<Unit> units = body.getUnits();
-        List<List<ValueBox>> webs = new ArrayList<List<ValueBox>>();
-
+    {		
         if(Options.v().verbose())
             G.v().out.println("[" + body.getMethod().getName() + "] Splitting locals...");
+        
+		if (Options.v().time()) 
+			Timers.v().splitTimer.start();
+		
 
         if(Options.v().time())
                 Timers.v().splitPhase1Timer.start();
 
+        if (throwAnalysis == null)
+        	throwAnalysis = Scene.v().getDefaultThrowAnalysis();
+        
+        if (omitExceptingUnitEdges == false)
+        	omitExceptingUnitEdges = Options.v().omit_excepting_unit_edges();
+                
         // Go through the definitions, building the webs
-        {
-            ExceptionalUnitGraph graph = new ExceptionalUnitGraph(body,this.throwAnalysis,
-            		forceOmitExceptingUnitEdges || Options.v().omit_excepting_unit_edges());
+    	ExceptionalUnitGraph graph = new ExceptionalUnitGraph(body, throwAnalysis, omitExceptingUnitEdges);
+ 	
+    	// run in panic mode on first split (maybe change this depending on the input source)
+		final LocalDefs defs = LocalDefs.Factory.newLocalDefs(graph, true);
+		final LocalUses uses = LocalUses.Factory.newLocalUses(graph, defs);
+		
+        if(Options.v().time())
+            Timers.v().splitPhase1Timer.end();
+        if(Options.v().time())
+            Timers.v().splitPhase2Timer.start();
 
-            final LocalDefs localDefs = new SmartLocalDefs(graph,
-    				new SimpleLiveLocals(graph));
-    		final LocalUses localUses = new SimpleLocalUses(graph, localDefs);
-    		
-            if(Options.v().time())
-                Timers.v().splitPhase1Timer.end();
-            if(Options.v().time())
-                Timers.v().splitPhase2Timer.start();
 
-            Set<ValueBox> markedBoxes = new HashSet<ValueBox>();
-            Map<ValueBox, Unit> boxToUnit = new HashMap<ValueBox, Unit>(units.size() * 2 + 1, 0.7f);
+		Set<Unit> visited = new HashSet<Unit>();
+        
+		int w = 0;
+        for (Unit s : body.getUnits()) {
+            if (s.getDefBoxes().isEmpty())
+                continue;
             
-            for (Unit s : units) {
-                if (s.getDefBoxes().size() > 1)
-                    throw new RuntimeException("stmt with more than 1 defbox!");
-                if (s.getDefBoxes().size() < 1)
-                    continue;
-                
-                ValueBox loBox = s.getDefBoxes().get(0);
-                Value lo = loBox.getValue();
-                
-                if(lo instanceof Local && !markedBoxes.contains(loBox))
-                {
-                    Deque<Unit> defsToVisit = new ArrayDeque<Unit>();
-                    Deque<ValueBox> boxesToVisit = new ArrayDeque<ValueBox>();
+            if (s.getDefBoxes().size() > 1)
+                throw new RuntimeException("stmt with more than 1 defbox!");
+            
+            if (!(s.getDefBoxes().get(0).getValue() instanceof Local))
+            	continue;
+            
+            // we don't want to visit a node twice
+            if (visited.remove(s))
+            	continue;
 
-                    List<ValueBox> web = new ArrayList<ValueBox>();
-                    webs.add(web);
-                    
-                    defsToVisit.add(s);
-                    markedBoxes.add(loBox);
-                    
-                    while(!boxesToVisit.isEmpty() || !defsToVisit.isEmpty())
-                    {
-                        if(!defsToVisit.isEmpty())
-                        {
-                            Unit d = defsToVisit.poll();
-                            web.add(d.getDefBoxes().get(0));
-                            
-                            // Add all the uses of this definition to the queue
-                            for (UnitValueBoxPair use : localUses.getUsesOf(d)) {
-                            	if(!markedBoxes.contains(use.valueBox)) {
-                            		markedBoxes.add(use.valueBox);
-                            		boxesToVisit.add(use.valueBox);
-                            		boxToUnit.put(use.valueBox, use.unit);
-                            	}
-                            }
-                        }
-                        else {
-                            ValueBox box = boxesToVisit.poll();
-                            web.add(box);
-
-                            // Add all the definitions of this use to the queue.
-                            List<Unit> defs = localDefs.getDefsOfAt((Local) box.getValue(),
-                            		boxToUnit.get(box));
-                            for (Unit u : defs) {
-                            	for (ValueBox b : u.getDefBoxes()) {
-                            		if(!markedBoxes.contains(b)) {
-                            			markedBoxes.add(b);
-                            			defsToVisit.add(u);
-                            		}
-                            	}
-                            }
-                        }
-                    }
-                }
-            }
+            
+            // always reassign locals to avoid "use before definition" bugs!
+            // unfortunately this creates a lot of new locals, so it's important
+            // to remove them afterwards
+            Local oldLocal = (Local) s.getDefBoxes().get(0).getValue();  
+            Local newLocal = (Local) oldLocal.clone();
+            
+            newLocal.setName(newLocal.getName()+'#'+ ++w); // renaming should not be done here
+    		body.getLocals().add(newLocal);
+            
+    		Deque<Unit> queue = new ArrayDeque<Unit>();
+    		queue.addFirst(s);
+    		do {
+    			final Unit head = queue.removeFirst();
+    			if (visited.add(head)) {
+        			for (UnitValueBoxPair use : uses.getUsesOf(head)) {        				
+        				ValueBox vb = use.valueBox;
+        				Value v = vb.getValue();
+        				
+        				if (v == newLocal)
+        					continue;
+        				
+        				// should always be true - but who knows ...
+        				if (v instanceof Local) {
+        					Local l = (Local) v;        		
+        					queue.addAll(defs.getDefsOfAt(l, use.unit));        					
+	        				vb.setValue(newLocal);
+        				}    				
+        			}
+        			
+    				for (ValueBox vb : head.getDefBoxes()) {
+    					Value v = vb.getValue();
+    					if (v instanceof Local) {        						
+    						vb.setValue(newLocal);
+    					}
+    				}
+    			}
+    		}
+    		while (!queue.isEmpty());
+    		
+    		// keep the set small
+    		visited.remove(s);
         }
-        
-        // Assign locals appropriately.
-        {
-            Map<Local, Integer> localToUseCount = new HashMap<Local, Integer>(body.getLocalCount() * 2 + 1, 0.7f);
 
-            for (List<ValueBox> web : webs) {
-                ValueBox rep = web.get(0);
-                Local desiredLocal = (Local) rep.getValue();
-
-                if(!localToUseCount.containsKey(desiredLocal))
-                {
-                    // claim this local for this set
-                    localToUseCount.put(desiredLocal, new Integer(1));
-                }
-                else {
-                    // generate a new local
-                    int useCount = localToUseCount.get(desiredLocal).intValue() + 1;
-                    localToUseCount.put(desiredLocal, new Integer(useCount));
-        
-                    Local local = (Local) desiredLocal.clone();
-                    local.setName(desiredLocal.getName() + "#" + useCount);
-                    
-                    body.getLocals().add(local);
-
-                    // Change all boxes to point to this new local
-                    for (ValueBox box : web) {
-                    	box.setValue(local);
-                    }
-                }
-            }
-        }
-        
         if(Options.v().time())
             Timers.v().splitPhase2Timer.end();
-    }   
+        
+		if (Options.v().time()) 
+			Timers.v().splitTimer.end();
+    }
 }

--- a/src/soot/toolkits/scalar/LocalUses.java
+++ b/src/soot/toolkits/scalar/LocalUses.java
@@ -31,8 +31,11 @@
 package soot.toolkits.scalar;
 
 import soot.*;
+import soot.toolkits.graph.UnitGraph;
+
 import java.util.*;
 
+import static soot.toolkits.scalar.LocalDefs.Factory.newLocalDefs;
 
 /**
  *   Provides an interface to find the Units that use
@@ -40,6 +43,26 @@ import java.util.*;
  */
 public interface LocalUses
 {
+	static final public class Factory {
+		private Factory() {}
+
+		public static LocalUses newLocalUses(Body body) {
+			return newLocalUses(body, newLocalDefs(body));
+		}
+		
+		public static LocalUses newLocalUses(Body body, LocalDefs localDefs) {
+			return new SimpleLocalUses(body, localDefs);
+		}
+		
+		public static LocalUses newLocalUses(UnitGraph graph) {
+			return newLocalUses(graph.getBody(), newLocalDefs(graph));
+		}
+		
+		public static LocalUses newLocalUses(UnitGraph graph, LocalDefs localDefs) {
+			return newLocalUses(graph.getBody(), localDefs);
+		}
+	}
+	
     /**
      *   Returns a list of the Units that use the Local that is 
      *   defined by a given Unit. 

--- a/src/soot/toolkits/scalar/SimpleLocalDefs.java
+++ b/src/soot/toolkits/scalar/SimpleLocalDefs.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.WeakHashMap;
 
 import soot.Local;
 import soot.Timers;
@@ -43,164 +42,149 @@ import static java.util.Collections.unmodifiableList;
  * Analysis that provides an implementation of the LocalDefs interface.
  */
 public class SimpleLocalDefs implements LocalDefs {
-	static class Entry {
-		final List<Unit> units;
-		final Local local;
-		
-		Entry(List<Unit> units, Local local) {
-			this.units = units;
-			this.local = local;
-		}
-	}
-	
-	static class FlowBitSet<T> extends BitSet {
-		private static final long serialVersionUID = -8348696077189400377L;
-		
-		final private T[] universe;
-		
-		FlowBitSet (T[] universe) {
-			super(universe.length);
-			this.universe = universe;
-		}
-	    
-	    List<T> asList(int fromIndex, int toIndex) {
-	    	BitSet bits = this;
-	    	if (fromIndex < 0 || toIndex > universe.length || toIndex < fromIndex)
-	    		throw new IndexOutOfBoundsException();
-
-	    	if (fromIndex == toIndex || fromIndex == toIndex - 1) {
-	    		if (bits.get(fromIndex)) {
-	    			return singletonList(universe[fromIndex]);
-	    		}
-	    		return emptyList();
-	    	}
-	    	
-	    	int i = bits.nextSetBit(fromIndex);
-	    	if (i < 0 || i >= toIndex)
-	    		return emptyList();
-	    	
-	    	if (i == toIndex - 1) 
-	    		return singletonList(universe[i]);
-	    	
-	        List<T> elements = new ArrayList<T>(toIndex-i);
-	                		
-			for (;;) {
-				int endOfRun = Math.min(toIndex, bits.nextClearBit(i+1));
-				do { elements.add(universe[i++]); }
-				while (i < endOfRun);
-				if (i >= toIndex)
-					break;
-				i = bits.nextSetBit(i+1);
-				if (i < 0 || i >= toIndex)
-					break;
-			}
-			return elements;
-	    }
-	}	
-	
-	abstract static class Assignment implements LocalDefs {		
-		final Map<ValueBox, Entry> resultValueBoxes;
-	
-		Assignment(int size) {
-			// never keep values longer than required
-			resultValueBoxes = new WeakHashMap<ValueBox, Entry>((size * 7)/2 + 3);
+	static private class StaticSingleAssignment implements LocalDefs {
+		final Map<Local, Integer> locals;
+		final List<Unit>[] units;
+		StaticSingleAssignment(Map<Local,Integer> internalLocal, List<Unit>[] unitList) {
+			assert internalLocal.size() <= unitList.length;
+			
+			// do not recreate the mapping
+			locals = internalLocal;
+			units = unitList;
 		}
 
 		@Override
 		public List<Unit> getDefsOfAt(Local l, Unit s) {
-			for (ValueBox useBox : s.getUseBoxes()) {
-				if (l == useBox.getValue()) {
-					Entry e = resultValueBoxes.get(useBox);
-					// check if local was exchanged!
-					if (e != null && l == e.local) {
-						return unmodifiableList(e.units);
-					}
-				}
-			}
-			return emptyList();
-		}
-		
-		public List<Unit> getDefsOf(ValueBox valueBox) {
-			Entry e = resultValueBoxes.get(valueBox);
-			if (e == null) 
+			Integer lno = locals.get(l);
+			if (lno == null)
 				return emptyList();
 			
-			return unmodifiableList(e.units);
+			return unmodifiableList(units[lno]);
+		}
+	}
+
+	static private class FlowAssignment extends ForwardFlowAnalysis<Unit, FlowAssignment.FlowBitSet> implements LocalDefs {
+		class FlowBitSet extends BitSet {
+			private static final long serialVersionUID = -8348696077189400377L;
+			
+			FlowBitSet () {
+				super(universe.length);
+			}
+		    
+		    List<Unit> asList(int fromIndex, int toIndex) {
+		    	BitSet bits = this;
+		    	if (fromIndex < 0 || toIndex > universe.length || toIndex < fromIndex)
+		    		throw new IndexOutOfBoundsException();
+
+		    	if (fromIndex == toIndex) {
+		    		return emptyList();
+		    	}
+		    	
+		    	if (fromIndex == toIndex - 1) {
+		    		if (bits.get(fromIndex)) {
+		    			return singletonList(universe[fromIndex]);
+		    		}
+		    		return emptyList();
+		    	}
+		    	
+		    	int i = bits.nextSetBit(fromIndex);
+		    	if (i < 0 || i >= toIndex)
+		    		return emptyList();
+		    	
+		    	if (i == toIndex - 1) 
+		    		return singletonList(universe[i]);
+		    	
+		        List<Unit> elements = new ArrayList<Unit>(toIndex-i);
+		                		
+				for (;;) {
+					int endOfRun = Math.min(toIndex, bits.nextClearBit(i+1));
+					do { elements.add(universe[i++]); }
+					while (i < endOfRun);
+					if (i >= toIndex)
+						break;
+					i = bits.nextSetBit(i+1);
+					if (i < 0 || i >= toIndex)
+						break;
+				}
+				return elements;
+		    }
+		}	
+		
+		final Map<Local, Integer> locals;
+		final List<Unit>[] unitList;
+		final int[] localRange;
+		final Unit[] universe;
+		
+		private Map<Unit, Integer> indexOfUnit;
+		FlowAssignment(DirectedGraph<Unit> graph, int locals, Map<Local,Integer> internalLocal, List<Unit>[] unitList, int units, boolean omitSSA) {
+			super(graph);
+			this.locals = internalLocal;
+			this.unitList = unitList;
+			
+			universe = new Unit[units];
+			indexOfUnit = new HashMap<Unit, Integer>((units*2)/3+7);
+			
+			localRange = new int[locals + 1];		
+			localRange[0] = 0;			
+			for (int j = 0, i = 0; i < locals; i++) {
+				if (unitList[i].size() >= 2 || omitSSA) {
+					for (Unit u : unitList[i]) {
+						indexOfUnit.put(universe[j] = u, j);
+						j++;
+					}
+				}
+				localRange[i + 1] = j;
+			}
+			assert localRange[locals] == units;
+			
+			doAnalysis();
+			
+			indexOfUnit.clear();
+			indexOfUnit = null;
 		}
 		
-		void putResult(ValueBox useBox, Local local, List<Unit> list) {
-			if (list.isEmpty())
-				return;			
-			// one of the most expensive steps :|
-			resultValueBoxes.put(useBox, new Entry(list, local));
-		}
-	}
-	
-	class StaticSingleAssignment extends Assignment {
-		StaticSingleAssignment(List<Unit>[] unitList) {	
-			// most of the units are like "a := b + c", 
-			// or a invoke like "a := b.foo()"
-			super(g.size());
-			assert localRange[N] == 0;
-			
-			for (Unit s : g) {
-				for (ValueBox useBox : s.getUseBoxes()) {
-					Value v = useBox.getValue();
-					if (v instanceof Local) {
-						Local l = (Local) v;
-						int lno = l.getNumber();
-
-						putResult(useBox, l, unitList[lno]);
-					}
-				}
-			}
-		}
-	}
-
-	class FlowAssignment extends Assignment {				
-		FlowAssignment(List<Unit>[] unitList) {
-			// most of the units are like "a := b + c", 
-			// or a invoke like "a := b.foo()"
-			super(g.size());
-
-			LocalDefsAnalysis defs = new LocalDefsAnalysis();
-
-			for (Unit s : g) {
-				for (ValueBox useBox : s.getUseBoxes()) {
-					Value v = useBox.getValue();
-					if (v instanceof Local) {
-						Local l = (Local) v;
-						int lno = l.getNumber();
-
-						int from = localRange[lno];
-						int to = localRange[lno + 1];
-						assert from <= to;
-						
-						if (from == to) {
-							putResult(useBox, l, unitList[lno]);
-						} else {							
-							putResult(useBox, l, defs.getFlowBefore(s).asList(from, to));
-						}				
-					}
-				}
-			}
-		}
-	}
-
-	private class LocalDefsAnalysis extends ForwardFlowAnalysis<Unit, FlowBitSet<Unit>> {
-		private LocalDefsAnalysis() {
-			super(g);
-			doAnalysis();
-		}
-				
 		@Override
-		protected void flowThrough(FlowBitSet<Unit> in, Unit unit, FlowBitSet<Unit> out) {
-			out.or(in);
+		public List<Unit> getDefsOfAt(Local l, Unit s) {
+			Integer lno = locals.get(l);
+			if (lno == null)
+				return emptyList();
 			
-			Integer idx = indexOfUnit.get(unit);
-			if (idx == null) 
+			int from = localRange[lno];
+			int to = localRange[lno + 1];
+			assert from <= to;
+			
+			if (from == to) {
+				assert unitList[lno] != null;
+				return unmodifiableList(unitList[lno]);
+			}
+			
+			return getFlowBefore(s).asList(from, to);
+		}
+
+		@Override
+		protected boolean omissible(Unit u) {
+			// avoids temporary creation of iterators (more like micro-tuning)
+			if (u.getDefBoxes().isEmpty())
+				return true;
+			for (ValueBox vb : u.getDefBoxes()) {
+				Value v = vb.getValue();
+				if (v instanceof Local) {
+					Local l = (Local) v;
+					int lno = l.getNumber();					
+					return (localRange[lno] == localRange[lno + 1]);
+				}
+			}			
+			return true;
+		}
+		
+		@Override
+		protected void flowThrough(FlowBitSet in, Unit unit, FlowBitSet out) {
+			copy(in, out);
+			
+			Integer i = indexOfUnit.get(unit);
+			if (i == null)
 				return;
-			
+				
 			if (!in.isEmpty()) {	
 				// reassign all definitions
 				for (ValueBox vb : unit.getDefBoxes()) {
@@ -219,43 +203,37 @@ public class SimpleLocalDefs implements LocalDefs {
 					}
 				}	
 			}
-			out.set(idx);
+			out.set(i);
 		}
 
 		@Override
-		protected void mergeInto(Unit succNode, FlowBitSet<Unit> inout, FlowBitSet<Unit> in) {
+		protected void mergeInto(Unit succNode, FlowBitSet inout, FlowBitSet in) {
 			inout.or(in);
 		}
 
 		@Override
-		protected void copy(FlowBitSet<Unit> source, FlowBitSet<Unit> dest) {
+		protected void copy(FlowBitSet source, FlowBitSet dest) {
+			if (dest == source)
+				return;
 			dest.clear();
 			dest.or(source);
 		}
 
 		@Override
-		protected FlowBitSet<Unit> newInitialFlow() {
-			return new FlowBitSet<Unit>(universe);
+		protected FlowBitSet newInitialFlow() {
+			return new FlowBitSet();
 		}
 
 		@Override
-		protected void merge(FlowBitSet<Unit> in1, FlowBitSet<Unit> in2, FlowBitSet<Unit> out) {
+		protected void merge(FlowBitSet in1, FlowBitSet in2, FlowBitSet out) {
 			throw new UnsupportedOperationException("should never be called");
 		}
 	}
-
-	final private DirectedGraph<Unit> g;
-	final int N;
-
-	private int[] localRange;
-
-	private Unit[] universe;
-	private Map<Unit, Integer> indexOfUnit;
-
-	private Assignment assignment;
+	
+	private LocalDefs def;
 
 	public SimpleLocalDefs(UnitGraph graph) {
-		this(graph, false);
+		this(graph, false); 
 	}
 	
 	public SimpleLocalDefs(UnitGraph graph, boolean omitSSA) {
@@ -270,8 +248,7 @@ public class SimpleLocalDefs implements LocalDefs {
 		if (Options.v().time())
 			Timers.v().defsTimer.start();
 
-		this.g = graph;
-		this.N = locals.length;
+		final int N = locals.length;
 		
 		// reassign local numbers
 		int[] oldNumbers = new int[N];
@@ -280,79 +257,69 @@ public class SimpleLocalDefs implements LocalDefs {
 			locals[i].setNumber(i);
 		}
 
-		init(omitSSA);
+		init(graph, locals, omitSSA);
 
 		// restore local numbering
 		for (int i = 0; i < N; i++) {
 			locals[i].setNumber(oldNumbers[i]);
 		}
-		
-		// GC help
-		localRange = null;
-		
-		indexOfUnit.clear();
-		indexOfUnit = null;
-		
-		Arrays.fill(universe, null);
-		universe = null;
-		
+				
 		if (Options.v().time())
 			Timers.v().defsTimer.end();
 	}
 
-	private void init(boolean omitSSA) {
-		indexOfUnit = new HashMap<Unit, Integer>(g.size());
-		universe = new Unit[g.size()];
-		localRange = new int[N + 1];
+	private void init(DirectedGraph<Unit> graph, Local[] locals, boolean omitSSA) {
+		int N = locals.length;
+		Map<Local,Integer> internalLocal = new HashMap<Local, Integer>((N*3)/2+7);		
 		
 		@SuppressWarnings("unchecked")
 		List<Unit>[] unitList = (List<Unit>[]) new List[N];
 
-		for (int i = 0; i < N; i++) {
-			unitList[i] = new ArrayList<Unit>();
-		}
-
+		Arrays.fill(unitList, emptyList());
+		
 		boolean doFlowAnalsis = omitSSA;
 				
-		// collect all live def points
-		for (Unit unit : g) {
+		int units = 0;
+		
+		// collect all def points
+		for (Unit unit : graph) {
 			for (ValueBox box : unit.getDefBoxes()) {
 				Value v = box.getValue();
 				if (v instanceof Local) {
 					Local l = (Local) v;
 					int lno = l.getNumber();
-
-					doFlowAnalsis |= !unitList[lno].isEmpty();
-					unitList[lno].add(unit);
+					
+					switch (unitList[lno].size()) {
+					case 0:
+						unitList[lno] = singletonList(unit);
+						internalLocal.put(l, lno);
+						if (omitSSA)
+							units++;
+						break;
+					case 1:
+						if (!omitSSA)
+							units++;
+						unitList[lno] = new ArrayList<Unit>(unitList[lno]);
+						doFlowAnalsis = true;
+						// fallthrough
+					default:
+						unitList[lno].add(unit);
+						units++;
+						break;
+					}					
 				}
 			}
 		}
 		
 		if (doFlowAnalsis) {
-			localRange[0] = 0;
-			for (int j = 0, i = 0; i < N; i++) {
-				if (unitList[i].size() >= 2 || omitSSA) {
-					for (Unit u : unitList[i]) {
-						indexOfUnit.put(universe[j] = u, j);
-						j++;
-					}
-				}
-				localRange[i + 1] = j;
-			}
-			assignment = new FlowAssignment(unitList);
+			def = new FlowAssignment(graph, N, internalLocal, unitList, units, omitSSA);
 		} else {
-			Arrays.fill(localRange, 0);
-			assignment = new StaticSingleAssignment(unitList);
+			def = new StaticSingleAssignment(internalLocal, unitList);
 		}		
 	}
 
 	@Override
 	public List<Unit> getDefsOfAt(Local l, Unit s) {
-		return assignment.getDefsOfAt(l, s);
-	}
-	
-	
-	public Collection<Unit> getDefsOf(ValueBox valueBox) {
-		return assignment.getDefsOf(valueBox);
+		return def.getDefsOfAt(l, s);
 	}
 }

--- a/src/soot/toolkits/scalar/SimpleLocalDefs.java
+++ b/src/soot/toolkits/scalar/SimpleLocalDefs.java
@@ -232,6 +232,10 @@ public class SimpleLocalDefs implements LocalDefs {
 	
 	private LocalDefs def;
 
+	/**
+	 * 
+	 * @param graph
+	 */
 	public SimpleLocalDefs(UnitGraph graph) {
 		this(graph, false); 
 	}

--- a/src/soot/toolkits/scalar/UnusedLocalEliminator.java
+++ b/src/soot/toolkits/scalar/UnusedLocalEliminator.java
@@ -26,7 +26,6 @@
 package soot.toolkits.scalar;
 
 import soot.options.*;
-
 import soot.*;
 
 import java.util.*;
@@ -62,33 +61,36 @@ public class UnusedLocalEliminator extends BodyTransformer {
 			i++;
 		}
 		
-		BitSet usedLocals = new BitSet(n);
+		boolean[] usedLocals = new boolean[n];
 
 		// Traverse statements noting all the uses and defs
 		for (Unit s : body.getUnits()) {
-			for (ValueBox vb : s.getDefBoxes()) {
-				Value v = vb.getValue();
-				if (v instanceof Local) {
-					Local l = (Local) v;
-					usedLocals.set(l.getNumber());
-				}
-			}
 			for (ValueBox vb : s.getUseBoxes()) {
 				Value v = vb.getValue();
 				if (v instanceof Local) {
 					Local l = (Local) v;
-					usedLocals.set(l.getNumber());
+					usedLocals[l.getNumber()] = true;
+				}
+			}
+			for (ValueBox vb : s.getDefBoxes()) {
+				Value v = vb.getValue();
+				if (v instanceof Local) {
+					Local l = (Local) v;
+					usedLocals[l.getNumber()] = true;
 				}
 			}
 		}
 
 		// Remove all locals that are unused.
+		List<Local> keep = new ArrayList<Local>(locals.length);
 		for ( Local local : locals ) {
 			int lno = local.getNumber();
 			local.setNumber(oldNumbers[lno]);
-			if ( !usedLocals.get(lno) ) {
-				body.getLocals().remove(local);
+			if ( usedLocals[lno] ) {
+				keep.add(local);
 			}
 		}
+		body.getLocals().clear();
+		body.getLocals().addAll(keep);
 	}
 }

--- a/src/soot/util/PriorityQueue.java
+++ b/src/soot/util/PriorityQueue.java
@@ -272,7 +272,12 @@ abstract public class PriorityQueue<E> extends AbstractQueue<E> {
 			public Integer get(Object key) {
 				return ((E) key).getNumber();
 			}
-
+			
+			@Override
+			public int size() {
+				return universe.size();
+			}
+			
 			@Override
 			public Set<java.util.Map.Entry<E, Integer>> entrySet() {
 				throw new UnsupportedOperationException();

--- a/src/soot/validation/UsesValidator.java
+++ b/src/soot/validation/UsesValidator.java
@@ -1,7 +1,6 @@
 package soot.validation;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import soot.Body;
@@ -14,8 +13,6 @@ import soot.toolkits.exceptions.ThrowAnalysis;
 import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.toolkits.graph.UnitGraph;
 import soot.toolkits.scalar.LocalDefs;
-import soot.toolkits.scalar.SimpleLiveLocals;
-import soot.toolkits.scalar.SmartLocalDefs;
 
 public enum UsesValidator implements BodyValidator {
 	INSTANCE;	
@@ -57,26 +54,24 @@ public enum UsesValidator implements BodyValidator {
 		
         ThrowAnalysis throwAnalysis = PedanticThrowAnalysis.v();
         UnitGraph g = new ExceptionalUnitGraph(body, throwAnalysis, false);
-        LocalDefs ld = new SmartLocalDefs(g, new SimpleLiveLocals(g));
+        LocalDefs ld = LocalDefs.Factory.newLocalDefs(g);
 
         Collection<Local> locals = body.getLocals();
         for (Unit u : body.getUnits()) {
-            Iterator<ValueBox> useBoxIt = u.getUseBoxes().iterator();
-            while (useBoxIt.hasNext())
-            {
-                Value v = (useBoxIt.next()).getValue();
+        	for (ValueBox box : u.getUseBoxes()) {
+                Value v = box.getValue();
                 if (v instanceof Local)
                 {
-					if(!locals.contains(v)) {
+                	Local l = (Local) v;
+                	
+					if(!locals.contains(l)) {
                     	String msg = "Local "+v+" is referenced here but not in body's local-chain. ("+body.getMethod()+")";
 						exception.add(new ValidationException(u, msg, msg));
                     }
-                	// This throws an exception if there is
-                    // no def already; we check anyhow.
-                    List<Unit> l = ld.getDefsOfAt((Local)v, u);
-                    if (l.size() == 0){
+										
+                    if (ld.getDefsOfAt(l, u).isEmpty()) {
                         exception.add(new ValidationException(u, "There is no path from a definition of " + v + " to this statement.", 
-                        		"("+ body.getMethod() +") no defs for value: " + v + "!"));
+                        		"("+ body.getMethod() +") no defs for value: " + l + "!"));
                     }
                 }
             }

--- a/src/soot/validation/UsesValidator.java
+++ b/src/soot/validation/UsesValidator.java
@@ -54,7 +54,7 @@ public enum UsesValidator implements BodyValidator {
 		
         ThrowAnalysis throwAnalysis = PedanticThrowAnalysis.v();
         UnitGraph g = new ExceptionalUnitGraph(body, throwAnalysis, false);
-        LocalDefs ld = LocalDefs.Factory.newLocalDefs(g);
+        LocalDefs ld = LocalDefs.Factory.newLocalDefs(g, true);
 
         Collection<Local> locals = body.getLocals();
         for (Unit u : body.getUnits()) {


### PR DESCRIPTION
+rewritten SimpleLocalDefs
+some reduced HashMap pressure from SmartLocalDefs / SimpleLiveLocals
+complete rewritten FlowAnalysis
+introduced factories for LocalDefs/LiveLocals/LocalUses
+changed LocalSplitter to behave less optimistic (usage of undefined locals)
+removed the usage of SmartLocalDefsPool (it causes memoryleaks, and isn't required anymore)
+added "FlowSet.isSubSet"
+added some Div/Rem Constant checks for 	DeadAssignmentEliminator
+added some asserts to soot.validation.UsesValidator


The behaviour of SimpleLocalDefs and FlowAnalysis has changed a little bit: only reachable nodes within a graph will be visited. It's not a big deal but maybe this causes some errors that have been hidden before (see also soot.validation.UsesValidator.graphEdgesAreValid). This triggers especially bugs in UnitGraph, ExceptionalUnitGraph, etc and in the ThrowAnalysis (or in combination).

The newly introduced pooling was removed, it doesn't offer any benefit with the SimpleLocalDefs/FlowAnalysis and just silently fills the memory.

SimpleLocalDefs uses a mixed strategy that works best when used with the "semi-ssa" code that the LocalSplitter creates, so you should avoiding to use LocalPacker.