### PR TITLE
Added ant target to publish soot jar files to local ivy repository.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0"?>
 
-<project default="compile" name="Soot Build File">
+<project xmlns:ivy="antlib:org.apache.ivy.ant" default="compile" name="Soot Build File">
     <property file="ant.settings"/>
+
+    <property name="ivy.install.version" value="2.1.0-rc2" />
+    <condition property="ivy.home" value="${env.IVY_HOME}">
+        <isset property="env.IVY_HOME" />
+    </condition>
+    <property name="ivy.home" value="${user.home}/.ivy2" />
+    <property name="ivy.jar.dir" value="${ivy.home}/lib" />
+    <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
+
     <target name="settings">
         <fail
             message="Please copy ant.settings.template to ant.settings, and set the variables in it."
@@ -371,5 +380,35 @@
             <fileset dir="generated/options"/>
         </jar>
 	</target>
+
+    <!-- IVY RELATED TARGETS -->
+
+    <target name="download-ivy" unless="offline">
+
+        <mkdir dir="${ivy.jar.dir}"/>
+        <!-- download Ivy from web site so that it can be used even without any special installation -->
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+             dest="${ivy.jar.file}" usetimestamp="true"/>
+    </target>
+
+    <target name="init-ivy" depends="download-ivy">
+        <!-- try to load ivy here from ivy home, in case the user has not already dropped
+                it into ant's lib dir (note that the latter copy will always take precedence).
+                We will not fail as long as local lib dir exists (it may be empty) and
+                ivy is in at least one of ant's lib dir or the local lib dir. -->
+        <path id="ivy.lib.path">
+            <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
+
+        </path>
+        <taskdef resource="org/apache/ivy/ant/antlib.xml"
+                 uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
+    </target>
+
+    <target name="publish-local" depends="init-ivy, fulljar, classesjar, sourcejar, javadoc">
+        <ivy:resolve/>
+        <ivy:publish pubrevision="${soot.version}" status="release" resolver="local" overwrite="true" >
+            <artifacts pattern="{release.loc}/[artifact]-[revision].[ext]"/>
+        </ivy:publish>
+    </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -407,7 +407,7 @@
     <target name="publish-local" depends="init-ivy, fulljar, classesjar, sourcejar, javadoc">
         <ivy:resolve/>
         <ivy:publish pubrevision="${soot.version}" status="release" resolver="local" overwrite="true" >
-            <artifacts pattern="{release.loc}/[artifact]-[revision].[ext]"/>
+            <artifacts pattern="${release.loc}/[artifact]-[revision].[ext]"/>
         </ivy:publish>
     </target>
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,29 @@
+<ivy-module version="2.0">
+    <info organisation="ca.mcgill.sable" module="soot"/>
+    <publications>
+        <artifact name="soot" type="jar" ext="jar" />
+        <artifact name="sootjavadoc" type="javadoc" ext="jar" />
+        <artifact name="sootsources" type="source" ext="jar" />
+        <!--
+        <artifact name="soot" type="classes" ext="jar" />
+        -->
+    </publications>
+    <!--<dependencies>
+        <dependency org="org.ow2.asm" name="asm-debug-all" rev="5.0.3" />
+        <!-AXMLPrinter2.jar missing ->
+        <dependency org="cglib" name="cglib-nodep" rev="2.2.2" />
+        <dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" />
+        <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
+        <dependency org="org.jboss" name="jboss-common-core" rev="2.5.0.Final" />
+        <dependency org="junit" name="junit" rev="4.11"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.10.8"/>
+        <dependency org="io.takari.polyglot" name="polyglot" rev="0.1.14" />
+        <dependency org="org.powermock" name="powermock-mockito-release-full" rev="1.6.4" />
+        <!-util-2.1.0-dev.jar ->
+        <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5"/>
+        <dependency org="org.slf4j" name="slf4j-simple" rev="1.7.5"/>
+
+        <dependency org="ca.mcgill.sable" name="heros" rev="trunk" changing="true" />
+        <dependency org="ca.mcgill.sable" name="jasmin" rev="trunk" changing="true" />
+    </dependencies>-->
+</ivy-module>


### PR DESCRIPTION
Added ant target to publish soot jar files to local ivy repository.
If there is no ivy-plugin for ant installed, the ant script loads ivy.jar from maven-repo and packs it into the ant directory.

It would be easy to manage the dependencies (asm, cglib, hamcrest ...) also via ivy.
Furthermore it would be comfortable to also publish heros to a public maven repository (maven central and/or a snapshot repo)