### PR TITLE
Making the Abstract Switch Statement visible

### DIFF
--- a/src/soot/jimple/internal/AbstractSwitchStmt.java
+++ b/src/soot/jimple/internal/AbstractSwitchStmt.java
@@ -11,7 +11,7 @@ import soot.ValueBox;
 import soot.jimple.SwitchStmt;
 
 @SuppressWarnings("serial")
-abstract class AbstractSwitchStmt extends AbstractStmt implements SwitchStmt {
+public abstract class AbstractSwitchStmt extends AbstractStmt implements SwitchStmt {
 
     final UnitBox defaultTargetBox;
     


### PR DESCRIPTION
Then we can operate on all Jimple switches using the common interface.