### PR TITLE
Stabilize Local Ordering

### DIFF
--- a/src/soot/JimpleBodyPack.java
+++ b/src/soot/JimpleBodyPack.java
@@ -84,6 +84,12 @@ public class JimpleBodyPack extends BodyPack
         PackManager.v().getTransform( "jb.lp" ).apply( b );			// LocalPacker
         PackManager.v().getTransform( "jb.ne" ).apply( b );			// NopEliminator
         PackManager.v().getTransform( "jb.uce" ).apply( b );		// UnreachableCodeEliminator: Again, we might have new dead code
+        
+        // LocalNameStandardizer: After all these changes, some locals
+        // may end up being eliminated. If we want a stable local iteration
+        // order between soot instances, running LocalNameStandardizer
+        // again after all other changes is required.
+        PackManager.v().getTransform( "jb.lns" ).apply( b );
                     
         if(Options.v().time())
             Timers.v().stmtCount += b.getUnits().size();

--- a/src/soot/JimpleClassProvider.java
+++ b/src/soot/JimpleClassProvider.java
@@ -31,7 +31,11 @@ public class JimpleClassProvider implements ClassProvider
         String fileName = className + ".jimple";
         SourceLocator.FoundFile file = 
             SourceLocator.v().lookupInClassPath(fileName);
-        if( file == null ) return null;
+        if( file == null ){
+        	fileName = className.replace('.', '/') + ".jimple";
+        	file = SourceLocator.v().lookupInClassPath(fileName);
+        	if( file == null ) return null;
+        }
         return new JimpleClassSource(className, file.inputStream());
     }
 }

--- a/src/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
+++ b/src/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
@@ -64,65 +64,65 @@ public class LocalNameStandardizer extends BodyTransformer
              * the same code in different iterations.
              * 
              * First sorts the locals alphabetically by the string representation of
