### PR TITLE
Manager.v().registerSetIfNew performance improvements & other

### DIFF
--- a/src/soot/Main.java
+++ b/src/soot/Main.java
@@ -18,13 +18,14 @@
  */
 
 /*
- * Modified by the Sable Research Group and others 1997-2008.  
+ * Modified by the Sable Research Group and others 1997-2008.
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
 
 package soot;
 
+import static java.net.URLEncoder.encode;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
@@ -34,9 +35,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Date;
-import java.util.Iterator;
 
 import soot.options.CGOptions;
 import soot.options.Options;
@@ -46,124 +45,122 @@ import com.google.common.base.Joiner;
 
 /** Main class for Soot; provides Soot's command-line user interface. */
 public class Main {
-    public Main(Singletons.Global g) {
-    }
-    public static Main v() {
-        return G.v().soot_Main();
-    }
-    // TODO: the following string should be updated by the source control
-    // No it shouldn't. Prcs is horribly broken in this respect, and causes
-    // the code to not compile all the time.
-    public static final String versionString = Main.class.getPackage().getImplementationVersion() == null ? "trunk" : Main.class.getPackage().getImplementationVersion();
+	public Main(Singletons.Global g) {
+	}
+	public static Main v() {
+		return G.v().soot_Main();
+	}
+	// TODO: the following string should be updated by the source control
+	// No it shouldn't. Prcs is horribly broken in this respect, and causes
+	// the code to not compile all the time.
+	public static final String versionString = Main.class.getPackage().getImplementationVersion() == null ? "trunk" : Main.class.getPackage().getImplementationVersion();
 
-    private Date start;
-    private Date finish;
-    
-    private void printVersion() {
-        G.v().out.println("Soot version " + versionString);
+	private Date start;
+	private Date finish;
 
-        G.v().out.println(
-            "Copyright (C) 1997-2010 Raja Vallee-Rai and others.");
-        G.v().out.println("All rights reserved.");
-        G.v().out.println("");
-        G.v().out.println(
-            "Contributions are copyright (C) 1997-2010 by their respective contributors.");
-        G.v().out.println("See the file 'credits' for a list of contributors.");
-        G.v().out.println("See individual source files for details.");
-        G.v().out.println("");
-        G.v().out.println(
-            "Soot comes with ABSOLUTELY NO WARRANTY.  Soot is free software,");
-        G.v().out.println(
-            "and you are welcome to redistribute it under certain conditions.");
-        G.v().out.println(
-            "See the accompanying file 'COPYING-LESSER.txt' for details.");
-        G.v().out.println();
-        G.v().out.println("Visit the Soot website:");
-        G.v().out.println("  http://www.sable.mcgill.ca/soot/");
-        G.v().out.println();
-        G.v().out.println("For a list of command line options, enter:");
-        G.v().out.println("  java soot.Main --help");
-    }
+	private void printVersion() {
+		G.v().out.println("Soot version " + versionString);
 
-    private void processCmdLine(String[] args) {
+		G.v().out.println(
+				"Copyright (C) 1997-2010 Raja Vallee-Rai and others.");
+		G.v().out.println("All rights reserved.");
+		G.v().out.println("");
+		G.v().out.println(
+				"Contributions are copyright (C) 1997-2010 by their respective contributors.");
+		G.v().out.println("See the file 'credits' for a list of contributors.");
+		G.v().out.println("See individual source files for details.");
+		G.v().out.println("");
+		G.v().out.println(
+				"Soot comes with ABSOLUTELY NO WARRANTY.  Soot is free software,");
+		G.v().out.println(
+				"and you are welcome to redistribute it under certain conditions.");
+		G.v().out.println(
+				"See the accompanying file 'COPYING-LESSER.txt' for details.");
+		G.v().out.println();
+		G.v().out.println("Visit the Soot website:");
+		G.v().out.println("  http://www.sable.mcgill.ca/soot/");
+		G.v().out.println();
+		G.v().out.println("For a list of command line options, enter:");
+		G.v().out.println("  java soot.Main --help");
+	}
 
-        if (!Options.v().parse(args))
-            throw new OptionsParseException("Option parse error");
+	private void processCmdLine(String[] args) {
 
-        if( PackManager.v().onlyStandardPacks() ) {
-            for (Pack pack : PackManager.v().allPacks()) {
-                Options.v().warnForeignPhase(pack.getPhaseName());
-                for( Iterator<Transform> trIt = pack.iterator(); trIt.hasNext(); ) {
-                    final Transform tr = trIt.next();
-                    Options.v().warnForeignPhase(tr.getPhaseName());
-                }
-            }
-        }
-        Options.v().warnNonexistentPhase();
+		if (!Options.v().parse(args))
+			throw new OptionsParseException("Option parse error");
 
-        if (Options.v().help()) {
-            G.v().out.println(Options.v().getUsage());
-            throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
-        }
+		if (PackManager.v().onlyStandardPacks()) {
+			for (Pack pack : PackManager.v().allPacks()) {
+				Options.v().warnForeignPhase(pack.getPhaseName());
+				for (Transform tr : pack) {
+					Options.v().warnForeignPhase(tr.getPhaseName());
+				}
+			}
+		}
+		Options.v().warnNonexistentPhase();
 
-        if (Options.v().phase_list()) {
-            G.v().out.println(Options.v().getPhaseList());
-            throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
-        }
+		if (Options.v().help()) {
+			G.v().out.println(Options.v().getUsage());
+			throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
+		}
 
-        if(!Options.v().phase_help().isEmpty()) {
-            for( Iterator<String> phaseIt = Options.v().phase_help().iterator(); phaseIt.hasNext(); ) {
-                final String phase = phaseIt.next();
-                G.v().out.println(Options.v().getPhaseHelp(phase));
-            }
-            throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
-        }
+		if (Options.v().phase_list()) {
+			G.v().out.println(Options.v().getPhaseList());
+			throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
+		}
 
-        if ((!Options.v().unfriendly_mode() && args.length == 0) || Options.v().version()) {
-            printVersion();
-            throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
-        }
-        
-        if(Options.v().on_the_fly()) {
-        	Options.v().set_whole_program(true);
-    		PhaseOptions.v().setPhaseOption("cg", "off");
-        }
+		if (!Options.v().phase_help().isEmpty()) {
+			for (String phase : Options.v().phase_help()) {
+				G.v().out.println(Options.v().getPhaseHelp(phase));
+			}
+			throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
+		}
 
-        postCmdLineCheck();
-    }
+		if ((!Options.v().unfriendly_mode() && (args.length == 0)) || Options.v().version()) {
+			printVersion();
+			throw new CompilationDeathException(CompilationDeathException.COMPILATION_SUCCEEDED);
+		}
 
-    private void postCmdLineCheck() {
-        if (Options.v().classes().isEmpty()
-        && Options.v().process_dir().isEmpty()) {
-            throw new CompilationDeathException(
-                CompilationDeathException.COMPILATION_ABORTED,
-                "No input classes specified!");
-        }
-    }
+		if(Options.v().on_the_fly()) {
+			Options.v().set_whole_program(true);
+			PhaseOptions.v().setPhaseOption("cg", "off");
+		}
 
-    public String[] cmdLineArgs = new String[0];
-    /**
-     *   Entry point for cmd line invocation of soot.
-     */
-    public static void main(String[] args) {
-        try {
-            Main.v().run(args);
-        } catch ( OptionsParseException e ) {
-        	// error message has already been printed
-        } catch( StackOverflowError e ) {
-            G.v().out.println( "Soot has run out of stack memory." );
-            G.v().out.println( "To allocate more stack memory to Soot, use the -Xss switch to Java." );
-            G.v().out.println( "For example (for 2MB): java -Xss2m soot.Main ..." );
-            throw e;
-        } catch( OutOfMemoryError e ) {
-            G.v().out.println( "Soot has run out of the memory allocated to it by the Java VM." );
-            G.v().out.println( "To allocate more memory to Soot, use the -Xmx switch to Java." );
-            G.v().out.println( "For example (for 2GB): java -Xmx2g soot.Main ..." );
-            throw e;
-        } catch( RuntimeException e ) {
-        	e.printStackTrace();
-        	
-        	ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		postCmdLineCheck();
+	}
+
+	private void postCmdLineCheck() {
+		if (Options.v().classes().isEmpty()
+				&& Options.v().process_dir().isEmpty()) {
+			throw new CompilationDeathException(
+					CompilationDeathException.COMPILATION_ABORTED,
+					"No input classes specified!");
+		}
+	}
+
+	public String[] cmdLineArgs = new String[0];
+	/**
+	 *   Entry point for cmd line invocation of soot.
+	 */
+	public static void main(String[] args) {
+		try {
+			Main.v().run(args);
+		} catch (OptionsParseException e) {
+        		// error message has already been printed
+		} catch (StackOverflowError e ) {
+			G.v().out.println( "Soot has run out of stack memory." );
+			G.v().out.println( "To allocate more stack memory to Soot, use the -Xss switch to Java." );
+			G.v().out.println( "For example (for 2MB): java -Xss2m soot.Main ..." );
+			throw e;
+		} catch (OutOfMemoryError e) {
+			G.v().out.println( "Soot has run out of the memory allocated to it by the Java VM." );
+			G.v().out.println( "To allocate more memory to Soot, use the -Xmx switch to Java." );
+			G.v().out.println( "For example (for 2GB): java -Xmx2g soot.Main ..." );
+			throw e;
+		} catch (RuntimeException e) {
+			e.printStackTrace();
+
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
 			e.printStackTrace(new PrintStream(bos));
 			String stackStraceString = bos.toString();
 			try {
@@ -171,126 +168,153 @@ public class Main {
 				String commandLineArgs = Joiner.on(" ").join(args);
 				String body = "Steps to reproduce:\n1.) ...\n\n"
 						+ "Files used to reproduce: \n...\n\n"
-						+ "Soot version: "+versionString+"\n\n"
-						+ "Command line:\n"+commandLineArgs+"\n\nMax Memory:\n"+Runtime.getRuntime().maxMemory()/(1024*1024)+"MB\n\nStack trace:\n"+stackStraceString;
+						+ "Soot version: "+"<pre>"+escape(versionString)+"</pre>"+"\n\n"
+						+ "Command line:\n"+"<pre>"+escape(commandLineArgs)+"</pre>\n\n"
+						+ "Max Memory:\n"+"<pre>"+escape((Runtime.getRuntime().maxMemory()/(1024*1024))+"MB")+"</pre>"+"\n\n"
+						+ "Stack trace:\n"+"<pre>"+escape(stackStraceString)+"</pre>";
+
+
 				String title = e.getClass().getName()+" when ...";
-				
-	        	StringBuilder sb = new StringBuilder();
-	        	sb.append("\n\nOuuups... something went wrong! Sorry about that.\n");
-	        	sb.append("Follow these steps to fix the problem:\n");
-	        	sb.append("1.) Are you sure you used the right command line?\n");
-	        	sb.append("    Click here to double-check:\n");
-	        	sb.append("    https://ssebuild.cased.de/nightly/soot/doc/soot_options.htm\n");
-	        	sb.append("\n");
-	        	sb.append("2.) Not sure whether it's a bug? Feel free to discuss\n");
+
+				StringBuilder sb = new StringBuilder();
+				sb.append("\n\nOuuups... something went wrong! Sorry about that.\n");
+				sb.append("Follow these steps to fix the problem:\n");
+				sb.append("1.) Are you sure you used the right command line?\n");
+				sb.append("    Click here to double-check:\n");
+				sb.append("    https://ssebuild.cased.de/nightly/soot/doc/soot_options.htm\n");
+				sb.append("\n");
+				sb.append("2.) Not sure whether it's a bug? Feel free to discuss\n");
 				sb.append("    the issue on the Soot mailing list:\n");
-				sb.append("    https://github.com/Sable/soot/wiki/Getting-help\n");			
-	        	sb.append("\n");
-	        	sb.append("3.) Sure it's a bug? Click this link to report it.\n");
-	        	sb.append("    "+TRACKER_URL+"title="+URLEncoder.encode(title,"UTF-8")+"&body="+URLEncoder.encode(body,"UTF-8")+"\n");
-	        	sb.append("    Please be as precise as possible when giving us\n");
-	        	sb.append("    information on how to reproduce the problem. Thanks!");
-	        	
-	        	System.err.println(sb.toString());
+				sb.append("    https://github.com/Sable/soot/wiki/Getting-help\n");
+				sb.append("\n");
+				sb.append("3.) Sure it's a bug? Click this link to report it.\n");
+				sb.append("    "+TRACKER_URL+"title="+encode(title, "UTF-8")+"&body="+encode(body, "UTF-8")+"\n");
+				sb.append("    Please be as precise as possible when giving us\n");
+				sb.append("    information on how to reproduce the problem. Thanks!");
+
+				System.err.println(sb);
 			} catch (UnsupportedEncodingException e1) {
 			}
-        }
-    }
+		}
+	}
 
-    /** 
-     *  Entry point to the soot's compilation process.
-     */
-    public void run(String[] args) {
-        cmdLineArgs = args;
+	private static CharSequence escape(CharSequence s) {
+		int start = 0; 
+		int end = s.length();
 
-        start = new Date();
-        
+		StringBuilder sb = new StringBuilder(32 + (end - start));
+		for (int i = start; i < end; i++) {
+			int c = s.charAt(i);
+			switch (c) {
+			case '<':
+			case '>':
+			case '"':
+			case '\'':
+			case '&':
+				sb.append(s, start, i);
+				sb.append("&#");
+				sb.append(c);
+				sb.append(';');
+				start = i + 1;
+				break;
+			}
+		}
+		return sb.append(s, start, end);
+	}
 
-        try {
-            Timers.v().totalTimer.start();
+	/**
+	 *  Entry point to the soot's compilation process.
+	 */
+	public void run(String[] args) {
+		cmdLineArgs = args;
 
-            processCmdLine(cmdLineArgs);
-            
-            autoSetOptions();
+		start = new Date();
 
-            G.v().out.println("Soot started on " + start);
 
-            Scene.v().loadNecessaryClasses();
+		try {
+			Timers.v().totalTimer.start();
 
-            /*
-             * By this all the java to jimple has occured so we just check ast-metrics flag
-             * 
-             * If it is set......print the astMetrics.xml file and stop executing soot
-             */
-            if(Options.v().ast_metrics()){
-        	   	try{
-            		OutputStream streamOut = new FileOutputStream("../astMetrics.xml");
-            		PrintWriter writerOut = new PrintWriter(new OutputStreamWriter(streamOut));
-            		writerOut.println("<?xml version='1.0'?>");
-            		writerOut.println("<ASTMetrics>");		 		
-            		
-            		Iterator<ClassData> it = G.v().ASTMetricsData.iterator();
-            		while(it.hasNext()){
-            			//each is a classData object
-            			ClassData cData = it.next();
-            			writerOut.println(cData.toString());
-            		}
+			processCmdLine(cmdLineArgs);
 
-            		writerOut.println("</ASTMetrics>");
-             		writerOut.flush();
-            		streamOut.close();
-            	} catch (IOException e) {
-            		throw new CompilationDeathException("Cannot output file astMetrics",e);
-            	}
-                return;
-            }
-            
-            PackManager.v().runPacks();
-            if(!Options.v().oaat())
-            	PackManager.v().writeOutput();
+			autoSetOptions();
 
-            Timers.v().totalTimer.end();
+			G.v().out.println("Soot started on " + start);
 
-            // Print out time stats.				
-            if (Options.v().time())
-                Timers.v().printProfilingInformation();
+			Scene.v().loadNecessaryClasses();
 
-        } catch (CompilationDeathException e) {
-            Timers.v().totalTimer.end();
-            if(e.getStatus()!=CompilationDeathException.COMPILATION_SUCCEEDED)
-            	throw e;
-            else 
-            	return;
-        }
+			/*
+			 * By this all the java to jimple has occured so we just check ast-metrics flag
+			 *
+			 * If it is set......print the astMetrics.xml file and stop executing soot
+			 */
+			if(Options.v().ast_metrics()){
+				try{
+					OutputStream streamOut = new FileOutputStream("../astMetrics.xml");
+					PrintWriter writerOut = new PrintWriter(new OutputStreamWriter(streamOut));
+					writerOut.println("<?xml version='1.0'?>");
+					writerOut.println("<ASTMetrics>");
 
-        finish = new Date();
+					for (ClassData cData : G.v().ASTMetricsData) {
+						//each is a classData object
+						writerOut.println(cData);
+					}
 
-        G.v().out.println("Soot finished on " + finish);
-        long runtime = finish.getTime() - start.getTime();
-        G.v().out.println(
-            "Soot has run for "
-                + (runtime / 60000)
-                + " min. "
-                + ((runtime % 60000) / 1000)
-                + " sec.");
+					writerOut.println("</ASTMetrics>");
+					writerOut.flush();
+					streamOut.close();
+				} catch (IOException e) {
+					throw new CompilationDeathException("Cannot output file astMetrics",e);
+				}
+				return;
+			}
 
-    }
-    
+			PackManager.v().runPacks();
+			if(!Options.v().oaat())
+				PackManager.v().writeOutput();
+
+			Timers.v().totalTimer.end();
+
+			// Print out time stats.
+			if (Options.v().time())
+				Timers.v().printProfilingInformation();
+
+		} catch (CompilationDeathException e) {
+			Timers.v().totalTimer.end();
+			if(e.getStatus()!=CompilationDeathException.COMPILATION_SUCCEEDED)
+				throw e;
+			else
+				return;
+		}
+
+		finish = new Date();
+
+		G.v().out.println("Soot finished on " + finish);
+		long runtime = finish.getTime() - start.getTime();
+		G.v().out.println(
+				"Soot has run for "
+						+ (runtime / 60000)
+						+ " min. "
+						+ ((runtime % 60000) / 1000)
+						+ " sec.");
+
+	}
+
 	public void autoSetOptions() {
-		//when no-bodies-for-excluded is enabled, also enable phantom refs	
-        if(Options.v().no_bodies_for_excluded())
-        	Options.v().set_allow_phantom_refs(true);
-		
-		//when reflection log is enabled, also enable phantom refs	
-	    CGOptions cgOptions = new CGOptions( PhaseOptions.v().getPhaseOptions("cg") );
-	    String log = cgOptions.reflection_log();
-	    if(log!=null && log.length()>0) {
-	    	Options.v().set_allow_phantom_refs(true);
-	    }
-	    
-	    //if phantom refs enabled,  ignore wrong staticness in type assigner
-	    if(Options.v().allow_phantom_refs()) {
-	    	PhaseOptions.v().setPhaseOption("jb.tr", "ignore-wrong-staticness:true");
-	    }
+		//when no-bodies-for-excluded is enabled, also enable phantom refs
+		if(Options.v().no_bodies_for_excluded())
+			Options.v().set_allow_phantom_refs(true);
+
+		//when reflection log is enabled, also enable phantom refs
+		CGOptions cgOptions = new CGOptions( PhaseOptions.v().getPhaseOptions("cg") );
+		String log = cgOptions.reflection_log();
+		if((log!=null) && (log.length()>0)) {
+			Options.v().set_allow_phantom_refs(true);
+		}
+
+		//if phantom refs enabled,  ignore wrong staticness in type assigner
+		if(Options.v().allow_phantom_refs()) {
+			PhaseOptions.v().setPhaseOption("jb.tr", "ignore-wrong-staticness:true");
+		}
 	}
 }
+

--- a/src/soot/jimple/internal/AbstractDefinitionStmt.java
+++ b/src/soot/jimple/internal/AbstractDefinitionStmt.java
@@ -41,15 +41,10 @@ public abstract class AbstractDefinitionStmt extends AbstractStmt
 	public final ValueBox leftBox;
 	public final ValueBox rightBox;
 	
-	private final List<ValueBox> defBoxes; 
-
 	protected AbstractDefinitionStmt(ValueBox leftBox, ValueBox rightBox) {
 		this.leftBox = leftBox;
-		this.rightBox = rightBox;    	
-		
-		this.defBoxes = Collections.singletonList(leftBox); 
+		this.rightBox = rightBox;
 	}
-
     
     @Override
     public final Value getLeftOp()
@@ -78,7 +73,7 @@ public abstract class AbstractDefinitionStmt extends AbstractStmt
 	@Override
     public final List<ValueBox> getDefBoxes()
     {
-        return defBoxes;
+        return Collections.singletonList(leftBox);
     }
 
     @Override

--- a/tests/soot/toolkits/exceptions/ThrowableSetTest.java
+++ b/tests/soot/toolkits/exceptions/ThrowableSetTest.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,1494 +29,1488 @@ import soot.toolkits.exceptions.ExceptionTestUtility.ExceptionHashSet;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ThrowableSetTest {
 
-    static {
-        Scene.v().loadBasicClasses();
-    }
-
-    final static boolean DUMP_INTERNALS = false;
-    final ThrowableSet.Manager mgr = ThrowableSet.Manager.v();
-
-
-    // A class for verifying that the sizeToSetsMap
-    // follows our expectations. 
-    static class ExpectedSizeToSets {
-        private Map<Integer, Set<SetPair>> expectedMap = new HashMap<Integer, Set<SetPair>>(); // from Integer to Set.
-
-        private static class SetPair {
-            Set<RefLikeType> included;
-            Set<AnySubType> excluded;
-
-            SetPair(Set<RefLikeType> included, Set<AnySubType> excluded) {
-                this.included = included;
-                this.excluded = excluded;
-            }
-
-            public boolean equals(Object o) {
-                if (o == this) {
-                    return true;
-                }
-                if (! (o instanceof SetPair)) {
-                    return false;
-                }
-                SetPair sp = (SetPair) o;
-                return (   this.included.equals(sp.included)
-                        && this.excluded.equals(sp.excluded));
-            }
-
-            public int hashCode() {
-                int result = 31;
-                result = 37 * result + included.hashCode();
-                result = 37 * result + excluded.hashCode();
-                return result;
-            }
-
-            public String toString() {
-                return (  super.toString() 
-                        + System.getProperty("line.separator") 
-                        + "+[" + included.toString() + ']'
-                        + "-[" + excluded.toString() + ']');
-            }
-        }
-
-        ExpectedSizeToSets() {
-            // The empty set.
-            this.add(Collections.<RefLikeType>emptySet(), Collections.<AnySubType>emptySet());
-
-            // All Throwables set.
-            Set<RefLikeType> temp = new ExceptionHashSet<RefLikeType>();
-            temp.add(AnySubType.v(Scene.v().getRefType("java.lang.Throwable")));
-            this.add(temp, Collections.<AnySubType>emptySet());
-
-            // VM errors set.
-            temp = new ExceptionHashSet<RefLikeType>();
-            temp.add(Scene.v().getRefType("java.lang.InternalError"));
-            temp.add(Scene.v().getRefType("java.lang.OutOfMemoryError"));
-            temp.add(Scene.v().getRefType("java.lang.StackOverflowError"));
-            temp.add(Scene.v().getRefType("java.lang.UnknownError"));
-            temp.add(Scene.v().getRefType("java.lang.ThreadDeath"));
-            this.add(temp, Collections.<AnySubType>emptySet());
-
-            // Resolve Class errors set.
-            Set<RefLikeType> classErrors = new ExceptionHashSet<RefLikeType>();
-            classErrors.add(Scene.v().getRefType("java.lang.ClassCircularityError"));
-            classErrors.add(AnySubType.v(Scene.v().getRefType("java.lang.ClassFormatError")));
-            classErrors.add(Scene.v().getRefType("java.lang.IllegalAccessError"));
-            classErrors.add(Scene.v().getRefType("java.lang.IncompatibleClassChangeError"));
-            classErrors.add(Scene.v().getRefType("java.lang.LinkageError"));
-            classErrors.add(Scene.v().getRefType("java.lang.NoClassDefFoundError"));
-            classErrors.add(Scene.v().getRefType("java.lang.VerifyError"));
-            this.add(classErrors, Collections.<AnySubType>emptySet());
-
-            // Resolve Field errors set.
-            temp = new ExceptionHashSet<RefLikeType>(classErrors);
-            temp.add(Scene.v().getRefType("java.lang.NoSuchFieldError"));
-            this.add(temp, Collections.<AnySubType>emptySet());
-
-            // Resolve method errors set.
-            temp = new ExceptionHashSet<RefLikeType>(classErrors);
-            temp.add(Scene.v().getRefType("java.lang.AbstractMethodError"));
-            temp.add(Scene.v().getRefType("java.lang.NoSuchMethodError"));
-            temp.add(Scene.v().getRefType("java.lang.UnsatisfiedLinkError"));
-            this.add(temp, Collections.<AnySubType>emptySet());
-
-            // Initialization errors set.
-            temp = new ExceptionHashSet<RefLikeType>();
-            temp.add(AnySubType.v(Scene.v().getRefType("java.lang.Error")));
-            this.add(temp, Collections.<AnySubType>emptySet());
-        }
-
-        void add(Set<RefLikeType> inclusions, Set<AnySubType> exclusions) {
-            Integer sz = new Integer(inclusions.size() + exclusions.size());
-            Set<SetPair> values = expectedMap.get(sz);
-            if (values == null) {
-                values = new HashSet<SetPair>();
-                expectedMap.put(sz, values);
-            }
-            // Make sure we have our own copies of the sets.
-            values.add(new SetPair(new ExceptionHashSet<RefLikeType>(inclusions), 
-                        new ExceptionHashSet<AnySubType>(exclusions)));
-        }
-
-        void addAndCheck(Set<RefLikeType> inclusions, Set<AnySubType> exclusions) {
-            this.add(inclusions, exclusions);
-            assertTrue(this.match());
-        }
-
-        boolean match() {
-            boolean result = true;
-            Map<Integer, List<ThrowableSet>> actualMap = ThrowableSet.Manager.v().getSizeToSets();
-            if (expectedMap.size() != actualMap.size()) {
-                result = false;
-            } else {
-setloop: 
-                for (Integer key : expectedMap.keySet()) {
-                    Set<SetPair> expectedValues = expectedMap.get(key);
-
-                    // To minimize restrictions on the contents of 
-                    // sizeToSets, use only the Collection interface
-                    // to access its values:
-                    Collection<ThrowableSet> actualValues = actualMap.get(key);
-
-                    if (expectedValues.size() != actualValues.size()) {
-                        result = false;
-                        break setloop;
-                    }
-                    for (ThrowableSet actual : actualValues) {
-                        SetPair actualPair
-                            = new SetPair(new ExceptionHashSet<RefLikeType>(actual.typesIncluded()),
-                                    new ExceptionHashSet<AnySubType>(actual.typesExcluded()));
-                        if (! expectedValues.contains(actualPair)) {
-                            result = false;
-                            break setloop;
-                        }
-                    }
-                        }
-            }
-            if (DUMP_INTERNALS) {
-                if (! result) System.err.println("!!!ExpectedSizeToSets.match() FAILED!!!");
-                System.err.println("expectedMap:");
-                System.err.println(expectedMap.toString());
-                System.err.println("actualMap:");
-                System.err.println(actualMap.toString());
-                System.err.flush();
-            } 
-            return result;
-        }
-    }
-    private static ExpectedSizeToSets expectedSizeToSets;
-
-    // A class to check that memoized results match what we expect.
-    // Admittedly, this amounts to a reimplementation of the memoized
-    // structures within ThrowableSet -- I'm hoping that the two 
-    // implementations will have different bugs!
-    static class ExpectedMemoizations  {
-        Map<ThrowableSet, Map<Object, ThrowableSet>> throwableSetToMemoized =
-        		new HashMap<ThrowableSet, Map<Object, ThrowableSet>>();
-
-        void checkAdd(ThrowableSet lhs, Object rhs, ThrowableSet result) {
-            // rhs should be either a ThrowableSet or a RefType.
-            Map<Object, ThrowableSet> actualMemoized = lhs.getMemoizedAdds();
-            assertTrue(actualMemoized.get(rhs) == result);
-
-            Map<Object, ThrowableSet> expectedMemoized = throwableSetToMemoized.get(lhs);
-            if (expectedMemoized == null) {
-                expectedMemoized = new HashMap<Object, ThrowableSet>();
-                throwableSetToMemoized.put(lhs, expectedMemoized);
-            }
-            expectedMemoized.put(rhs, result);
-            assertEquals(expectedMemoized, actualMemoized);
-        }
-    }
-    private static ExpectedMemoizations expectedMemoizations;
-
-    private static ExceptionTestUtility util;
-
-    @BeforeClass
-    public static void setUp() {
-        expectedSizeToSets = new ExpectedSizeToSets();
-        expectedMemoizations = new ExpectedMemoizations();
-        util = new ExceptionTestUtility(System.getProperty("sun.boot.class.path"));
-    }
-
-    /**
-     * Asserts that the membership in the component sets of a
-     * ThrowableSet correspond to expectations.
-     *
-     * @param s The set to be checked.
-     *
-     * @param included the {@link Set} of RefLikeTypes 
-     * expected to be in included in <code>s</code>.
-     *
-     * @param excluded an {@link Set} of RefLikeTypes
-     * expected to be excluded from <code>s</code>.
-     *
-     * @throws  AssertionFailedError if <code>s</code> does not
-     * contain the types in <code>included</code> except for those 
-     * in <code>excluded</code>.
-     */
-    public static void assertSameMembers(ThrowableSet s,
-            Set<? extends RefLikeType> included,
-            Set<AnySubType> excluded) {
-        assertTrue(ExceptionTestUtility.sameMembers(included, excluded, s));
-    }
-
-
-    /**
-     * Asserts that the membership in the component sets of a
-     * ThrowableSet correspond to expectations.
-     *
-     * @param s The set to be checked.
-     *
-     * @param included an array containing the RefLikeTypes 
-     * expected to be in included in <code>s</code>.
-     *
-     * @param excluded an array containing the RefLikeTypes
-     * expected to be excluded from <code>s</code>.
-     *
-     * @throws  AssertionFailedError if <code>s</code> does not
-     * contain the types in <code>included</code> except for those 
-     * in <code>excluded</code>.
-     */
-    public static void assertSameMembers(ThrowableSet s,
-            RefLikeType[] included,
-            AnySubType[] excluded) {
-        assertTrue(ExceptionTestUtility.sameMembers(
-                    new ExceptionHashSet<RefLikeType>(Arrays.asList(included)), 
-                    new ExceptionHashSet<AnySubType>(Arrays.asList(excluded)),
-                    s));
-    }
-
-
-    /**
-     * Asserts that the membership in the component sets of a
-     * ThrowableSet.Pair correspond to expectations.
-     *
-     * @param p The pair to be checked.
-     *
-     * @param caughtIncluded the set of {@link RefLikeType}s
-     * expected to be in included in <code>p.getCaught()</code>.
-     *
-     * @param caughtExcluded the set of <code>RefLikeType</code>s
-     * expected to be excluded from <code>p.getCaught()</code>.
-     *
-     * @param uncaughtIncluded the set of <code>RefLikeType</code>s
-     * expected to be in included in <code>p.getUncaught()</code>.
-     *
-     * @param uncaughtExcluded the set of <code>RefLikeType</code>s
-     * expected to be excluded from <code>p.getUncaught()</code>.
-     *
-     * @throws  AssertionFailedError if <code>s</code> does not
-     * contain the types in <code>included</code> except for those 
-     * in <code>excluded</code>.
-     */
-    public static void assertSameMembers(ThrowableSet.Pair p,
-            Set<? extends RefLikeType> caughtIncluded,
-            Set<AnySubType> caughtExcluded,
-            Set<? extends RefLikeType> uncaughtIncluded,
-            Set<AnySubType> uncaughtExcluded) {
-        assertSameMembers(p.getCaught(), caughtIncluded, caughtExcluded);
-        assertSameMembers(p.getUncaught(), uncaughtIncluded, uncaughtExcluded);
-    }
-
-
-    /**
-     * Asserts that the membership in the component sets of a
-     * ThrowableSet.Pair correspond to expectations.
-     *
-     * @param p The pair to be checked.
-     *
-     * @param caughtIncluded an array containing the {@link RefLikeType}s
-     * expected to be in included in <code>p.getCaught()</code>.
-     *
-     * @param caughtExcluded an array containing the <code>RefLikeType</code>s
-     * expected to be excluded from <code>p.getCaught()</code>.
-     *
-     * @param uncaughtIncluded an array containing the <code>RefLikeType</code>s
-     * expected to be in included in <code>p.getUncaught()</code>.
-     *
-     * @param uncaughtExcluded an array containing the <code>RefLikeType</code>s
-     * expected to be excluded from <code>p.getUncaught()</code>.
-     *
-     * @throws  AssertionFailedError if <code>s</code> does not
-     * contain the types in <code>included</code> except for those 
-     * in <code>excluded</code>.
-     */
-    public static void assertSameMembers(ThrowableSet.Pair p,
-            RefLikeType[] caughtIncluded,
-            AnySubType[] caughtExcluded,
-            RefLikeType[] uncaughtIncluded,
-            AnySubType[] uncaughtExcluded) {
-        assertSameMembers(p.getCaught(), caughtIncluded, caughtExcluded);
-        assertSameMembers(p.getUncaught(), uncaughtIncluded, uncaughtExcluded);
-    }
-
-
-    private ThrowableSet checkAdd(ThrowableSet lhs, Object rhs,
-            Set<RefLikeType> expectedIncluded, Set<AnySubType> expectedExcluded,
-            ThrowableSet actualResult) {
-        // Utility routine used by the next three add()s.
-
-        assertSameMembers(actualResult, expectedIncluded, expectedExcluded);
-        expectedSizeToSets.addAndCheck(expectedIncluded, expectedExcluded);
-        expectedMemoizations.checkAdd(lhs, rhs, actualResult);
-        return actualResult;
-    }
-
-    private ThrowableSet checkAdd(ThrowableSet lhs, Object rhs,
-            Set<RefLikeType> expectedResult, ThrowableSet actualResult) {
-        // Utility routine used by the next three add()s.
-        return checkAdd(lhs, rhs, expectedResult, Collections.<AnySubType>emptySet(), 
-                actualResult);
-    }
-
-
-    private ThrowableSet add(ThrowableSet lhs, ThrowableSet rhs, 
-            Set<RefLikeType> expectedIncluded, Set<AnySubType> expectedExcluded) {
-        // Add rhs to lhs, checking the results.
-
-        ThrowableSet actualResult = lhs.add(rhs);
-        return checkAdd(lhs, rhs, expectedIncluded, expectedExcluded, 
-                actualResult);
-    }
-
-    private ThrowableSet add(ThrowableSet lhs, ThrowableSet rhs, 
-            Set<RefLikeType> expectedResult) {
-        // Add rhs to lhs, checking the results.
-        return add(lhs, rhs, expectedResult, Collections.<AnySubType>emptySet());
-    }
-
-    private ThrowableSet add(ThrowableSet lhs, RefType rhs,
-            Set<RefLikeType> expectedResult) {
-        // Add rhs to lhs, checking the results.
-
-        ThrowableSet actualResult = lhs.add(rhs);
-        return checkAdd(lhs, rhs, expectedResult, actualResult);
-    }
-
-    private ThrowableSet add(ThrowableSet lhs, AnySubType rhs,
-            Set<RefLikeType> expectedResult) {
-        // Add rhs to lhs, checking the results.
-
-        ThrowableSet actualResult = lhs.add(rhs);
-        return checkAdd(lhs, rhs, expectedResult, actualResult);
-    }
-
-
-    @Test
-    public void test_01_InitialState() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestInitialState()");
-        }
-        assertTrue(expectedSizeToSets.match());
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-    @Test
-    public void test_02_SingleInstance0() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestSingleInstance0()");
-        }
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-        }));
-
-        ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
-                expected);
-        ThrowableSet set1 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
-                expected);
-        assertTrue("The same ThrowableSet object should represent two sets containing the same single class.",
-                set0 == set1);
-
-        Set<RefType> catchable = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-            util.RUNTIME_EXCEPTION,
-            util.EXCEPTION,
-            util.THROWABLE,
-        }));
-        assertEquals("Should be catchable only as UndeclaredThrowableException and its superclasses", 
-                catchable, util.catchableSubset(set0));
-
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        catchableAs = set0.whichCatchableAs(util.UNDECLARED_THROWABLE_EXCEPTION);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-    @Test
-    public void test_03_SingleInstance1() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestSingleInstance1()");
-        }
-        Set<RefLikeType> expected0 = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-        }));
-        Set<RefLikeType> expected1 = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
-        }));
-        Set<RefLikeType> expectedResult = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-            util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
-        }));
-
-        ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
-                expected0);
-        ThrowableSet set0a = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
-                expectedResult);
-        ThrowableSet set1 = add(mgr.EMPTY, 
-                util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
-                expected1);
-        ThrowableSet set1a = add(set1, util.UNDECLARED_THROWABLE_EXCEPTION,
-                expectedResult);
-
-        assertTrue("The same ThrowableSet object should represent two sets containing the same two exceptions, even if added in different orders.",
-                set0a == set1a);
-
-        Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(expectedResult);
-        catchable.add(util.RUNTIME_EXCEPTION);
-        catchable.add(util.EXCEPTION);
-        catchable.add(util.THROWABLE);
-        assertEquals("Should be catchable only as UndeclaredThrowableException "
-                + "UnsupportedLookAndFeelException and superclasses", 
-                catchable, util.catchableSubset(set0a));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_04_AddingSubclasses() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestAddingSubclasses()");
-        }
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>();
-        expected.add(util.INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        ThrowableSet set0 = add(mgr.EMPTY, util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
-                expected);
-
-        expected.clear();
-        expected.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
-        ThrowableSet set1 = add(mgr.EMPTY, 
-                AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
-                expected);
-        assertTrue("ThrowableSet should distinguish the case where a single exception includes subclasses from that where it does not.",
-                set0 != set1);
-
-        Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
-            util.RUNTIME_EXCEPTION,
-            util.EXCEPTION,
-            util.THROWABLE,
-        }));
-        assertEquals(catchable, util.catchableSubset(set0));
-
-        catchable.add(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        catchable.add(util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        assertEquals(catchable, util.catchableSubset(set1));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-    @Test
-    public void test_05_AddingSets0() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestAddingSets0()");
-        }
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
-        }));
-        ThrowableSet set0 = add(mgr.EMPTY, util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
-                expected);
-
-        expected.clear();
-        expected.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
-        ThrowableSet set1 = add(mgr.EMPTY,
-                AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
-                expected);
-
-        ThrowableSet result = add(set1, set0, expected);
-        assertTrue("{AnySubType(E)} union {E} should equal {AnySubType(E)}",
-                result == set1);
-
-        result = add(set1, set0, expected);
-        assertTrue("{E} union {AnySubType(E)} should equal {AnySubType(E)}",
-                result == set1);
-
-        if (DUMP_INTERNALS) {
-            System.err.println("testAddingSets0()");
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_06_AddingSets1() {
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(util.VM_ERRORS);
-        expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        ThrowableSet set0 = add(mgr.VM_ERRORS,
-                util.UNDECLARED_THROWABLE_EXCEPTION, expected);
-        expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        set0 = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION, expected);
-
-        ThrowableSet set1 = mgr.INITIALIZATION_ERRORS;
-        expected = new ExceptionHashSet<RefLikeType>();
-        expected.add(AnySubType.v(util.ERROR));
-        assertSameMembers(set1, expected, Collections.<AnySubType>emptySet());
-
-        expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        ThrowableSet result0 = add(set0, set1, expected);
-        ThrowableSet result1 = add(set1, set0, expected);
-        assertTrue("Adding sets should be commutative.", result0 == result1);
-
-        Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(util.ALL_TEST_ERRORS_PLUS_SUPERTYPES);
-        catchable.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        catchable.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        catchable.add(util.RUNTIME_EXCEPTION);// Superclasses of 
-        catchable.add(util.EXCEPTION);        // others.
-        catchable.add(util.ERROR);
-        catchable.add(util.THROWABLE);
-        assertEquals(catchable, util.catchableSubset(result0));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_07_AddingSets2() {
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(util.VM_ERRORS);
-        expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        ThrowableSet set0 = add(mgr.VM_ERRORS,
-                util.UNDECLARED_THROWABLE_EXCEPTION, expected);
-        expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        set0 = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION, expected);
-
-        ThrowableSet set1 = mgr.INITIALIZATION_ERRORS;
-        expected = new ExceptionHashSet<RefLikeType>();
-        expected.add(AnySubType.v(util.ERROR));
-        assertSameMembers(set1, expected, Collections.<AnySubType>emptySet());
-
-        expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        ThrowableSet result0 = add(set0, set1, expected);
-        ThrowableSet result1 = add(set1, set0, expected);
-        assertTrue("Adding sets should be commutative.", result0 == result1);
-
-        Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(util.ALL_TEST_ERRORS_PLUS_SUPERTYPES);
-        catchable.add(util.UNDECLARED_THROWABLE_EXCEPTION);
-        catchable.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
-        catchable.add(util.RUNTIME_EXCEPTION);// Superclasses of 
-        catchable.add(util.EXCEPTION);        // others.
-        catchable.add(util.ERROR);
-        catchable.add(util.THROWABLE);
-        assertEquals(catchable, util.catchableSubset(result0));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_08_WhichCatchable0() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchable0()");
-        }
-        Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-        }));
-
-        ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
-                expected);
-        Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.UNDECLARED_THROWABLE_EXCEPTION,
-            util.RUNTIME_EXCEPTION,
-            util.EXCEPTION,
-            util.THROWABLE,
-        }));
-
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(catchable, util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.UNDECLARED_THROWABLE_EXCEPTION));
-        catchableAs = set0.whichCatchableAs(util.UNDECLARED_THROWABLE_EXCEPTION);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.RUNTIME_EXCEPTION));
-        catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.EXCEPTION));
-        catchableAs = set0.whichCatchableAs(util.EXCEPTION);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.THROWABLE));
-        catchableAs = set0.whichCatchableAs(util.THROWABLE);
-        assertEquals(catchableAs.getCaught(), set0);
-        assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
-        assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.ERROR));
-        catchableAs = set0.whichCatchableAs(util.ERROR);
-        assertEquals(catchableAs.getCaught(), mgr.EMPTY);
-        assertEquals(catchableAs.getUncaught(), set0);
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(catchable, util.catchableSubset(catchableAs.getUncaught()));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_09_WhichCatchable1() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchable1()");
-        }
-        ThrowableSet set0 = mgr.EMPTY.add(util.LINKAGE_ERROR);
-        Set<RefType> catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.LINKAGE_ERROR,
-            util.ERROR,
-            util.THROWABLE,
-        }));
-
-        assertTrue(set0.catchableAs(util.ERROR));
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ERROR);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(catcherTypes, 
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(catcherTypes,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(catcherTypes,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.INSTANTIATION_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INSTANTIATION_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(catcherTypes, 
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.INTERNAL_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INTERNAL_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(catcherTypes,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_10_WhichCatchable2() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchable2()");
-        }
-
-        ThrowableSet set0 = mgr.EMPTY.add(AnySubType.v(util.LINKAGE_ERROR));
-        Set<RefType> catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-            util.ABSTRACT_METHOD_ERROR,
-            util.ILLEGAL_ACCESS_ERROR,
-            util.INSTANTIATION_ERROR,
-            util.NO_SUCH_FIELD_ERROR,
-            util.NO_SUCH_METHOD_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.LINKAGE_ERROR,
-            util.ERROR,
-            util.THROWABLE,
-        }));
-
-        assertTrue(set0.catchableAs(util.ERROR));
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ERROR);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(catcherTypes, 
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET, 
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(catcherTypes, 
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
-        Set<AnySubType> expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
-        Set<AnySubType> expectedCaughtExcluded = Collections.emptySet();
-        Set<AnySubType> expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.LINKAGE_ERROR)}));
-        Set<AnySubType> expectedUncaughtExcluded = expectedCaughtIncluded;
-        assertSameMembers(catchableAs,
-                expectedCaughtIncluded, 
-                expectedCaughtExcluded,
-                expectedUncaughtIncluded, 
-                expectedUncaughtExcluded);
-        catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                     util.ABSTRACT_METHOD_ERROR,
-                     util.ILLEGAL_ACCESS_ERROR,
-                     util.INSTANTIATION_ERROR,
-                     util.NO_SUCH_FIELD_ERROR,
-                     util.NO_SUCH_METHOD_ERROR,
-                     util.LINKAGE_ERROR,
-                     util.ERROR,
-                     util.THROWABLE,
-        }));
-        Set<RefType> noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.LINKAGE_ERROR,
-            util.ERROR,
-            util.THROWABLE,
-        }));
-        assertEquals(catcherTypes,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(noncatcherTypes,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.INSTANTIATION_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INSTANTIATION_ERROR);
-        expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.INSTANTIATION_ERROR)}));
-        expectedCaughtExcluded = Collections.emptySet();
-        expectedUncaughtExcluded = expectedCaughtIncluded;
-        assertSameMembers(catchableAs,
-                expectedCaughtIncluded, 
-                expectedCaughtExcluded,
-                expectedUncaughtIncluded, 
-                expectedUncaughtExcluded);
-        catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.INSTANTIATION_ERROR,
-                     util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                     util.LINKAGE_ERROR,
-                     util.ERROR,
-                     util.THROWABLE,
-        }));
-        noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.CLASS_CIRCULARITY_ERROR,
-                        util.CLASS_FORMAT_ERROR,
-                        util.UNSUPPORTED_CLASS_VERSION_ERROR,
-                        util.EXCEPTION_IN_INITIALIZER_ERROR,
-                        util.ABSTRACT_METHOD_ERROR,
-                        util.ILLEGAL_ACCESS_ERROR,
-                        util.NO_SUCH_FIELD_ERROR,
-                        util.NO_SUCH_METHOD_ERROR,
-                        util.NO_CLASS_DEF_FOUND_ERROR,
-                        util.UNSATISFIED_LINK_ERROR,
-                        util.VERIFY_ERROR,
-                        util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                        util.LINKAGE_ERROR,
-                        util.ERROR,
-                        util.THROWABLE,
-        }));
-        assertEquals(catcherTypes,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(noncatcherTypes,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.INTERNAL_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INTERNAL_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.CLASS_CIRCULARITY_ERROR,
-                        util.CLASS_FORMAT_ERROR,
-                        util.UNSUPPORTED_CLASS_VERSION_ERROR,
-                        util.EXCEPTION_IN_INITIALIZER_ERROR,
-                        util.ABSTRACT_METHOD_ERROR,
-                        util.ILLEGAL_ACCESS_ERROR,
-                        util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                        util.NO_SUCH_FIELD_ERROR,
-                        util.NO_SUCH_METHOD_ERROR,
-                        util.INSTANTIATION_ERROR,
-                        util.NO_CLASS_DEF_FOUND_ERROR,
-                        util.UNSATISFIED_LINK_ERROR,
-                        util.VERIFY_ERROR,
-                        util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                        util.LINKAGE_ERROR,
-                        util.ERROR,
-                        util.THROWABLE,
-        }));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(noncatcherTypes,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_11_WhichCatchable3() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchable3()");
-        }
-
-        ThrowableSet set0 = mgr.EMPTY;
-        set0 = set0.add(AnySubType.v(util.ERROR));
-
-        assertTrue(set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
-        Set<AnySubType> expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
-        Set<AnySubType> expectedCaughtExcluded = Collections.emptySet();
-        Set<AnySubType> expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.ERROR)}));
-        Set<AnySubType> expectedUncaughtExcluded = expectedCaughtIncluded;
-        assertTrue(ExceptionTestUtility.sameMembers(expectedCaughtIncluded, 
-                    expectedCaughtExcluded,
-                    catchableAs.getCaught()));
-        assertTrue(ExceptionTestUtility.sameMembers(expectedUncaughtIncluded, 
-                    expectedUncaughtExcluded,
-                    catchableAs.getUncaught()));
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.LINKAGE_ERROR,
-            util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-            util.ABSTRACT_METHOD_ERROR,
-            util.INSTANTIATION_ERROR,
-            util.ILLEGAL_ACCESS_ERROR,
-            util.NO_SUCH_FIELD_ERROR,
-            util.NO_SUCH_METHOD_ERROR,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.AWT_ERROR,
-            util.LINKAGE_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        set0 = catchableAs.getUncaught();
-
-        assertTrue(set0.catchableAs(util.THROWABLE));
-        catchableAs = set0.whichCatchableAs(util.THROWABLE);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.AWT_ERROR,
-            util.LINKAGE_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.ERROR));
-        catchableAs = set0.whichCatchableAs(util.ERROR);
-        assertEquals(set0, catchableAs.getCaught());
-        assertEquals(mgr.EMPTY, catchableAs.getUncaught());
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.AWT_ERROR,
-            util.LINKAGE_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
-        expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.LINKAGE_ERROR)}));
-        expectedCaughtExcluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
-        expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
-                Arrays.asList(new AnySubType[] 
-                    {AnySubType.v(util.ERROR)}));
-        expectedUncaughtExcluded = expectedCaughtIncluded;
-        assertTrue(ExceptionTestUtility.sameMembers(expectedCaughtIncluded, 
-                    expectedCaughtExcluded,
-                    catchableAs.getCaught()));
-        assertTrue(ExceptionTestUtility.sameMembers(expectedUncaughtIncluded, 
-                    expectedUncaughtExcluded,
-                    catchableAs.getUncaught()));
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.LINKAGE_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.AWT_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        assertTrue(! set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
-        catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.LINKAGE_ERROR,
-            util.AWT_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        catchableAs = set0.whichCatchableAs(util.ILLEGAL_ACCESS_ERROR);
-        assertEquals(mgr.EMPTY, catchableAs.getCaught());
-        assertEquals(set0, catchableAs.getUncaught());
-        assertEquals(Collections.EMPTY_SET,
-                util.catchableSubset(catchableAs.getCaught()));
-        assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.LINKAGE_ERROR,
-            util.AWT_ERROR,
-            util.THREAD_DEATH,
-            util.VIRTUAL_MACHINE_ERROR,
-            util.INTERNAL_ERROR,
-            util.OUT_OF_MEMORY_ERROR,
-            util.STACK_OVERFLOW_ERROR,
-            util.CLASS_CIRCULARITY_ERROR,
-            util.CLASS_FORMAT_ERROR,
-            util.UNSUPPORTED_CLASS_VERSION_ERROR,
-            util.EXCEPTION_IN_INITIALIZER_ERROR,
-            util.NO_CLASS_DEF_FOUND_ERROR,
-            util.UNSATISFIED_LINK_ERROR,
-            util.VERIFY_ERROR,
-            util.UNKNOWN_ERROR,})),
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        if (DUMP_INTERNALS) {
-            printAllSets();
-        }
-    }
-
-
-    @Test
-    public void test_12_WhichCatchable10() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchable3()");
-        }
-
-        ThrowableSet set0 = mgr.EMPTY;
-        set0 = set0.add(AnySubType.v(util.THROWABLE));
-
-        assertTrue(set0.catchableAs(util.ARITHMETIC_EXCEPTION));
-        ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ARITHMETIC_EXCEPTION);
-        assertSameMembers(catchableAs,
-                new RefLikeType[] {
-                    AnySubType.v(util.ARITHMETIC_EXCEPTION),
-                }, 
-                new AnySubType[] {
-                },
-                new RefLikeType[] {
-                    AnySubType.v(util.THROWABLE),
-                }, 
-                new AnySubType[] {
-                    AnySubType.v(util.ARITHMETIC_EXCEPTION),
-                });
-        assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.THROWABLE,
-            util.EXCEPTION,
-            util.RUNTIME_EXCEPTION,
-            util.ARITHMETIC_EXCEPTION,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        HashSet<RefLikeType> expectedUncaught = new HashSet<RefLikeType>(util.ALL_TEST_THROWABLES);
-        expectedUncaught.remove(util.ARITHMETIC_EXCEPTION);
-        assertEquals(expectedUncaught,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        set0 = catchableAs.getUncaught();
-        assertTrue(set0.catchableAs(util.ABSTRACT_METHOD_ERROR));
-        catchableAs = set0.whichCatchableAs(util.ABSTRACT_METHOD_ERROR);
-        assertSameMembers(catchableAs,
-                new RefLikeType[] {
-                    AnySubType.v(util.ABSTRACT_METHOD_ERROR),
-                },
-                new AnySubType[] {
-                },
-                new RefLikeType[] {
-                    AnySubType.v(util.THROWABLE),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.ARITHMETIC_EXCEPTION),
-            AnySubType.v(util.ABSTRACT_METHOD_ERROR),
-                });
-        assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.THROWABLE,
-            util.ERROR,
-            util.LINKAGE_ERROR,
-            util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-            util.ABSTRACT_METHOD_ERROR,})),
-                util.catchableSubset(catchableAs.getCaught()));
-        expectedUncaught.remove(util.ABSTRACT_METHOD_ERROR);
-        assertEquals(expectedUncaught,
-                util.catchableSubset(catchableAs.getUncaught()));
-
-        set0 = catchableAs.getUncaught();
-        assertTrue(set0.catchableAs(util.RUNTIME_EXCEPTION));
-        catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
-        assertSameMembers(catchableAs,
-                new RefLikeType[] {
-                    AnySubType.v(util.RUNTIME_EXCEPTION),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.ARITHMETIC_EXCEPTION),
-                },
-                new RefLikeType[] {
-                    AnySubType.v(util.THROWABLE),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.RUNTIME_EXCEPTION),
-            AnySubType.v(util.ABSTRACT_METHOD_ERROR),
-                });
-        assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
-            util.THROWABLE,
-            util.EXCEPTION,
-            util.RUNTIME_EXCEPTION,
-            util.ARRAY_STORE_EXCEPTION,
-            util.CLASS_CAST_EXCEPTION,
-            util.ILLEGAL_MONITOR_STATE_EXCEPTION,
-            util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
-            util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION,
-            util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION,
-            util.NEGATIVE_ARRAY_SIZE_EXCEPTION,
-            util.NULL_POINTER_EXCEPTION,
-            util.UNDECLARED_THROWABLE_EXCEPTION})),
-                util.catchableSubset(catchableAs.getCaught()));
-        expectedUncaught.remove(util.RUNTIME_EXCEPTION);
-        expectedUncaught.remove(util.ARRAY_STORE_EXCEPTION);
-        expectedUncaught.remove(util.CLASS_CAST_EXCEPTION);
-        expectedUncaught.remove(util.ILLEGAL_MONITOR_STATE_EXCEPTION);
-        expectedUncaught.remove(util.INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        expectedUncaught.remove(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        expectedUncaught.remove(util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        expectedUncaught.remove(util.NEGATIVE_ARRAY_SIZE_EXCEPTION);
-        expectedUncaught.remove(util.NULL_POINTER_EXCEPTION);
-        expectedUncaught.remove(util.UNDECLARED_THROWABLE_EXCEPTION);
-        assertEquals(expectedUncaught,
-                util.catchableSubset(catchableAs.getUncaught()));
-    }
-
-
-    @Test
-    public void test_13_AddAfterWhichCatchableAs0() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestAddAfterWhichCatchable0()");
-        }
-
-        ThrowableSet anyError = mgr.EMPTY.add(AnySubType.v(util.ERROR));
-
-        assertTrue(anyError.catchableAs(util.LINKAGE_ERROR));
-        ThrowableSet.Pair catchableAs = anyError.whichCatchableAs(util.LINKAGE_ERROR);
-        assertSameMembers(catchableAs,
-                new RefLikeType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                }, 
-                new AnySubType[] {
-                },
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-                }, 
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-
-        ThrowableSet anyErrorMinusLinkage = catchableAs.getUncaught();
-        try {
-            ThrowableSet anyErrorMinusLinkagePlusIncompatibleClassChange
-                = anyErrorMinusLinkage.add(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
-            fail("add(IncompatiableClassChangeError) after removing LinkageError should currently generate an exception");
-
-            // Following documents what we would like to be able to implement:
-            assertSameMembers(anyErrorMinusLinkagePlusIncompatibleClassChange,
-                    new RefLikeType[] {
-                        AnySubType.v(util.ERROR),
-                util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
-                    },
-                    new AnySubType[] {
-                        AnySubType.v(util.LINKAGE_ERROR),
-                    });
-        } catch (ThrowableSet.AlreadyHasExclusionsException e) {
-            // this is what should happen.
-        }
-
-        try {
-            ThrowableSet anyErrorMinusLinkagePlusAnyIncompatibleClassChange
-                = anyErrorMinusLinkage.add(AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
-            fail("add(AnySubType.v(IncompatiableClassChangeError)) after removing LinkageError should currently generate an exception");
-
-            // Following documents what we would like to be able to implement:
-            assertSameMembers(anyErrorMinusLinkagePlusAnyIncompatibleClassChange,
-                    new RefLikeType[] {
-                        AnySubType.v(util.ERROR),
-                AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR),
-                    },
-                    new AnySubType[] {
-                        AnySubType.v(util.LINKAGE_ERROR),
-                    });
-        } catch (ThrowableSet.AlreadyHasExclusionsException e) {
-            // this is what should happen.
-        }
-
-        // Add types that should not change the set.
-        ThrowableSet sameSet
-            = anyErrorMinusLinkage.add(util.VIRTUAL_MACHINE_ERROR);
-        assertTrue(sameSet == anyErrorMinusLinkage);
-        assertSameMembers(sameSet,
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-        sameSet
-            = anyErrorMinusLinkage.add(AnySubType.v(util.VIRTUAL_MACHINE_ERROR));
-        assertTrue(sameSet == anyErrorMinusLinkage);
-        assertSameMembers(sameSet,
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-
-        ThrowableSet anyErrorMinusLinkagePlusArrayIndex
-            = anyErrorMinusLinkage.add(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        assertSameMembers(anyErrorMinusLinkagePlusArrayIndex,
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-            util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION,
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-
-        ThrowableSet anyErrorMinusLinkagePlusAnyIndex
-            = anyErrorMinusLinkagePlusArrayIndex.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
-        assertSameMembers(anyErrorMinusLinkagePlusAnyIndex,
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-            AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-
-        ThrowableSet anyErrorMinusLinkagePlusAnyRuntime
-            = anyErrorMinusLinkagePlusAnyIndex.add(AnySubType.v(util.RUNTIME_EXCEPTION));
-        assertSameMembers(anyErrorMinusLinkagePlusAnyRuntime,
-                new RefLikeType[] {
-                    AnySubType.v(util.ERROR),
-            AnySubType.v(util.RUNTIME_EXCEPTION),
-                },
-                new AnySubType[] {
-                    AnySubType.v(util.LINKAGE_ERROR),
-                });
-
-        try {
-            ThrowableSet anyErrorMinusLinkagePlusAnyRuntimePlusError
-                = anyErrorMinusLinkagePlusAnyRuntime.add(AnySubType.v(util.ERROR));
-            fail("add(AnySubType(Error)) after removing LinkageError should currently generate an exception.");
-
-            // This documents what we would like to implement:
-            assertSameMembers(anyErrorMinusLinkagePlusAnyRuntimePlusError,
-                    new RefLikeType[] {
-                        AnySubType.v(util.ERROR),
-                AnySubType.v(util.RUNTIME_EXCEPTION),
-                    },
-                    new AnySubType[] {
-                    });
-        } catch (ThrowableSet.AlreadyHasExclusionsException e) {
-            // This is what should happen.
-        }
-
-        try {
-            ThrowableSet anyErrorMinusLinkagePlusAnyRuntimePlusLinkageError
-                = anyErrorMinusLinkagePlusAnyRuntime.add(AnySubType.v(util.LINKAGE_ERROR));
-            fail("add(AnySubType(LinkageError)) after removing LinkageError should currently generate an exception.");
-
-            // This documents what we would like to implement:
-            assertSameMembers(anyErrorMinusLinkagePlusAnyRuntimePlusLinkageError,
-                    new RefLikeType[] {
-                        AnySubType.v(util.ERROR),
-                AnySubType.v(util.RUNTIME_EXCEPTION),
-                    },
-                    new AnySubType[] {
-                    });
-        } catch (ThrowableSet.AlreadyHasExclusionsException e) {
-            // This is what should happen.
-        }
-
-    }
-
-    @Test
-    public void test_14_WhichCatchablePhantom0() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchablePhantom0()");
-        }
-
-        ThrowableSet anyError = mgr.EMPTY.add(AnySubType.v(util.ERROR));
-        
-        assertSameMembers(anyError.whichCatchableAs(util.LINKAGE_ERROR),
-        		new RefLikeType[] { AnySubType.v(util.LINKAGE_ERROR) },
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.ERROR) },
-        		new AnySubType[] { AnySubType.v(util.LINKAGE_ERROR) });
-        assertSameMembers(anyError.whichCatchableAs(util.PHANTOM_EXCEPTION1),
-        		new RefLikeType[] {},
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.ERROR) },
-        		new AnySubType[] {});
-        
-        assertTrue(anyError.catchableAs(util.LINKAGE_ERROR));
-        assertFalse(anyError.catchableAs(util.PHANTOM_EXCEPTION1));
-        
-        ThrowableSet phantomOnly = mgr.EMPTY.add(util.PHANTOM_EXCEPTION1);
-        
-        assertSameMembers(phantomOnly.whichCatchableAs(util.LINKAGE_ERROR),
-        		new RefLikeType[] {},
-        		new AnySubType[] {},
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
-        		new AnySubType[] {});
-        assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION2),
-        		new RefLikeType[] {},
-        		new AnySubType[] {},
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
-        		new AnySubType[] {});
-        assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION1),
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
-        		new AnySubType[] {},
-        		new RefLikeType[] {},
-        		new AnySubType[] {});
-        
-        assertFalse(phantomOnly.catchableAs(util.LINKAGE_ERROR));
-        assertTrue(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION1));
-        assertFalse(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION2));
-        
-        ThrowableSet bothPhantoms = phantomOnly.add(util.PHANTOM_EXCEPTION2);
-
-        assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION1),
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
-        		new AnySubType[] {},
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION2 },
-        		new AnySubType[] {});
-        assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION2),
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION2 },
-        		new AnySubType[] {},
-        		new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
-        		new AnySubType[] {});
-        
-        assertFalse(bothPhantoms.catchableAs(util.LINKAGE_ERROR));
-        assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION1));
-        assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION2));
-
-        ThrowableSet bothPhantoms2 = phantomOnly.add(util.PHANTOM_EXCEPTION2);
-        assertTrue(bothPhantoms == bothPhantoms2);
-
-        ThrowableSet throwableOnly = mgr.EMPTY.add(util.THROWABLE);
-        assertFalse(throwableOnly.catchableAs(util.PHANTOM_EXCEPTION1));
-
-        ThrowableSet allThrowables = mgr.EMPTY.add(AnySubType.v(util.THROWABLE));
-        assertTrue(allThrowables.catchableAs(util.PHANTOM_EXCEPTION1));
-    }
-
-    @Test
-    public void test_14_WhichCatchablePhantom1() {
-        if (DUMP_INTERNALS) {
-            System.err.println("\n\ntestWhichCatchablePhantom1()");
-        }
-
-        ThrowableSet phantomOnly = mgr.EMPTY.add(AnySubType.v(util.PHANTOM_EXCEPTION1));
-        
-        assertSameMembers(phantomOnly.whichCatchableAs(util.LINKAGE_ERROR),
-        		new RefLikeType[] {},
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
-        		new AnySubType[] {});
-        assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION2),
-        		new RefLikeType[] {},
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
-        		new AnySubType[] {});
-        assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION1),
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
-        		new AnySubType[] {},
-        		new RefLikeType[] {},
-        		new AnySubType[] {});
-        
-        assertFalse(phantomOnly.catchableAs(util.LINKAGE_ERROR));
-        assertTrue(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION1));
-        assertFalse(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION2));
-        
-        ThrowableSet bothPhantoms = phantomOnly.add(AnySubType.v(util.PHANTOM_EXCEPTION2));
-
-        assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION1),
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION2) },
-        		new AnySubType[] {});
-        assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION2),
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION2) },
-        		new AnySubType[] {},
-        		new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
-        		new AnySubType[] {});
-        
-        assertFalse(bothPhantoms.catchableAs(util.LINKAGE_ERROR));
-        assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION1));
-        assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION2));
-
-        ThrowableSet bothPhantoms2 = phantomOnly.add(AnySubType.v(util.PHANTOM_EXCEPTION2));
-        assertTrue(bothPhantoms == bothPhantoms2);
-    }
-
-    void printAllSets() {
-        for (List <ThrowableSet> sizeList : mgr.getSizeToSets().values()) {
-            for (ThrowableSet s : sizeList) {
-                System.err.println(s.toString());
-                System.err.println("\n\tMemoized Adds:");
-                for (Map.Entry<Object, ThrowableSet> entry : s.getMemoizedAdds().entrySet()) {
-                    System.err.print(' ');
-                    if (entry.getKey() instanceof ThrowableSet) {
-                        System.err.print(((ThrowableSet) entry.getKey()).toBriefString());
-                    } else {
-                        System.err.print(entry.getKey().toString());
-                    }
-                    System.err.print('=');
-                    System.err.print(((ThrowableSet) entry.getValue()).toBriefString());
-                    System.err.print('\n');
-                        }
-            }
-        }
-    }
-
-
-    /*
+	static {
+		Scene.v().loadBasicClasses();
+	}
+
+	final static boolean DUMP_INTERNALS = false;
+	final ThrowableSet.Manager mgr = ThrowableSet.Manager.v();
+
+
+	// A class for verifying that the sizeToSetsMap
+	// follows our expectations.
+	static class ExpectedSizeToSets {
+		private Map<Integer, Set<SetPair>> expectedMap = new HashMap<Integer, Set<SetPair>>(); // from Integer to Set.
+
+		private static class SetPair {
+			Set<RefLikeType> included;
+			Set<AnySubType> excluded;
+
+			SetPair(Set<RefLikeType> included, Set<AnySubType> excluded) {
+				this.included = included;
+				this.excluded = excluded;
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				if (o == this) {
+					return true;
+				}
+				if (! (o instanceof SetPair)) {
+					return false;
+				}
+				SetPair sp = (SetPair) o;
+				return (   this.included.equals(sp.included)
+						&& this.excluded.equals(sp.excluded));
+			}
+
+			@Override
+			public int hashCode() {
+				int result = 31;
+				result = (37 * result) + included.hashCode();
+				result = (37 * result) + excluded.hashCode();
+				return result;
+			}
+
+			@Override
+			public String toString() {
+				return (  super.toString()
+						+ System.getProperty("line.separator")
+						+ "+[" + included.toString() + ']'
+						+ "-[" + excluded.toString() + ']');
+			}
+		}
+
+		ExpectedSizeToSets() {
+			// The empty set.
+			this.add(Collections.<RefLikeType>emptySet(), Collections.<AnySubType>emptySet());
+
+			// All Throwables set.
+			Set<RefLikeType> temp = new ExceptionHashSet<RefLikeType>();
+			temp.add(AnySubType.v(Scene.v().getRefType("java.lang.Throwable")));
+			this.add(temp, Collections.<AnySubType>emptySet());
+
+			// VM errors set.
+			temp = new ExceptionHashSet<RefLikeType>();
+			temp.add(Scene.v().getRefType("java.lang.InternalError"));
+			temp.add(Scene.v().getRefType("java.lang.OutOfMemoryError"));
+			temp.add(Scene.v().getRefType("java.lang.StackOverflowError"));
+			temp.add(Scene.v().getRefType("java.lang.UnknownError"));
+			temp.add(Scene.v().getRefType("java.lang.ThreadDeath"));
+			this.add(temp, Collections.<AnySubType>emptySet());
+
+			// Resolve Class errors set.
+			Set<RefLikeType> classErrors = new ExceptionHashSet<RefLikeType>();
+			classErrors.add(Scene.v().getRefType("java.lang.ClassCircularityError"));
+			classErrors.add(AnySubType.v(Scene.v().getRefType("java.lang.ClassFormatError")));
+			classErrors.add(Scene.v().getRefType("java.lang.IllegalAccessError"));
+			classErrors.add(Scene.v().getRefType("java.lang.IncompatibleClassChangeError"));
+			classErrors.add(Scene.v().getRefType("java.lang.LinkageError"));
+			classErrors.add(Scene.v().getRefType("java.lang.NoClassDefFoundError"));
+			classErrors.add(Scene.v().getRefType("java.lang.VerifyError"));
+			this.add(classErrors, Collections.<AnySubType>emptySet());
+
+			// Resolve Field errors set.
+			temp = new ExceptionHashSet<RefLikeType>(classErrors);
+			temp.add(Scene.v().getRefType("java.lang.NoSuchFieldError"));
+			this.add(temp, Collections.<AnySubType>emptySet());
+
+			// Resolve method errors set.
+			temp = new ExceptionHashSet<RefLikeType>(classErrors);
+			temp.add(Scene.v().getRefType("java.lang.AbstractMethodError"));
+			temp.add(Scene.v().getRefType("java.lang.NoSuchMethodError"));
+			temp.add(Scene.v().getRefType("java.lang.UnsatisfiedLinkError"));
+			this.add(temp, Collections.<AnySubType>emptySet());
+
+			// Initialization errors set.
+			temp = new ExceptionHashSet<RefLikeType>();
+			temp.add(AnySubType.v(Scene.v().getRefType("java.lang.Error")));
+			this.add(temp, Collections.<AnySubType>emptySet());
+		}
+
+		void add(Set<RefLikeType> inclusions, Set<AnySubType> exclusions) {
+			int key = inclusions.size() + exclusions.size();
+			Set<SetPair> values = expectedMap.get(key);
+			if (values == null) {
+				values = new HashSet<SetPair>();
+				expectedMap.put(key, values);
+			}
+			// Make sure we have our own copies of the sets.
+			values.add(newSetPair(inclusions,exclusions));
+		}
+
+		void addAndCheck(Set<RefLikeType> inclusions, Set<AnySubType> exclusions) {
+			add(inclusions, exclusions);
+			assertTrue(match());
+		}
+
+		SetPair newSetPair(Collection<RefLikeType> inclusions, Collection<AnySubType> exclusions) {
+			return new SetPair(new ExceptionHashSet<RefLikeType>(inclusions),
+					new ExceptionHashSet<AnySubType>(exclusions));
+		}
+
+		boolean match() {
+			final Collection<ThrowableSet> toCompare = ThrowableSet.Manager.v().getThrowableSets();
+
+			int sum = 0;
+			for (Collection<SetPair> expectedValues : expectedMap.values()) {
+				sum += expectedValues.size();
+			}
+			assertEquals(sum, toCompare.size());
+
+			for (ThrowableSet actual : toCompare) {
+				Collection<RefLikeType> included = actual.typesIncluded();
+				Collection<AnySubType> excluded = actual.typesExcluded();
+				
+				SetPair actualPair = newSetPair(included, excluded);
+				int key = included.size() + excluded.size();
+				assertTrue("Undefined SetPair found", expectedMap.get(key).contains(actualPair));
+			}
+			boolean result = true;
+
+			if (DUMP_INTERNALS) {
+				if (! result) System.err.println("!!!ExpectedSizeToSets.match() FAILED!!!");
+				System.err.println("expectedMap:");
+				System.err.println(expectedMap);
+				System.err.println("actualMap:");
+				System.err.println(toCompare);
+				System.err.flush();
+			}
+			return result;
+		}
+	}
+	private static ExpectedSizeToSets expectedSizeToSets;
+
+	// A class to check that memoized results match what we expect.
+	// Admittedly, this amounts to a reimplementation of the memoized
+	// structures within ThrowableSet -- I'm hoping that the two
+	// implementations will have different bugs!
+	static class ExpectedMemoizations  {
+		Map<ThrowableSet, Map<Object, ThrowableSet>> throwableSetToMemoized =
+				new HashMap<ThrowableSet, Map<Object, ThrowableSet>>();
+
+		void checkAdd(ThrowableSet lhs, Object rhs, ThrowableSet result) {
+			// rhs should be either a ThrowableSet or a RefType.
+			Map<Object, ThrowableSet> actualMemoized = lhs.getMemoizedAdds();
+			assertTrue(actualMemoized.get(rhs) == result);
+
+			Map<Object, ThrowableSet> expectedMemoized = throwableSetToMemoized.get(lhs);
+			if (expectedMemoized == null) {
+				expectedMemoized = new HashMap<Object, ThrowableSet>();
+				throwableSetToMemoized.put(lhs, expectedMemoized);
+			}
+			expectedMemoized.put(rhs, result);
+			assertEquals(expectedMemoized, actualMemoized);
+		}
+	}
+	private static ExpectedMemoizations expectedMemoizations;
+
+	private static ExceptionTestUtility util;
+
+	@BeforeClass
+	public static void setUp() {
+		expectedSizeToSets = new ExpectedSizeToSets();
+		expectedMemoizations = new ExpectedMemoizations();
+		util = new ExceptionTestUtility(System.getProperty("sun.boot.class.path"));
+	}
+
+	/**
+	 * Asserts that the membership in the component sets of a
+	 * ThrowableSet correspond to expectations.
+	 *
+	 * @param s The set to be checked.
+	 *
+	 * @param included the {@link Set} of RefLikeTypes
+	 * expected to be in included in <code>s</code>.
+	 *
+	 * @param excluded an {@link Set} of RefLikeTypes
+	 * expected to be excluded from <code>s</code>.
+	 *
+	 * @throws  AssertionFailedError if <code>s</code> does not
+	 * contain the types in <code>included</code> except for those
+	 * in <code>excluded</code>.
+	 */
+	public static void assertSameMembers(ThrowableSet s,
+			Set<? extends RefLikeType> included,
+			Set<AnySubType> excluded) {
+		assertTrue(ExceptionTestUtility.sameMembers(included, excluded, s));
+	}
+
+
+	/**
+	 * Asserts that the membership in the component sets of a
+	 * ThrowableSet correspond to expectations.
+	 *
+	 * @param s The set to be checked.
+	 *
+	 * @param included an array containing the RefLikeTypes
+	 * expected to be in included in <code>s</code>.
+	 *
+	 * @param excluded an array containing the RefLikeTypes
+	 * expected to be excluded from <code>s</code>.
+	 *
+	 * @throws  AssertionFailedError if <code>s</code> does not
+	 * contain the types in <code>included</code> except for those
+	 * in <code>excluded</code>.
+	 */
+	public static void assertSameMembers(ThrowableSet s,
+			RefLikeType[] included,
+			AnySubType[] excluded) {
+		assertTrue(ExceptionTestUtility.sameMembers(
+				new ExceptionHashSet<RefLikeType>(Arrays.asList(included)),
+				new ExceptionHashSet<AnySubType>(Arrays.asList(excluded)),
+				s));
+	}
+
+
+	/**
+	 * Asserts that the membership in the component sets of a
+	 * ThrowableSet.Pair correspond to expectations.
+	 *
+	 * @param p The pair to be checked.
+	 *
+	 * @param caughtIncluded the set of {@link RefLikeType}s
+	 * expected to be in included in <code>p.getCaught()</code>.
+	 *
+	 * @param caughtExcluded the set of <code>RefLikeType</code>s
+	 * expected to be excluded from <code>p.getCaught()</code>.
+	 *
+	 * @param uncaughtIncluded the set of <code>RefLikeType</code>s
+	 * expected to be in included in <code>p.getUncaught()</code>.
+	 *
+	 * @param uncaughtExcluded the set of <code>RefLikeType</code>s
+	 * expected to be excluded from <code>p.getUncaught()</code>.
+	 *
+	 * @throws  AssertionFailedError if <code>s</code> does not
+	 * contain the types in <code>included</code> except for those
+	 * in <code>excluded</code>.
+	 */
+	public static void assertSameMembers(ThrowableSet.Pair p,
+			Set<? extends RefLikeType> caughtIncluded,
+			Set<AnySubType> caughtExcluded,
+			Set<? extends RefLikeType> uncaughtIncluded,
+			Set<AnySubType> uncaughtExcluded) {
+		assertSameMembers(p.getCaught(), caughtIncluded, caughtExcluded);
+		assertSameMembers(p.getUncaught(), uncaughtIncluded, uncaughtExcluded);
+	}
+
+
+	/**
+	 * Asserts that the membership in the component sets of a
+	 * ThrowableSet.Pair correspond to expectations.
+	 *
+	 * @param p The pair to be checked.
+	 *
+	 * @param caughtIncluded an array containing the {@link RefLikeType}s
+	 * expected to be in included in <code>p.getCaught()</code>.
+	 *
+	 * @param caughtExcluded an array containing the <code>RefLikeType</code>s
+	 * expected to be excluded from <code>p.getCaught()</code>.
+	 *
+	 * @param uncaughtIncluded an array containing the <code>RefLikeType</code>s
+	 * expected to be in included in <code>p.getUncaught()</code>.
+	 *
+	 * @param uncaughtExcluded an array containing the <code>RefLikeType</code>s
+	 * expected to be excluded from <code>p.getUncaught()</code>.
+	 *
+	 * @throws  AssertionFailedError if <code>s</code> does not
+	 * contain the types in <code>included</code> except for those
+	 * in <code>excluded</code>.
+	 */
+	public static void assertSameMembers(ThrowableSet.Pair p,
+			RefLikeType[] caughtIncluded,
+			AnySubType[] caughtExcluded,
+			RefLikeType[] uncaughtIncluded,
+			AnySubType[] uncaughtExcluded) {
+		assertSameMembers(p.getCaught(), caughtIncluded, caughtExcluded);
+		assertSameMembers(p.getUncaught(), uncaughtIncluded, uncaughtExcluded);
+	}
+
+
+	private ThrowableSet checkAdd(ThrowableSet lhs, Object rhs,
+			Set<RefLikeType> expectedIncluded, Set<AnySubType> expectedExcluded,
+			ThrowableSet actualResult) {
+		// Utility routine used by the next three add()s.
+
+		assertSameMembers(actualResult, expectedIncluded, expectedExcluded);
+		expectedSizeToSets.addAndCheck(expectedIncluded, expectedExcluded);
+		expectedMemoizations.checkAdd(lhs, rhs, actualResult);
+		return actualResult;
+	}
+
+	private ThrowableSet checkAdd(ThrowableSet lhs, Object rhs,
+			Set<RefLikeType> expectedResult, ThrowableSet actualResult) {
+		// Utility routine used by the next three add()s.
+		return checkAdd(lhs, rhs, expectedResult, Collections.<AnySubType>emptySet(),
+				actualResult);
+	}
+
+
+	private ThrowableSet add(ThrowableSet lhs, ThrowableSet rhs,
+			Set<RefLikeType> expectedIncluded, Set<AnySubType> expectedExcluded) {
+		// Add rhs to lhs, checking the results.
+
+		ThrowableSet actualResult = lhs.add(rhs);
+		return checkAdd(lhs, rhs, expectedIncluded, expectedExcluded,
+				actualResult);
+	}
+
+	private ThrowableSet add(ThrowableSet lhs, ThrowableSet rhs,
+			Set<RefLikeType> expectedResult) {
+		// Add rhs to lhs, checking the results.
+		return add(lhs, rhs, expectedResult, Collections.<AnySubType>emptySet());
+	}
+
+	private ThrowableSet add(ThrowableSet lhs, RefType rhs,
+			Set<RefLikeType> expectedResult) {
+		// Add rhs to lhs, checking the results.
+
+		ThrowableSet actualResult = lhs.add(rhs);
+		return checkAdd(lhs, rhs, expectedResult, actualResult);
+	}
+
+	private ThrowableSet add(ThrowableSet lhs, AnySubType rhs,
+			Set<RefLikeType> expectedResult) {
+		// Add rhs to lhs, checking the results.
+
+		ThrowableSet actualResult = lhs.add(rhs);
+		return checkAdd(lhs, rhs, expectedResult, actualResult);
+	}
+
+
+	@Test
+	public void test_01_InitialState() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestInitialState()");
+		}
+		assertTrue(expectedSizeToSets.match());
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+	@Test
+	public void test_02_SingleInstance0() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestSingleInstance0()");
+		}
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+		}));
+
+		ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
+				expected);
+		ThrowableSet set1 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
+				expected);
+		assertTrue("The same ThrowableSet object should represent two sets containing the same single class.",
+				set0 == set1);
+
+		Set<RefType> catchable = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+				util.RUNTIME_EXCEPTION,
+				util.EXCEPTION,
+				util.THROWABLE,
+		}));
+		assertEquals("Should be catchable only as UndeclaredThrowableException and its superclasses",
+				catchable, util.catchableSubset(set0));
+
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		catchableAs = set0.whichCatchableAs(util.UNDECLARED_THROWABLE_EXCEPTION);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+	@Test
+	public void test_03_SingleInstance1() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestSingleInstance1()");
+		}
+		Set<RefLikeType> expected0 = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+		}));
+		Set<RefLikeType> expected1 = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
+		}));
+		Set<RefLikeType> expectedResult = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+				util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
+		}));
+
+		ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
+				expected0);
+		ThrowableSet set0a = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
+				expectedResult);
+		ThrowableSet set1 = add(mgr.EMPTY,
+				util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION,
+				expected1);
+		ThrowableSet set1a = add(set1, util.UNDECLARED_THROWABLE_EXCEPTION,
+				expectedResult);
+
+		assertTrue("The same ThrowableSet object should represent two sets containing the same two exceptions, even if added in different orders.",
+				set0a == set1a);
+
+		Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(expectedResult);
+		catchable.add(util.RUNTIME_EXCEPTION);
+		catchable.add(util.EXCEPTION);
+		catchable.add(util.THROWABLE);
+		assertEquals("Should be catchable only as UndeclaredThrowableException "
+				+ "UnsupportedLookAndFeelException and superclasses",
+				catchable, util.catchableSubset(set0a));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_04_AddingSubclasses() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestAddingSubclasses()");
+		}
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>();
+		expected.add(util.INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		ThrowableSet set0 = add(mgr.EMPTY, util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				expected);
+
+		expected.clear();
+		expected.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
+		ThrowableSet set1 = add(mgr.EMPTY,
+				AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
+				expected);
+		assertTrue("ThrowableSet should distinguish the case where a single exception includes subclasses from that where it does not.",
+				set0 != set1);
+
+		Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				util.RUNTIME_EXCEPTION,
+				util.EXCEPTION,
+				util.THROWABLE,
+		}));
+		assertEquals(catchable, util.catchableSubset(set0));
+
+		catchable.add(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		catchable.add(util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		assertEquals(catchable, util.catchableSubset(set1));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+	@Test
+	public void test_05_AddingSets0() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestAddingSets0()");
+		}
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
+		}));
+		ThrowableSet set0 = add(mgr.EMPTY, util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				expected);
+
+		expected.clear();
+		expected.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
+		ThrowableSet set1 = add(mgr.EMPTY,
+				AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
+				expected);
+
+		ThrowableSet result = add(set1, set0, expected);
+		assertTrue("{AnySubType(E)} union {E} should equal {AnySubType(E)}",
+				result == set1);
+
+		result = add(set1, set0, expected);
+		assertTrue("{E} union {AnySubType(E)} should equal {AnySubType(E)}",
+				result == set1);
+
+		if (DUMP_INTERNALS) {
+			System.err.println("testAddingSets0()");
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_06_AddingSets1() {
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(util.VM_ERRORS);
+		expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		ThrowableSet set0 = add(mgr.VM_ERRORS,
+				util.UNDECLARED_THROWABLE_EXCEPTION, expected);
+		expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		set0 = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION, expected);
+
+		ThrowableSet set1 = mgr.INITIALIZATION_ERRORS;
+		expected = new ExceptionHashSet<RefLikeType>();
+		expected.add(AnySubType.v(util.ERROR));
+		assertSameMembers(set1, expected, Collections.<AnySubType>emptySet());
+
+		expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		ThrowableSet result0 = add(set0, set1, expected);
+		ThrowableSet result1 = add(set1, set0, expected);
+		assertTrue("Adding sets should be commutative.", result0 == result1);
+
+		Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(util.ALL_TEST_ERRORS_PLUS_SUPERTYPES);
+		catchable.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		catchable.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		catchable.add(util.RUNTIME_EXCEPTION);// Superclasses of
+		catchable.add(util.EXCEPTION);        // others.
+		catchable.add(util.ERROR);
+		catchable.add(util.THROWABLE);
+		assertEquals(catchable, util.catchableSubset(result0));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_07_AddingSets2() {
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(util.VM_ERRORS);
+		expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		ThrowableSet set0 = add(mgr.VM_ERRORS,
+				util.UNDECLARED_THROWABLE_EXCEPTION, expected);
+		expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		set0 = add(set0, util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION, expected);
+
+		ThrowableSet set1 = mgr.INITIALIZATION_ERRORS;
+		expected = new ExceptionHashSet<RefLikeType>();
+		expected.add(AnySubType.v(util.ERROR));
+		assertSameMembers(set1, expected, Collections.<AnySubType>emptySet());
+
+		expected.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		expected.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		ThrowableSet result0 = add(set0, set1, expected);
+		ThrowableSet result1 = add(set1, set0, expected);
+		assertTrue("Adding sets should be commutative.", result0 == result1);
+
+		Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(util.ALL_TEST_ERRORS_PLUS_SUPERTYPES);
+		catchable.add(util.UNDECLARED_THROWABLE_EXCEPTION);
+		catchable.add(util.UNSUPPORTED_LOOK_AND_FEEL_EXCEPTION);
+		catchable.add(util.RUNTIME_EXCEPTION);// Superclasses of
+		catchable.add(util.EXCEPTION);        // others.
+		catchable.add(util.ERROR);
+		catchable.add(util.THROWABLE);
+		assertEquals(catchable, util.catchableSubset(result0));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_08_WhichCatchable0() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchable0()");
+		}
+		Set<RefLikeType> expected = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+		}));
+
+		ThrowableSet set0 = add(mgr.EMPTY, util.UNDECLARED_THROWABLE_EXCEPTION,
+				expected);
+		Set<RefLikeType> catchable = new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.UNDECLARED_THROWABLE_EXCEPTION,
+				util.RUNTIME_EXCEPTION,
+				util.EXCEPTION,
+				util.THROWABLE,
+		}));
+
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(catchable, util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.UNDECLARED_THROWABLE_EXCEPTION));
+		catchableAs = set0.whichCatchableAs(util.UNDECLARED_THROWABLE_EXCEPTION);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.RUNTIME_EXCEPTION));
+		catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.EXCEPTION));
+		catchableAs = set0.whichCatchableAs(util.EXCEPTION);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.THROWABLE));
+		catchableAs = set0.whichCatchableAs(util.THROWABLE);
+		assertEquals(catchableAs.getCaught(), set0);
+		assertEquals(catchableAs.getUncaught(), mgr.EMPTY);
+		assertEquals(catchable, util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.ERROR));
+		catchableAs = set0.whichCatchableAs(util.ERROR);
+		assertEquals(catchableAs.getCaught(), mgr.EMPTY);
+		assertEquals(catchableAs.getUncaught(), set0);
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(catchable, util.catchableSubset(catchableAs.getUncaught()));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_09_WhichCatchable1() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchable1()");
+		}
+		ThrowableSet set0 = mgr.EMPTY.add(util.LINKAGE_ERROR);
+		Set<RefType> catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+
+		assertTrue(set0.catchableAs(util.ERROR));
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ERROR);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.INSTANTIATION_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INSTANTIATION_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.INTERNAL_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INTERNAL_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_10_WhichCatchable2() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchable2()");
+		}
+
+		ThrowableSet set0 = mgr.EMPTY.add(AnySubType.v(util.LINKAGE_ERROR));
+		Set<RefType> catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.ABSTRACT_METHOD_ERROR,
+				util.ILLEGAL_ACCESS_ERROR,
+				util.INSTANTIATION_ERROR,
+				util.NO_SUCH_FIELD_ERROR,
+				util.NO_SUCH_METHOD_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+
+		assertTrue(set0.catchableAs(util.ERROR));
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ERROR);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
+		Set<AnySubType> expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
+		Set<AnySubType> expectedCaughtExcluded = Collections.emptySet();
+		Set<AnySubType> expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.LINKAGE_ERROR)}));
+		Set<AnySubType> expectedUncaughtExcluded = expectedCaughtIncluded;
+		assertSameMembers(catchableAs,
+				expectedCaughtIncluded,
+				expectedCaughtExcluded,
+				expectedUncaughtIncluded,
+				expectedUncaughtExcluded);
+		catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.ABSTRACT_METHOD_ERROR,
+				util.ILLEGAL_ACCESS_ERROR,
+				util.INSTANTIATION_ERROR,
+				util.NO_SUCH_FIELD_ERROR,
+				util.NO_SUCH_METHOD_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+		Set<RefType> noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(noncatcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.INSTANTIATION_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INSTANTIATION_ERROR);
+		expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.INSTANTIATION_ERROR)}));
+		expectedCaughtExcluded = Collections.emptySet();
+		expectedUncaughtExcluded = expectedCaughtIncluded;
+		assertSameMembers(catchableAs,
+				expectedCaughtIncluded,
+				expectedCaughtExcluded,
+				expectedUncaughtIncluded,
+				expectedUncaughtExcluded);
+		catcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.INSTANTIATION_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+		noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.ABSTRACT_METHOD_ERROR,
+				util.ILLEGAL_ACCESS_ERROR,
+				util.NO_SUCH_FIELD_ERROR,
+				util.NO_SUCH_METHOD_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+		assertEquals(catcherTypes,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(noncatcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.INTERNAL_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INTERNAL_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		noncatcherTypes = new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.ABSTRACT_METHOD_ERROR,
+				util.ILLEGAL_ACCESS_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.NO_SUCH_FIELD_ERROR,
+				util.NO_SUCH_METHOD_ERROR,
+				util.INSTANTIATION_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.LINKAGE_ERROR,
+				util.ERROR,
+				util.THROWABLE,
+		}));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(noncatcherTypes,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_11_WhichCatchable3() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchable3()");
+		}
+
+		ThrowableSet set0 = mgr.EMPTY;
+		set0 = set0.add(AnySubType.v(util.ERROR));
+
+		assertTrue(set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
+		Set<AnySubType> expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
+		Set<AnySubType> expectedCaughtExcluded = Collections.emptySet();
+		Set<AnySubType> expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.ERROR)}));
+		Set<AnySubType> expectedUncaughtExcluded = expectedCaughtIncluded;
+		assertTrue(ExceptionTestUtility.sameMembers(expectedCaughtIncluded,
+				expectedCaughtExcluded,
+				catchableAs.getCaught()));
+		assertTrue(ExceptionTestUtility.sameMembers(expectedUncaughtIncluded,
+				expectedUncaughtExcluded,
+				catchableAs.getUncaught()));
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.LINKAGE_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.ABSTRACT_METHOD_ERROR,
+				util.INSTANTIATION_ERROR,
+				util.ILLEGAL_ACCESS_ERROR,
+				util.NO_SUCH_FIELD_ERROR,
+				util.NO_SUCH_METHOD_ERROR,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.AWT_ERROR,
+				util.LINKAGE_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		set0 = catchableAs.getUncaught();
+
+		assertTrue(set0.catchableAs(util.THROWABLE));
+		catchableAs = set0.whichCatchableAs(util.THROWABLE);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.AWT_ERROR,
+				util.LINKAGE_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.ERROR));
+		catchableAs = set0.whichCatchableAs(util.ERROR);
+		assertEquals(set0, catchableAs.getCaught());
+		assertEquals(mgr.EMPTY, catchableAs.getUncaught());
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.AWT_ERROR,
+				util.LINKAGE_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(set0.catchableAs(util.LINKAGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.LINKAGE_ERROR);
+		expectedCaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.LINKAGE_ERROR)}));
+		expectedCaughtExcluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR)}));
+		expectedUncaughtIncluded = new ExceptionHashSet<AnySubType>(
+				Arrays.asList(new AnySubType[]
+						{AnySubType.v(util.ERROR)}));
+		expectedUncaughtExcluded = expectedCaughtIncluded;
+		assertTrue(ExceptionTestUtility.sameMembers(expectedCaughtIncluded,
+				expectedCaughtExcluded,
+				catchableAs.getCaught()));
+		assertTrue(ExceptionTestUtility.sameMembers(expectedUncaughtIncluded,
+				expectedUncaughtExcluded,
+				catchableAs.getUncaught()));
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.LINKAGE_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.AWT_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		assertTrue(! set0.catchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
+		catchableAs = set0.whichCatchableAs(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.LINKAGE_ERROR,
+				util.AWT_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		catchableAs = set0.whichCatchableAs(util.ILLEGAL_ACCESS_ERROR);
+		assertEquals(mgr.EMPTY, catchableAs.getCaught());
+		assertEquals(set0, catchableAs.getUncaught());
+		assertEquals(Collections.EMPTY_SET,
+				util.catchableSubset(catchableAs.getCaught()));
+		assertEquals(new ExceptionHashSet<RefType>(Arrays.asList(new RefType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.LINKAGE_ERROR,
+				util.AWT_ERROR,
+				util.THREAD_DEATH,
+				util.VIRTUAL_MACHINE_ERROR,
+				util.INTERNAL_ERROR,
+				util.OUT_OF_MEMORY_ERROR,
+				util.STACK_OVERFLOW_ERROR,
+				util.CLASS_CIRCULARITY_ERROR,
+				util.CLASS_FORMAT_ERROR,
+				util.UNSUPPORTED_CLASS_VERSION_ERROR,
+				util.EXCEPTION_IN_INITIALIZER_ERROR,
+				util.NO_CLASS_DEF_FOUND_ERROR,
+				util.UNSATISFIED_LINK_ERROR,
+				util.VERIFY_ERROR,
+				util.UNKNOWN_ERROR,})),
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		if (DUMP_INTERNALS) {
+			printAllSets();
+		}
+	}
+
+
+	@Test
+	public void test_12_WhichCatchable10() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchable3()");
+		}
+
+		ThrowableSet set0 = mgr.EMPTY;
+		set0 = set0.add(AnySubType.v(util.THROWABLE));
+
+		assertTrue(set0.catchableAs(util.ARITHMETIC_EXCEPTION));
+		ThrowableSet.Pair catchableAs = set0.whichCatchableAs(util.ARITHMETIC_EXCEPTION);
+		assertSameMembers(catchableAs,
+				new RefLikeType[] {
+				AnySubType.v(util.ARITHMETIC_EXCEPTION),
+		},
+		new AnySubType[] {
+		},
+		new RefLikeType[] {
+				AnySubType.v(util.THROWABLE),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.ARITHMETIC_EXCEPTION),
+		});
+		assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.THROWABLE,
+				util.EXCEPTION,
+				util.RUNTIME_EXCEPTION,
+				util.ARITHMETIC_EXCEPTION,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		HashSet<RefLikeType> expectedUncaught = new HashSet<RefLikeType>(util.ALL_TEST_THROWABLES);
+		expectedUncaught.remove(util.ARITHMETIC_EXCEPTION);
+		assertEquals(expectedUncaught,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		set0 = catchableAs.getUncaught();
+		assertTrue(set0.catchableAs(util.ABSTRACT_METHOD_ERROR));
+		catchableAs = set0.whichCatchableAs(util.ABSTRACT_METHOD_ERROR);
+		assertSameMembers(catchableAs,
+				new RefLikeType[] {
+				AnySubType.v(util.ABSTRACT_METHOD_ERROR),
+		},
+		new AnySubType[] {
+		},
+		new RefLikeType[] {
+				AnySubType.v(util.THROWABLE),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.ARITHMETIC_EXCEPTION),
+				AnySubType.v(util.ABSTRACT_METHOD_ERROR),
+		});
+		assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.THROWABLE,
+				util.ERROR,
+				util.LINKAGE_ERROR,
+				util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+				util.ABSTRACT_METHOD_ERROR,})),
+				util.catchableSubset(catchableAs.getCaught()));
+		expectedUncaught.remove(util.ABSTRACT_METHOD_ERROR);
+		assertEquals(expectedUncaught,
+				util.catchableSubset(catchableAs.getUncaught()));
+
+		set0 = catchableAs.getUncaught();
+		assertTrue(set0.catchableAs(util.RUNTIME_EXCEPTION));
+		catchableAs = set0.whichCatchableAs(util.RUNTIME_EXCEPTION);
+		assertSameMembers(catchableAs,
+				new RefLikeType[] {
+				AnySubType.v(util.RUNTIME_EXCEPTION),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.ARITHMETIC_EXCEPTION),
+		},
+		new RefLikeType[] {
+				AnySubType.v(util.THROWABLE),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.RUNTIME_EXCEPTION),
+				AnySubType.v(util.ABSTRACT_METHOD_ERROR),
+		});
+		assertEquals(new ExceptionHashSet<RefLikeType>(Arrays.asList(new RefLikeType[] {
+				util.THROWABLE,
+				util.EXCEPTION,
+				util.RUNTIME_EXCEPTION,
+				util.ARRAY_STORE_EXCEPTION,
+				util.CLASS_CAST_EXCEPTION,
+				util.ILLEGAL_MONITOR_STATE_EXCEPTION,
+				util.INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION,
+				util.NEGATIVE_ARRAY_SIZE_EXCEPTION,
+				util.NULL_POINTER_EXCEPTION,
+				util.UNDECLARED_THROWABLE_EXCEPTION})),
+				util.catchableSubset(catchableAs.getCaught()));
+		expectedUncaught.remove(util.RUNTIME_EXCEPTION);
+		expectedUncaught.remove(util.ARRAY_STORE_EXCEPTION);
+		expectedUncaught.remove(util.CLASS_CAST_EXCEPTION);
+		expectedUncaught.remove(util.ILLEGAL_MONITOR_STATE_EXCEPTION);
+		expectedUncaught.remove(util.INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		expectedUncaught.remove(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		expectedUncaught.remove(util.STRING_INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		expectedUncaught.remove(util.NEGATIVE_ARRAY_SIZE_EXCEPTION);
+		expectedUncaught.remove(util.NULL_POINTER_EXCEPTION);
+		expectedUncaught.remove(util.UNDECLARED_THROWABLE_EXCEPTION);
+		assertEquals(expectedUncaught,
+				util.catchableSubset(catchableAs.getUncaught()));
+	}
+
+
+	@Test
+	public void test_13_AddAfterWhichCatchableAs0() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestAddAfterWhichCatchable0()");
+		}
+
+		ThrowableSet anyError = mgr.EMPTY.add(AnySubType.v(util.ERROR));
+
+		assertTrue(anyError.catchableAs(util.LINKAGE_ERROR));
+		ThrowableSet.Pair catchableAs = anyError.whichCatchableAs(util.LINKAGE_ERROR);
+		assertSameMembers(catchableAs,
+				new RefLikeType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		},
+		new AnySubType[] {
+		},
+		new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+
+		ThrowableSet anyErrorMinusLinkage = catchableAs.getUncaught();
+		try {
+			ThrowableSet anyErrorMinusLinkagePlusIncompatibleClassChange
+			= anyErrorMinusLinkage.add(util.INCOMPATIBLE_CLASS_CHANGE_ERROR);
+			fail("add(IncompatiableClassChangeError) after removing LinkageError should currently generate an exception");
+
+			// Following documents what we would like to be able to implement:
+			assertSameMembers(anyErrorMinusLinkagePlusIncompatibleClassChange,
+					new RefLikeType[] {
+					AnySubType.v(util.ERROR),
+					util.INCOMPATIBLE_CLASS_CHANGE_ERROR,
+			},
+			new AnySubType[] {
+					AnySubType.v(util.LINKAGE_ERROR),
+			});
+		} catch (ThrowableSet.AlreadyHasExclusionsException e) {
+			// this is what should happen.
+		}
+
+		try {
+			ThrowableSet anyErrorMinusLinkagePlusAnyIncompatibleClassChange
+			= anyErrorMinusLinkage.add(AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR));
+			fail("add(AnySubType.v(IncompatiableClassChangeError)) after removing LinkageError should currently generate an exception");
+
+			// Following documents what we would like to be able to implement:
+			assertSameMembers(anyErrorMinusLinkagePlusAnyIncompatibleClassChange,
+					new RefLikeType[] {
+					AnySubType.v(util.ERROR),
+					AnySubType.v(util.INCOMPATIBLE_CLASS_CHANGE_ERROR),
+			},
+			new AnySubType[] {
+					AnySubType.v(util.LINKAGE_ERROR),
+			});
+		} catch (ThrowableSet.AlreadyHasExclusionsException e) {
+			// this is what should happen.
+		}
+
+		// Add types that should not change the set.
+		ThrowableSet sameSet
+		= anyErrorMinusLinkage.add(util.VIRTUAL_MACHINE_ERROR);
+		assertTrue(sameSet == anyErrorMinusLinkage);
+		assertSameMembers(sameSet,
+				new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+		sameSet
+		= anyErrorMinusLinkage.add(AnySubType.v(util.VIRTUAL_MACHINE_ERROR));
+		assertTrue(sameSet == anyErrorMinusLinkage);
+		assertSameMembers(sameSet,
+				new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+
+		ThrowableSet anyErrorMinusLinkagePlusArrayIndex
+		= anyErrorMinusLinkage.add(util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION);
+		assertSameMembers(anyErrorMinusLinkagePlusArrayIndex,
+				new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+				util.ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION,
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+
+		ThrowableSet anyErrorMinusLinkagePlusAnyIndex
+		= anyErrorMinusLinkagePlusArrayIndex.add(AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION));
+		assertSameMembers(anyErrorMinusLinkagePlusAnyIndex,
+				new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+				AnySubType.v(util.INDEX_OUT_OF_BOUNDS_EXCEPTION),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+
+		ThrowableSet anyErrorMinusLinkagePlusAnyRuntime
+		= anyErrorMinusLinkagePlusAnyIndex.add(AnySubType.v(util.RUNTIME_EXCEPTION));
+		assertSameMembers(anyErrorMinusLinkagePlusAnyRuntime,
+				new RefLikeType[] {
+				AnySubType.v(util.ERROR),
+				AnySubType.v(util.RUNTIME_EXCEPTION),
+		},
+		new AnySubType[] {
+				AnySubType.v(util.LINKAGE_ERROR),
+		});
+
+		try {
+			ThrowableSet anyErrorMinusLinkagePlusAnyRuntimePlusError
+			= anyErrorMinusLinkagePlusAnyRuntime.add(AnySubType.v(util.ERROR));
+			fail("add(AnySubType(Error)) after removing LinkageError should currently generate an exception.");
+
+			// This documents what we would like to implement:
+			assertSameMembers(anyErrorMinusLinkagePlusAnyRuntimePlusError,
+					new RefLikeType[] {
+					AnySubType.v(util.ERROR),
+					AnySubType.v(util.RUNTIME_EXCEPTION),
+			},
+			new AnySubType[] {
+			});
+		} catch (ThrowableSet.AlreadyHasExclusionsException e) {
+			// This is what should happen.
+		}
+
+		try {
+			ThrowableSet anyErrorMinusLinkagePlusAnyRuntimePlusLinkageError
+			= anyErrorMinusLinkagePlusAnyRuntime.add(AnySubType.v(util.LINKAGE_ERROR));
+			fail("add(AnySubType(LinkageError)) after removing LinkageError should currently generate an exception.");
+
+			// This documents what we would like to implement:
+			assertSameMembers(anyErrorMinusLinkagePlusAnyRuntimePlusLinkageError,
+					new RefLikeType[] {
+					AnySubType.v(util.ERROR),
+					AnySubType.v(util.RUNTIME_EXCEPTION),
+			},
+			new AnySubType[] {
+			});
+		} catch (ThrowableSet.AlreadyHasExclusionsException e) {
+			// This is what should happen.
+		}
+
+	}
+
+	@Test
+	public void test_14_WhichCatchablePhantom0() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchablePhantom0()");
+		}
+
+		ThrowableSet anyError = mgr.EMPTY.add(AnySubType.v(util.ERROR));
+
+		assertSameMembers(anyError.whichCatchableAs(util.LINKAGE_ERROR),
+				new RefLikeType[] { AnySubType.v(util.LINKAGE_ERROR) },
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.ERROR) },
+				new AnySubType[] { AnySubType.v(util.LINKAGE_ERROR) });
+		assertSameMembers(anyError.whichCatchableAs(util.PHANTOM_EXCEPTION1),
+				new RefLikeType[] {},
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.ERROR) },
+				new AnySubType[] {});
+
+		assertTrue(anyError.catchableAs(util.LINKAGE_ERROR));
+		assertFalse(anyError.catchableAs(util.PHANTOM_EXCEPTION1));
+
+		ThrowableSet phantomOnly = mgr.EMPTY.add(util.PHANTOM_EXCEPTION1);
+
+		assertSameMembers(phantomOnly.whichCatchableAs(util.LINKAGE_ERROR),
+				new RefLikeType[] {},
+				new AnySubType[] {},
+				new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
+				new AnySubType[] {});
+		assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION2),
+				new RefLikeType[] {},
+				new AnySubType[] {},
+				new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
+				new AnySubType[] {});
+		assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION1),
+				new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
+				new AnySubType[] {},
+				new RefLikeType[] {},
+				new AnySubType[] {});
+
+		assertFalse(phantomOnly.catchableAs(util.LINKAGE_ERROR));
+		assertTrue(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION1));
+		assertFalse(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION2));
+
+		ThrowableSet bothPhantoms = phantomOnly.add(util.PHANTOM_EXCEPTION2);
+
+		assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION1),
+				new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
+				new AnySubType[] {},
+				new RefLikeType[] { util.PHANTOM_EXCEPTION2 },
+				new AnySubType[] {});
+		assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION2),
+				new RefLikeType[] { util.PHANTOM_EXCEPTION2 },
+				new AnySubType[] {},
+				new RefLikeType[] { util.PHANTOM_EXCEPTION1 },
+				new AnySubType[] {});
+
+		assertFalse(bothPhantoms.catchableAs(util.LINKAGE_ERROR));
+		assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION1));
+		assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION2));
+
+		ThrowableSet bothPhantoms2 = phantomOnly.add(util.PHANTOM_EXCEPTION2);
+		assertTrue(bothPhantoms == bothPhantoms2);
+
+		ThrowableSet throwableOnly = mgr.EMPTY.add(util.THROWABLE);
+		assertFalse(throwableOnly.catchableAs(util.PHANTOM_EXCEPTION1));
+
+		ThrowableSet allThrowables = mgr.EMPTY.add(AnySubType.v(util.THROWABLE));
+		assertTrue(allThrowables.catchableAs(util.PHANTOM_EXCEPTION1));
+	}
+
+	@Test
+	public void test_14_WhichCatchablePhantom1() {
+		if (DUMP_INTERNALS) {
+			System.err.println("\n\ntestWhichCatchablePhantom1()");
+		}
+
+		ThrowableSet phantomOnly = mgr.EMPTY.add(AnySubType.v(util.PHANTOM_EXCEPTION1));
+
+		assertSameMembers(phantomOnly.whichCatchableAs(util.LINKAGE_ERROR),
+				new RefLikeType[] {},
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
+				new AnySubType[] {});
+		assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION2),
+				new RefLikeType[] {},
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
+				new AnySubType[] {});
+		assertSameMembers(phantomOnly.whichCatchableAs(util.PHANTOM_EXCEPTION1),
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
+				new AnySubType[] {},
+				new RefLikeType[] {},
+				new AnySubType[] {});
+
+		assertFalse(phantomOnly.catchableAs(util.LINKAGE_ERROR));
+		assertTrue(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION1));
+		assertFalse(phantomOnly.catchableAs(util.PHANTOM_EXCEPTION2));
+
+		ThrowableSet bothPhantoms = phantomOnly.add(AnySubType.v(util.PHANTOM_EXCEPTION2));
+
+		assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION1),
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION2) },
+				new AnySubType[] {});
+		assertSameMembers(bothPhantoms.whichCatchableAs(util.PHANTOM_EXCEPTION2),
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION2) },
+				new AnySubType[] {},
+				new RefLikeType[] { AnySubType.v(util.PHANTOM_EXCEPTION1) },
+				new AnySubType[] {});
+
+		assertFalse(bothPhantoms.catchableAs(util.LINKAGE_ERROR));
+		assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION1));
+		assertTrue(bothPhantoms.catchableAs(util.PHANTOM_EXCEPTION2));
+
+		ThrowableSet bothPhantoms2 = phantomOnly.add(AnySubType.v(util.PHANTOM_EXCEPTION2));
+		assertTrue(bothPhantoms == bothPhantoms2);
+	}
+
+	void printAllSets() {
+		for (ThrowableSet s : mgr.getThrowableSets()) {
+			System.err.println(s.toString());
+			System.err.println("\n\tMemoized Adds:");
+			for (Map.Entry<Object, ThrowableSet> entry : s.getMemoizedAdds().entrySet()) {
+				System.err.print(' ');
+				if (entry.getKey() instanceof ThrowableSet) {
+					System.err.print(((ThrowableSet) entry.getKey()).toBriefString());
+				} else {
+					System.err.print(entry.getKey().toString());
+				}
+				System.err.print('=');
+				System.err.print(entry.getValue().toBriefString());
+				System.err.print('\n');
+			}
+		}
+	}
+
+
+	/*
     // Suite that uses a prescribed order, rather than whatever
     // order reflection produces.
     public static Test cannedSuite() {
@@ -1552,5 +1545,6 @@ setloop:
         junit.textui.TestRunner.run(reflectionSuite());
         System.out.println(ThrowableSet.Manager.v().reportInstrumentation());
     }
-    */
+	 */
 }
+


### PR DESCRIPTION
This patch improves the performance of registerSetIfNew with a weak flyweight-cache for ThrowableSet.

Other changes besides whitespace normalization:
* removes the defbox cache from AbstractDefinitionStmt, as it just wastes memory and doesn't improve the performance
* slighly improves the issu-tracker template
* removed the redundant immutable-view from ThrowableSet.typesIncluded and ThrowableSet.typesExcluded
* updated the tests for ThrowableSet