### PR TITLE
Fixes the FieldRefValidator regarding phantom fields

### DIFF
--- a/src/soot/jimple/validation/FieldRefValidator.java
+++ b/src/soot/jimple/validation/FieldRefValidator.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import soot.Body;
 import soot.ResolutionFailedException;
+import soot.SootField;
 import soot.SootMethod;
 import soot.Unit;
 import soot.jimple.FieldRef;
@@ -12,6 +13,7 @@ import soot.jimple.StaticFieldRef;
 import soot.jimple.Stmt;
 import soot.util.Chain;
 import soot.validation.BodyValidator;
+import soot.validation.UnitValidationException;
 import soot.validation.ValidationException;
 
 public enum FieldRefValidator implements BodyValidator {
@@ -43,35 +45,29 @@ public enum FieldRefValidator implements BodyValidator {
 			if (fr instanceof StaticFieldRef) {
 				StaticFieldRef v = (StaticFieldRef) fr;
 				try {
-					if (!v.getField().isStatic()) {
-						exception.add(new ValidationException(unit, formatMsg("trying to get a static field which is non-static: " + v, unit, body)));
+					SootField field = v.getField();
+					if (!field.isStatic() && !field.isPhantom()) {
+						exception.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
 					}
 				} catch (ResolutionFailedException e) {
-					exception.add(new ValidationException(unit, formatMsg("trying to get a static field which is non-static: " + v, unit, body)));
+					exception.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
 				}
 			} else if (fr instanceof InstanceFieldRef) {
 				InstanceFieldRef v = (InstanceFieldRef) fr;
 
 				try {
-					if (v.getField().isStatic()) {
-						exception.add(new ValidationException(unit, formatMsg("trying to get an instance field which is static: " + v, unit, body)));
+					SootField field = v.getField();
+					if (field.isStatic() && !field.isPhantom()) {
+						exception.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
 					}
 				} catch (ResolutionFailedException e) {
-					exception.add(new ValidationException(unit, formatMsg("trying to get an instance field which is static: " + v, unit, body)));
+					exception.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
 				}
 			} else {
 				throw new RuntimeException("unknown field ref");
 			}
 		}
     }
-
-	private String formatMsg(String s, Unit u, Body b) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(s + "\n");
-		sb.append("in unit: " + u + "\n");
-		sb.append("in body: \n " + b + "\n");
-		return sb.toString();
-	}
 
 
 	@Override

--- a/src/soot/validation/UnitValidationException.java
+++ b/src/soot/validation/UnitValidationException.java
@@ -1,0 +1,44 @@
+package soot.validation;
+
+import soot.Body;
+import soot.Unit;
+
+
+/**
+ * This kind of validation exception can be used if a unit is the cause of an validation error.
+ */
+public class UnitValidationException extends ValidationException {
+	
+	/**
+	 * Creates a new ValidationException.
+	 * @param concerned the unit which is concerned and could be highlighted in an IDE
+	 * @param body the body which contains the concerned unit
+	 * @param strMessage the message to display in an IDE supporting the concerned feature
+	 * @param isWarning whether the exception can be considered as a warning message
+	 */
+	public UnitValidationException(Unit concerned, Body body, String strMessage, boolean isWarning) {
+		super(concerned, strMessage, formatMsg(strMessage, concerned, body), isWarning);
+	}
+
+	/**
+	 * Creates a new ValidationException, treated as an error.
+	 * @param body the body which contains the concerned unit
+	 * @param concerned the object which is concerned and could be highlighted in an IDE; for example an unit, a SootMethod, a SootClass or a local.
+	 * @param strMessage the message to display in an IDE supporting the concerned feature
+	 */
+	public UnitValidationException(Unit concerned, Body body, String strMessage) {
+		super(concerned, strMessage, formatMsg(strMessage, concerned, body), false);
+	}
+
+
+	private static String formatMsg(String s, Unit u, Body b) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(s + "\n");
+		sb.append("in unit: " + u + "\n");
+		sb.append("in body: \n " + b + "\n");
+		return sb.toString();
+	}
+
+	private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
Fixes the new FieldRefValidator regarding the handling of phantom fields, which modifiers may not be accurate.

Also introduces a new UnitValidationException, which can be used if a particular unit is the cause of a validation error. The message should not contain the whole body in text form, since e.g. CodeInspect will display the whole text of the exception and thus includes the body text in the problems view.
Nevertheless, the user of soot should get the more verbose exception message including the body.