-        	 * their type. Then if there are two locals with the same type, it uses
-        	 * the only other source of structurally stable information (i.e. the 
-        	 * instructions themselves) to produce an ordering for the locals
-        	 * that remains consistent between different soot instances. It achieves
-        	 * this by determining the position of a local's first occurrence in the 
-        	 * instruction's list of definition statements. This position is then used
-        	 * to sort the locals with the same type in an ascending order. 
-        	 * 
-        	 * The only times that this may not produce a consistent ordering for the 
-        	 * locals between different soot instances is if a local is never defined in
-        	 * the instructions or if the instructions themselves are changed in some way
-        	 * that effects the ordering of the locals. In the first case, if a local is 
-        	 * never defined, the other jimple body phases will remove this local as it is 
-        	 * unused. As such, all we have to do is rerun this LocalNameStandardizer after
-        	 * all other jimple body phases to eliminate any ambiguity introduced by these
-        	 * phases and by the removed unused locals. In the second case, if the instructions
-        	 * themselves changed then the user would have had to intentionally told soot to
-        	 * modify the instructions of the code. Otherwise, the instructions would not have
-        	 * changed because we assume the instructions to always be structurally stable
-        	 * between different instances of soot. As such, in this instance, the user should
-        	 * not be expecting soot to produce the same output as the input and thus the
-        	 * ordering of the locals does not matter.
-        	 */
+             * their type. Then if there are two locals with the same type, it uses
+             * the only other source of structurally stable information (i.e. the 
+             * instructions themselves) to produce an ordering for the locals
+             * that remains consistent between different soot instances. It achieves
+             * this by determining the position of a local's first occurrence in the 
+             * instruction's list of definition statements. This position is then used
+             * to sort the locals with the same type in an ascending order. 
+             * 
+             * The only times that this may not produce a consistent ordering for the 
+             * locals between different soot instances is if a local is never defined in
+             * the instructions or if the instructions themselves are changed in some way
+             * that effects the ordering of the locals. In the first case, if a local is 
+             * never defined, the other jimple body phases will remove this local as it is 
+             * unused. As such, all we have to do is rerun this LocalNameStandardizer after
+             * all other jimple body phases to eliminate any ambiguity introduced by these
+             * phases and by the removed unused locals. In the second case, if the instructions
+             * themselves changed then the user would have had to intentionally told soot to
+             * modify the instructions of the code. Otherwise, the instructions would not have
+             * changed because we assume the instructions to always be structurally stable
+             * between different instances of soot. As such, in this instance, the user should
+             * not be expecting soot to produce the same output as the input and thus the
+             * ordering of the locals does not matter.
+             */
             if(sortLocals){
-            	Chain<Local> locals = body.getLocals();
-            	final List<ValueBox> defs = body.getDefBoxes();
-            	ArrayList<Local> sortedLocals = new ArrayList<Local>(locals);
-            	
-            	Collections.sort(sortedLocals, new Comparator<Local>(){
-            		private Map<Local, Integer> firstOccuranceCache = new HashMap<Local, Integer>();
-					public int compare(Local arg0, Local arg1) {
-						int ret = arg0.getType().toString().compareTo(arg1.getType().toString());
-						if(ret == 0){
-							ret = Integer.compare(getFirstOccurance(arg0), getFirstOccurance(arg1));
-						}
-						return ret;
-					}
-					private int getFirstOccurance(Local l){
-						Integer cur = firstOccuranceCache.get(l);
-						if(cur != null){
-							return cur;
-						}else{
-							int count = 0;
-		            		int first = -1;
-							for(ValueBox vb : defs){
-								Value v = vb.getValue();
-		            			if(v instanceof Local && v.equals(l)){
-		            				first = count;
-		            				break;
-		            			}
-		            			count++;
-							}
-							firstOccuranceCache.put(l,first);
-							return first;
-						}
-					}
-            	});
-            	locals.clear();
-            	locals.addAll(sortedLocals);
+                Chain<Local> locals = body.getLocals();
+                final List<ValueBox> defs = body.getDefBoxes();
+                ArrayList<Local> sortedLocals = new ArrayList<Local>(locals);
+                
+                Collections.sort(sortedLocals, new Comparator<Local>(){
+                    private Map<Local, Integer> firstOccuranceCache = new HashMap<Local, Integer>();
+                    public int compare(Local arg0, Local arg1) {
+                        int ret = arg0.getType().toString().compareTo(arg1.getType().toString());
+                        if(ret == 0){
+                            ret = Integer.compare(getFirstOccurance(arg0), getFirstOccurance(arg1));
+                        }
+                        return ret;
+                    }
+                    private int getFirstOccurance(Local l){
+                        Integer cur = firstOccuranceCache.get(l);
+                        if(cur != null){
+                            return cur;
+                        }else{
+                            int count = 0;
+                            int first = -1;
+                            for(ValueBox vb : defs){
+                                Value v = vb.getValue();
+                                if(v instanceof Local && v.equals(l)){
+                                    first = count;
+                                    break;
+                                }
+                                count++;
+                            }
+                            firstOccuranceCache.put(l,first);
+                            return first;
+                        }
+                    }
+                });
+                locals.clear();
+                locals.addAll(sortedLocals);
             }
             
             Iterator<Local> localIt = body.getLocals().iterator();

--- a/src/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
+++ b/src/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
@@ -31,6 +31,7 @@
 package soot.jimple.toolkits.scalar;
 
 import soot.*;
+import soot.util.Chain;
 
 import java.util.*;
 
