### PR TITLE
Fix errorneously removed call graph edge reported by florian: getMeth…

### DIFF
--- a/src/soot/jimple/spark/geom/geomE/FullSensitiveNode.java
+++ b/src/soot/jimple/spark/geom/geomE/FullSensitiveNode.java
@@ -273,8 +273,9 @@ public class FullSensitiveNode extends IVarAbstraction
 		boolean added, hasNewPointsTo;
 
 		if ( pt_objs.size() == 0 ) return;
+//		System.err.println("+++ Process assignment for: " + toString());
 		
-		// We first build the new flow edges via the field dereferences
+		// We first build the flow edges that flow in to/out of object fields
 		if ( complex_cons != null ) {
 			
 			for ( Map.Entry<AllocNode, GeometricManager> entry : new_pts.entrySet() ) {
@@ -301,6 +302,7 @@ public class FullSensitiveNode extends IVarAbstraction
 					}
 					
 					qn = (FullSensitiveNode) pcons.otherSide;
+//					System.err.println("--load/store-->: " + qn.toString());
 					
 					for ( i = 0; i < GeometricManager.Divisions; ++i ) {
 						pts = entry_pts[i];
@@ -329,12 +331,14 @@ public class FullSensitiveNode extends IVarAbstraction
 		
 		if ( flowto.size() == 0 ) return;
 		
-		// First, we get the flow-to shapes
+		// Next, we process the assignments (e.g. p = q)
 		for (Map.Entry<FullSensitiveNode, GeometricManager> entry1 : flowto.entrySet()) {	
 			added = false;
 			qn = entry1.getKey();
 			gm1 = entry1.getValue();
 			entry_pe = gm1.getFigures();
+			
+//			System.err.println("-assign->: " + qn.toString());
 			
 			// We specialize the two cases that we hope it running faster
 			// We have new flow-to edges
@@ -421,9 +425,10 @@ public class FullSensitiveNode extends IVarAbstraction
 			if ( added )
 				worklist.push( qn );
 		}
+		
+//		System.err.println();
 	}
 
-	
 	
 	@Override
 	public boolean isDeadObject( AllocNode obj )

--- a/src/soot/jimple/spark/geom/geomE/FullSensitiveNodeGenerator.java
+++ b/src/soot/jimple/spark/geom/geomE/FullSensitiveNodeGenerator.java
@@ -94,6 +94,7 @@ public class FullSensitiveNodeGenerator extends IEncodingBroker
 
 			case Constants.ASSIGN_CONS:
 				// Assigning between two pointers
+				
 				if ( cons.interCallEdges != null ) {
 					// Inter-procedural assignment (parameter passing, function return)
 					for ( Iterator<Edge> it = cons.interCallEdges.iterator(); it.hasNext(); ) {

--- a/src/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
+++ b/src/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
@@ -407,10 +407,17 @@ public class GeomPointsTo extends PAG
 			else if ( edge.isInstance() && !edge.isSpecial() ) {
 				// We try to refine the virtual callsites (virtual + interface) with multiple call targets				
 				InstanceInvokeExpr expr = (InstanceInvokeExpr)callsite.getInvokeExpr();
-				p.base_var = findLocalVarNode( expr.getBase() );
-				if ( SootInfo.countCallEdgesForCallsite(callsite, true) > 1 &&
-						p.base_var != null ) {
-					multiCallsites.add(callsite);
+				if (expr.getMethodRef().getSignature()
+						.contains("<java.lang.Thread: void start()>")) {
+					// It is a thread start function
+					thread_run_callsites.add(callsite);
+				}
+				else {
+					p.base_var = findLocalVarNode( expr.getBase() );
+					if ( SootInfo.countCallEdgesForCallsite(callsite, true) > 1 &&
+							p.base_var != null ) {
+						multiCallsites.add(callsite);
+					}
 				}
 			}
 			
@@ -975,6 +982,7 @@ public class GeomPointsTo extends PAG
 				}
 				else {
 					// Update the corresponding SOOT call graph
+//					ps.println("%%% Remove an call edge: " + p.toString());
 					cg.removeEdge(p.sootEdge);
 					
 					// We record this obsoleted edge
@@ -1575,9 +1583,8 @@ public class GeomPointsTo extends PAG
 			int id = func2int.get( sm );
 			if ( vis_cg[id] == 0 )
 				ret = Constants.UNKNOWN_FUNCTION;
-			
-			if (ret == -1)
-				System.out.println();
+			else
+				ret = id;
 		}
 		
 		return ret;


### PR DESCRIPTION
@StevenArzt @ericbodden 

Bug fix:

"GeomPointsTo::getMethodIDFromPtr" returns wrong function ID for given pointer. This is a serious bug that can build wrong pointer assignment graph and miss points-to information. Thanks Florian Angerer to point out this bug.

Other improvements:

1. Slightly update comments in several places;

2. Rename the querying functions to the names used in my PhD thesis:

"contextsByAnyCallEdge" => "ContextsGoBy"

"contextsByCallChain" => "kCFA"

Original names are marked "deprecated".