### PR TITLE
Return the start region

### DIFF
--- a/src/soot/toolkits/graph/pdg/HashMutablePDG.java
+++ b/src/soot/toolkits/graph/pdg/HashMutablePDG.java
@@ -608,7 +608,7 @@ public class HashMutablePDG extends HashMutableEdgeLabelledDirectedGraph<PDGNode
 	 */
 	public IRegion GetStartRegion()
 	{
-		return this.m_pdgRegions.get(0);
+	    return (IRegion) GetStartNode().getNode();
 	}
 	
 	/**


### PR DESCRIPTION
Correct bug: GetStartRegion did not return the start region instead it
returned the first node visited in the post-order traversal of the
region hierarchy.