### PR TITLE
Add org.w3c.dom to isJavaLibraryClass method

### DIFF
--- a/src/soot/SootClass.java
+++ b/src/soot/SootClass.java
@@ -1043,7 +1043,8 @@ public class SootClass extends AbstractHost implements Numberable {
 	public boolean isJavaLibraryClass() {
 		if (name.startsWith("java.") || name.startsWith("sun.")
 				|| name.startsWith("javax.") || name.startsWith("com.sun.")
-				|| name.startsWith("org.omg.") || name.startsWith("org.xml."))
+				|| name.startsWith("org.omg.") || name.startsWith("org.xml.")
+                || name.startsWith("org.w3c.dom"))
 			return true;
 
 		return false;


### PR DESCRIPTION
According to `https://docs.oracle.com/javase/7/docs/api/org/w3c/dom/package-summary.html`, package org.w3c.dom is a part of Java's library since JDK 1.4.