@@ -42,6 +43,8 @@ public class LocalNameStandardizer extends BodyTransformer
     protected void internalTransform(Body body, String phaseName, Map<String,String> options)
     {
         boolean onlyStackName = PhaseOptions.getBoolean(options, "only-stack-locals");
+        //boolean sortLocals = PhaseOptions.getBoolean(options, "stabilize-local-order");
+        boolean sortLocals = true;
 
         // Change the names to the standard forms now.
         {
@@ -54,6 +57,74 @@ public class LocalNameStandardizer extends BodyTransformer
             int errorCount = 0;
             int nullCount = 0;
 
+            /* The goal of this option is to ensure that local ordering remains
+             * consistent between different iterations of soot. This helps to ensure
+             * things like stable string representations of instructions and stable
+             * jimple representations of a methods body when soot is used to load
+             * the same code in different iterations.
+             * 
+             * First sorts the locals alphabetically by the string representation of
+        	 * their type. Then if there are two locals with the same type, it uses
+        	 * the only other source of structurally stable information (i.e. the 
+        	 * instructions themselves) to produce an ordering for the locals
+        	 * that remains consistent between different soot instances. It achieves
+        	 * this by determining the position of a local's first occurrence in the 
+        	 * instruction's list of definition statements. This position is then used
+        	 * to sort the locals with the same type in an ascending order. 
+        	 * 
+        	 * The only times that this may not produce a consistent ordering for the 
+        	 * locals between different soot instances is if a local is never defined in
+        	 * the instructions or if the instructions themselves are changed in some way
+        	 * that effects the ordering of the locals. In the first case, if a local is 
+        	 * never defined, the other jimple body phases will remove this local as it is 
+        	 * unused. As such, all we have to do is rerun this LocalNameStandardizer after
+        	 * all other jimple body phases to eliminate any ambiguity introduced by these
+        	 * phases and by the removed unused locals. In the second case, if the instructions
+        	 * themselves changed then the user would have had to intentionally told soot to
+        	 * modify the instructions of the code. Otherwise, the instructions would not have
+        	 * changed because we assume the instructions to always be structurally stable
+        	 * between different instances of soot. As such, in this instance, the user should
+        	 * not be expecting soot to produce the same output as the input and thus the
+        	 * ordering of the locals does not matter.
+        	 */
+            if(sortLocals){
+            	Chain<Local> locals = body.getLocals();
+            	final List<ValueBox> defs = body.getDefBoxes();
+            	ArrayList<Local> sortedLocals = new ArrayList<Local>(locals);
+            	
+            	Collections.sort(sortedLocals, new Comparator<Local>(){
+            		private Map<Local, Integer> firstOccuranceCache = new HashMap<Local, Integer>();
+					public int compare(Local arg0, Local arg1) {
+						int ret = arg0.getType().toString().compareTo(arg1.getType().toString());
+						if(ret == 0){
+							ret = Integer.compare(getFirstOccurance(arg0), getFirstOccurance(arg1));
+						}
+						return ret;
+					}
+					private int getFirstOccurance(Local l){
+						Integer cur = firstOccuranceCache.get(l);
+						if(cur != null){
+							return cur;
+						}else{
+							int count = 0;
+		            		int first = -1;
+							for(ValueBox vb : defs){
+								Value v = vb.getValue();
+		            			if(v instanceof Local && v.equals(l)){
+		            				first = count;
+		            				break;
+		            			}
+		            			count++;
+							}
+							firstOccuranceCache.put(l,first);
+							return first;
+						}
+					}
+            	});
+            	locals.clear();
+            	locals.addAll(sortedLocals);
+            }
+            
             Iterator<Local> localIt = body.getLocals().iterator();
 
             while(localIt.hasNext())


### PR DESCRIPTION
This pull request has two changes.

1) This is a minor change that should not affect anybody. The changes talked about here were made in the JimpleClassProvider class. 

> Description: If a jimple class file cannot be found using the file path packageName.className.jimple it tries locating the file using the path packageName/className.jimple. Basically, this adds the ability for a jimple file to be looked up using the package name as a set of directories representing a path (much like how class files are loaded). This additional method will only be used if the original method for looking up jimple files fails.

2) The second change involves stabilizing the local ordering and thus the local naming. The changes talked about here were made in the JimpleBodyPack and the LocalNameStandardizer classes. Note I was going to make the code that orders the locals optional by adding a phase option to the LocalNameStandardizer but I was not sure how to go about adding a phase option.

> Description: The goal of this option is to ensure that local ordering remains consistent between different iterations of soot. This helps to ensure things like stable string representations of instructions and stable jimple representations of a methods body when soot is used to load the same code in different iterations.  

> This first sorts the locals alphabetically by the string representation of their type. Then if there are two locals with the same type, it uses the only other source of structurally stable information (i.e. the instructions themselves) to produce an ordering for the locals that remains consistent between different soot instances. It achieves this by determining the position of a local's first occurrence in the instruction's list of definition statements. This position is then used to sort the locals with the same type in an ascending order.  

> The only times that this may not produce a consistent ordering for the locals between different soot instances is if a local is never defined in the instructions or if the instructions themselves are changed in some way that affects the ordering of the locals. In the first case, if a local is never defined, the other jimple body phases will remove this local as it is unused. As such, all we have to do is rerun this LocalNameStandardizer after all other jimple body phases to eliminate any ambiguity introduced by these phases and by the removed unused locals. In the second case, if the instructions themselves changed then the user would have had to intentionally told soot to modify the instructions of the code. Otherwise, the instructions would not have changed because we assume the instructions to always be structurally stable between different instances of soot. As such, in this instance, the user should not be expecting soot to produce the same output as the input and thus the ordering of the locals does not matter.