### PR TITLE
Adds type-based resolution of invoke() calls

### DIFF
--- a/doc/soot_options.htm
+++ b/doc/soot_options.htm
@@ -2142,6 +2142,16 @@ print: the program prints a stack trace when reaching a porgram location that wa
 the program throws an Error instead.                                                                                                
 </p>
 </li>
+<li>
+<b>Types for invoke</b> (types-for-invoke)
+		<br>
+			(default value: <span class="value">false</span>)
+		<p>For each call to Method.invoke(), use the possible types of the first receiver
+								  argument and the possible types stored in the second argument array to resolve calls to
+								  Method.invoke(). This strategy makes no attempt to resolve reflectively invoked static methods.
+								  Currently only works for context insensitive pointer analyses.
+								  </p>
+</li>
 </ul>
 <h2>
 <a name="phase_5_1">Class Hierarchy Analysis (cg.cha)</a>

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -739,6 +739,9 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 		addToEnableGroup("cg", getcgtrim_clinit_widget(), "trim-clinit");
 		
 		
+		addToEnableGroup("cg", getcgtypes_for_invoke_widget(), "types-for-invoke");
+		
+		
 		getcgenabled_widget().getButton().addSelectionListener(this);
 		
 		getcgsafe_forname_widget().getButton().addSelectionListener(this);
@@ -752,6 +755,8 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 		getcgimplicit_entry_widget().getButton().addSelectionListener(this);
 		
 		getcgtrim_clinit_widget().getButton().addSelectionListener(this);
+		
+		getcgtypes_for_invoke_widget().getButton().addSelectionListener(this);
 		
 		
 		makeNewEnableGroup("cg", "cg.cha");
@@ -3066,6 +3071,16 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 
 		if (boolRes != defBoolRes) {
 			getConfig().put(getcgtrim_clinit_widget().getAlias(), new Boolean(boolRes));
+		}
+		
+		boolRes = getcgtypes_for_invoke_widget().getButton().getSelection();
+		
+		
+		defBoolRes = false;
+		
+
+		if (boolRes != defBoolRes) {
+			getConfig().put(getcgtypes_for_invoke_widget().getAlias(), new Boolean(boolRes));
 		}
 		
 		stringRes = getcgjdkver_widget().getText().getText();
@@ -7845,6 +7860,16 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 	
 	public BooleanOptionWidget getcgtrim_clinit_widget() {
 		return cgtrim_clinit_widget;
+	}	
+	
+	private BooleanOptionWidget cgtypes_for_invoke_widget;
+	
+	private void setcgtypes_for_invoke_widget(BooleanOptionWidget widget) {
+		cgtypes_for_invoke_widget = widget;
+	}
+	
+	public BooleanOptionWidget getcgtypes_for_invoke_widget() {
+		return cgtypes_for_invoke_widget;
 	}	
 	
 	
@@ -13499,6 +13524,22 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 		}
 
 		setcgtrim_clinit_widget(new BooleanOptionWidget(editGroupcg, SWT.NONE, new OptionData("Trim Static Initializer Edges", "p", "cg","trim-clinit", "\nThe call graph contains an edge from each statement that could \ntrigger execution of a static initializer to that static \ninitializer. However, each static initializer is triggered only \nonce. When this option is enabled, after the call graph is \nbuilt, an intra-procedural analysis is performed to detect \nstatic initializer edges leading to methods that must have \nalready been executed. Since these static initializers cannot be \nexecuted again, the corresponding call graph edges are removed \nfrom the call graph. ", defaultBool)));
+		
+		
+		
+		defKey = "p"+" "+"cg"+" "+"types-for-invoke";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultBool = getBoolDef(defKey);	
+		}
+		else {
+			
+			defaultBool = false;
+			
+		}
+
+		setcgtypes_for_invoke_widget(new BooleanOptionWidget(editGroupcg, SWT.NONE, new OptionData("Types for invoke", "p", "cg","types-for-invoke", "\nFor each call to Method.invoke(), use the possible types of the \nfirst receiver 								 argument and the possible types stored \nin the second argument array to resolve calls to 								 \nMethod.invoke(). This strategy makes no attempt to resolve \nreflectively invoked static methods. 								 Currently only \nworks for context insensitive pointer analyses. 								 ", defaultBool)));
 		
 		
 		

--- a/generated/options/soot/AntTask.java
+++ b/generated/options/soot/AntTask.java
@@ -1210,6 +1210,12 @@ public class AntTask extends MatchingTask {
             addArg("trim-clinit:"+(arg?"true":"false"));
           }
       
+          public void settypes_for_invoke(boolean arg) {
+            addArg("-p");
+            addArg("cg");
+            addArg("types-for-invoke:"+(arg?"true":"false"));
+          }
+      
           public void setlibrary(String arg) {
             addArg("-p");
             addArg("cg");

--- a/generated/options/soot/options/CGOptions.java
+++ b/generated/options/soot/options/CGOptions.java
@@ -142,6 +142,22 @@ public class CGOptions
         return soot.PhaseOptions.getBoolean( options, "trim-clinit" );
     }
     
+    /** Types for invoke --
+    
+     * Uses reaching types inferred by the pointer analysis to resolve 
+     * reflective calls..
+    
+     * For each call to Method.invoke(), use the possible types of the 
+     * first receiver 								 argument and the possible types stored 
+     * in the second argument array to resolve calls to 								 
+     * Method.invoke(). This strategy makes no attempt to resolve 
+     * reflectively invoked static methods. 								 Currently only 
+     * works for context insensitive pointer analyses. 								 
+     */
+    public boolean types_for_invoke() {
+        return soot.PhaseOptions.getBoolean( options, "types-for-invoke" );
+    }
+    
     /** JDK version --
     
      * JDK version for native methods.

--- a/generated/options/soot/options/Options.java
+++ b/generated/options/soot/options/Options.java
@@ -2073,7 +2073,8 @@ public class Options extends OptionsBase {
                 +padOpt( "implicit-entry (true)", "Include methods called implicitly by the VM as entry points" )
                 +padOpt( "trim-clinit (true)", "Removes redundant static initializer calls" )
                 +padOpt( "reflection-log", "Uses a reflection log to resolve reflective calls." )
-                +padOpt( "guards (ignore)", "Describes how to guard the program from unsound assumptions." );
+                +padOpt( "guards (ignore)", "Describes how to guard the program from unsound assumptions." )
+                +padOpt( "types-for-invoke (false)", "Uses reaching types inferred by the pointer analysis to resolve reflective calls." );
     
         if( phaseName.equals( "cg.cha" ) )
             return "Phase "+phaseName+":\n"+
@@ -3037,7 +3038,8 @@ public class Options extends OptionsBase {
                 +"implicit-entry "
                 +"trim-clinit "
                 +"reflection-log "
-                +"guards ";
+                +"guards "
+                +"types-for-invoke ";
     
         if( phaseName.equals( "cg.cha" ) )
             return ""
@@ -3656,7 +3658,8 @@ public class Options extends OptionsBase {
               +"all-reachable:false "
               +"implicit-entry:true "
               +"trim-clinit:true "
-              +"guards:ignore ";
+              +"guards:ignore "
+              +"types-for-invoke:false ";
     
         if( phaseName.equals( "cg.cha" ) )
             return ""

--- a/src/soot/jimple/spark/solver/OnFlyCallGraph.java
+++ b/src/soot/jimple/spark/solver/OnFlyCallGraph.java
@@ -22,7 +22,12 @@ import soot.Context;
 import soot.Local;
 import soot.MethodOrMethodContext;
 import soot.Scene;
+import soot.Type;
+import soot.jimple.IntConstant;
+import soot.jimple.NewArrayExpr;
+import soot.jimple.spark.pag.AllocDotField;
 import soot.jimple.spark.pag.AllocNode;
+import soot.jimple.spark.pag.ArrayElement;
 import soot.jimple.spark.pag.MethodPAG;
 import soot.jimple.spark.pag.Node;
 import soot.jimple.spark.pag.PAG;
@@ -72,7 +77,7 @@ public class OnFlyCallGraph {
     private void processReachables() {
         reachableMethods.update();
         while(reachablesReader.hasNext()) {
-            MethodOrMethodContext m = (MethodOrMethodContext) reachablesReader.next();
+            MethodOrMethodContext m = reachablesReader.next();
             MethodPAG mpag = MethodPAG.v( pag, m.method() );
             mpag.build();
             mpag.addToPAG(m.context());
@@ -80,7 +85,7 @@ public class OnFlyCallGraph {
     }
     private void processCallEdges() {
         while(callEdges.hasNext()) {
-            Edge e = (Edge) callEdges.next();
+            Edge e = callEdges.next();
             MethodPAG amp = MethodPAG.v( pag, e.tgt() );
             amp.build();
             amp.addToPAG( e.tgtCtxt() );
@@ -89,6 +94,20 @@ public class OnFlyCallGraph {
     }
 
     public OnFlyCallGraphBuilder ofcgb() { return ofcgb; }
+    
+    public void updatedFieldRef(final AllocDotField df, PointsToSetInternal ptsi) {
+    	if(df.getField() != ArrayElement.v()) {
+    		return;
+    	}
+    	if(ofcgb.wantArrayField(df)) {
+    		ptsi.forall(new P2SetVisitor() {
+				@Override
+				public void visit(Node n) {
+					ofcgb.addInvokeArgType(df, null, n.getType());
+				}
+			});
+    	}
+    }
 
     public void updatedNode( VarNode vn ) {
         Object r = vn.getVariable();
@@ -113,6 +132,26 @@ public class OnFlyCallGraph {
                     ofcgb.addStringConstant( receiver, context, null );
                 }
             }} );
+        }
+        if(ofcgb.wantInvokeArg(receiver)) {
+        	p2set.forall(new P2SetVisitor() {
+				@Override
+				public void visit(Node n) {
+					AllocNode an = ((AllocNode)n);
+					ofcgb.addInvokeArgDotField(receiver, an.dot(ArrayElement.v()));
+					assert an.getNewExpr() instanceof NewArrayExpr;
+					NewArrayExpr nae = (NewArrayExpr) an.getNewExpr();
+					if(!(nae.getSize() instanceof IntConstant)) {
+						ofcgb.setArgArrayNonDetSize(receiver, context);
+					} else {
+						IntConstant sizeConstant = (IntConstant) nae.getSize();
+						ofcgb.addPossibleArgArraySize(receiver, sizeConstant.value, context);
+					}
+				}
+			});
+        	for(Type ty : pag.reachingObjectsOfArrayElement(p2set).possibleTypes()) {
+        		ofcgb.addInvokeArgType(receiver, context, ty);
+        	}
         }
     }
 

--- a/src/soot/jimple/spark/solver/PropWorklist.java
+++ b/src/soot/jimple/spark/solver/PropWorklist.java
@@ -69,6 +69,9 @@ public final class PropWorklist extends Propagator {
 						public final void visit(Node n) {
 							AllocDotField nDotF = pag.makeAllocDotField(
 									(AllocNode) n, target.getField());
+                            if(ofcg != null) {
+                            	ofcg.updatedFieldRef(nDotF, src.getP2Set());
+                            }
 							nDotF.makeP2Set().addAll(src.getP2Set(), null);
 						}
 					});

--- a/src/soot/jimple/toolkits/callgraph/ConstantArrayAnalysis.java
+++ b/src/soot/jimple/toolkits/callgraph/ConstantArrayAnalysis.java
@@ -76,13 +76,13 @@ public class ConstantArrayAnalysis extends ForwardFlowAnalysis<Unit, ConstantArr
 		}
 	}
 
-	private Map<Local, Integer> localToInt = new HashMap<>();
-	private Map<Type, Integer> typeToInt = new HashMap<>();
-	private Map<Integer, Integer> sizeToInt = new HashMap<>();
+	private Map<Local, Integer> localToInt = new HashMap<Local, Integer>();
+	private Map<Type, Integer> typeToInt = new HashMap<Type, Integer>();
+	private Map<Integer, Integer> sizeToInt = new HashMap<Integer, Integer>();
 	
 	
-	private Map<Integer, Type> rvTypeToInt = new HashMap<>();
-	private Map<Integer, Integer> rvSizeToInt = new HashMap<>();
+	private Map<Integer, Type> rvTypeToInt = new HashMap<Integer, Type>();
+	private Map<Integer, Integer> rvSizeToInt = new HashMap<Integer, Integer>();
 	
 	private int size;
 	private int typeSize;

--- a/src/soot/jimple/toolkits/callgraph/ConstantArrayAnalysis.java
+++ b/src/soot/jimple/toolkits/callgraph/ConstantArrayAnalysis.java
@@ -1,0 +1,321 @@
+package soot.jimple.toolkits.callgraph;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import soot.ArrayType;
+import soot.Body;
+import soot.Local;
+import soot.Type;
+import soot.Unit;
+import soot.Value;
+import soot.ValueBox;
+import soot.jimple.ArrayRef;
+import soot.jimple.DefinitionStmt;
+import soot.jimple.IntConstant;
+import soot.jimple.NewArrayExpr;
+import soot.jimple.NullConstant;
+import soot.jimple.Stmt;
+import soot.shimple.PhiExpr;
+import soot.toolkits.graph.DirectedGraph;
+import soot.toolkits.scalar.ForwardFlowAnalysis;
+
+public class ConstantArrayAnalysis extends ForwardFlowAnalysis<Unit, ConstantArrayAnalysis.ArrayState> {
+	private class ArrayTypesInternal implements Cloneable {
+		BitSet typeState[];
+		BitSet sizeState = new BitSet(szSize);
+		@Override
+		public Object clone() {
+			ArrayTypesInternal s;
+			try {
+				s = (ArrayTypesInternal) super.clone();
+				s.sizeState = (BitSet) s.sizeState.clone();
+				s.typeState = s.typeState.clone();
+				return s;
+			} catch (CloneNotSupportedException e) {
+				throw new InternalError();
+			}
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if(!(obj instanceof ArrayTypesInternal)) {
+				return false;
+			}
+			ArrayTypesInternal otherTypes = (ArrayTypesInternal) obj;
+			return otherTypes.sizeState.equals(sizeState) && Arrays.equals(typeState, otherTypes.typeState);
+		}
+	}
+	
+	public static class ArrayTypes {
+		public Set<Integer> possibleSizes;
+		public Set<Type>[] possibleTypes;
+		@Override
+		public String toString() {
+			return "ArrayTypes [possibleSizes=" + possibleSizes
+					+ ", possibleTypes=" + Arrays.toString(possibleTypes) + "]";
+		}
+	}
+	
+	public class ArrayState {
+		ArrayTypesInternal[] state = new ArrayTypesInternal[size];
+		BitSet active = new BitSet(size);
+		
+		@Override
+		public boolean equals(Object obj) {
+			if(!(obj instanceof ArrayState)) {
+				return false;
+			}
+			ArrayState otherState = (ArrayState) obj;
+			return otherState.active.equals(active) && Arrays.equals(state, otherState.state);
+		}
+	}
+
+	private Map<Local, Integer> localToInt = new HashMap<>();
+	private Map<Type, Integer> typeToInt = new HashMap<>();
+	private Map<Integer, Integer> sizeToInt = new HashMap<>();
+	
+	
+	private Map<Integer, Type> rvTypeToInt = new HashMap<>();
+	private Map<Integer, Integer> rvSizeToInt = new HashMap<>();
+	
+	private int size;
+	private int typeSize;
+	private int szSize;
+	public ConstantArrayAnalysis(DirectedGraph<Unit> graph, Body b) {
+		super(graph);
+		for(Local l : b.getLocals()) {
+			localToInt.put(l, size++);
+		}
+		for(Unit u : b.getUnits()) {
+			Stmt s = (Stmt) u;
+			if(s instanceof DefinitionStmt) {
+				Type ty = ((DefinitionStmt) s).getRightOp().getType();
+				if(!typeToInt.containsKey(ty)) {
+					int key = typeSize++;
+					typeToInt.put(ty, key);
+					rvTypeToInt.put(key, ty);
+				}
+				if(((DefinitionStmt) s).getRightOp() instanceof NewArrayExpr) {
+					NewArrayExpr nae = (NewArrayExpr) ((DefinitionStmt) s).getRightOp();
+					if(nae.getSize() instanceof IntConstant) {
+						int sz = ((IntConstant) nae.getSize()).value;
+						if(!sizeToInt.containsKey(sz)) {
+							int key = szSize++;
+							sizeToInt.put(sz, key);
+							rvSizeToInt.put(key, sz);
+						}
+					}
+				}
+			}
+		}
+		doAnalysis();
+	}
+	
+	@Override
+	protected void flowThrough(ArrayState in, Unit d, ArrayState out) {
+		out.active.clear();
+		out.active.or(in.active);
+		out.state = Arrays.copyOf(in.state, in.state.length);
+		if(d instanceof DefinitionStmt) {
+			DefinitionStmt ds = (DefinitionStmt) d;
+			Value rhs = ds.getRightOp();
+			Value lhs = ds.getLeftOp();
+			if(rhs instanceof NewArrayExpr) {
+				Local l = (Local) lhs;
+				int varRef = localToInt.get(l);
+				NewArrayExpr nae = (NewArrayExpr) rhs;
+				out.active.set(varRef);
+				if(!(nae.getSize() instanceof IntConstant)) {
+					out.state[varRef] = null;
+				} else {
+					int arraySize = ((IntConstant) nae.getSize()).value;
+					out.state[varRef] = new ArrayTypesInternal();
+					out.state[varRef].sizeState.set(sizeToInt.get(arraySize));
+					out.state[varRef].typeState = new BitSet[arraySize];
+					for(int i = 0; i < arraySize; i++) {
+						out.state[varRef].typeState[i] = new BitSet(typeSize);
+					}
+				}
+			} else if(lhs instanceof Local &&
+					lhs.getType() instanceof ArrayType && 
+					rhs instanceof NullConstant) {
+				int varRef = localToInt.get(lhs);
+				out.active.clear(varRef);
+				out.state[varRef] = null;
+			} else if(lhs instanceof Local && rhs instanceof Local && 
+					in.state[localToInt.get(rhs)] != null && in.active.get(localToInt.get(rhs))) {
+				int lhsRef = localToInt.get(lhs);
+				int rhsRef = localToInt.get(rhs);
+				out.active.set(lhsRef);
+				out.state[lhsRef] = in.state[rhsRef];
+				out.state[rhsRef] = null;
+			} else if(lhs instanceof Local && rhs instanceof PhiExpr) {
+				PhiExpr rPhi = (PhiExpr) rhs;
+				int lhsRef = localToInt.get(lhs);
+				out.state[lhsRef] = null;
+				int i = 0;
+				List<Value> phiValues = rPhi.getValues();
+				for( ; i < phiValues.size(); i++) {
+					Value v = phiValues.get(i);
+					int argRef = localToInt.get(v);
+					if(!in.active.get(argRef)) {
+						continue;
+					}
+					out.active.set(lhsRef);
+					// one bottom -> all bottom
+					if(in.state[argRef] == null) {
+						out.state[lhsRef] = null;
+						break;
+					}
+					if(out.state[lhsRef] == null) {
+						out.state[lhsRef] = in.state[argRef];
+					} else {
+						out.state[lhsRef] = mergeTypeStates(in.state[argRef], out.state[lhsRef]);
+					}
+					out.state[argRef] = null;
+				}
+				for( ; i < phiValues.size(); i++) {
+					int argRef = localToInt.get(phiValues.get(i));
+					out.state[argRef] = null;
+				}
+			} else if(lhs instanceof ArrayRef) {
+				ArrayRef ar = (ArrayRef) lhs;
+				Value indexVal = ar.getIndex();
+				int localRef = localToInt.get(ar.getBase());
+				if(!(indexVal instanceof IntConstant)) {
+					out.state[localRef] = null;
+					out.active.set(localRef);
+				} else if(out.state[localRef] != null) {
+					Type assignType = rhs.getType();
+					int index = ((IntConstant) indexVal).value;
+					assert index < out.state[localRef].typeState.length;
+					out.state[localRef] = (ArrayTypesInternal) out.state[localRef].clone();
+					out.state[localRef].typeState[index] = (BitSet) out.state[localRef].typeState[index].clone();
+					assert out.state[localRef].typeState[index] != null : d;
+					out.state[localRef].typeState[index].set(typeToInt.get(assignType));
+				}
+			} else {
+				Value leftOp = lhs;
+				if(leftOp instanceof Local) {
+					Local defLocal = (Local) leftOp;
+					int varRef = localToInt.get(defLocal);
+					out.active.set(varRef);
+					out.state[varRef] = null;
+				}
+			}
+			for(ValueBox b : rhs.getUseBoxes()) {
+				if(localToInt.containsKey(b.getValue())) {
+					int localRef = localToInt.get(b.getValue());
+					out.state[localRef] = null;
+					out.active.set(localRef);
+				}
+			}
+			if(localToInt.containsKey(rhs)) {
+				int localRef = localToInt.get(rhs);
+				out.state[localRef] = null;
+				out.active.set(localRef);
+			}
+		} else {
+			for(ValueBox b : d.getUseBoxes()) {
+				if(localToInt.containsKey(b.getValue())) {
+					int localRef = localToInt.get(b.getValue());
+					out.state[localRef] = null;
+					out.active.set(localRef);
+				}
+			}
+		}
+	}
+	
+	@Override
+	protected ArrayState newInitialFlow() {
+		return new ArrayState();
+	}
+	@Override
+	protected void merge(ArrayState in1, ArrayState in2, ArrayState out) {
+		out.active.clear();
+		out.active.or(in1.active);
+		out.active.or(in2.active);
+		BitSet in2_excl = (BitSet) in2.active.clone();
+		in2_excl.andNot(in1.active);
+		
+		for (int i = in1.active.nextSetBit(0); i >= 0; i = in1.active.nextSetBit(i + 1)) {
+			if(in1.state[i] == null) {
+				out.state[i] = null;
+			} else if(in2.active.get(i)) {
+				if(in2.state[i] == null) {
+					out.state[i] = null;
+				} else {
+					out.state[i] = mergeTypeStates(in1.state[i], in2.state[i]);
+				}
+			} else {
+				out.state[i] = in1.state[i];
+			}
+		}
+		for (int i = in2_excl.nextSetBit(0); i >= 0; i = in2_excl.nextSetBit(i + 1)) {
+			out.state[i] = in2.state[i];
+		}
+	}
+	private ArrayTypesInternal mergeTypeStates(ArrayTypesInternal a1, ArrayTypesInternal a2) {
+		assert a1 != null && a2 != null;
+		ArrayTypesInternal toRet = new ArrayTypesInternal();
+		toRet.sizeState.or(a1.sizeState);
+		toRet.sizeState.or(a2.sizeState);
+		int maxSize = Math.max(a1.typeState.length, a2.typeState.length);
+		int commonSize = Math.min(a1.typeState.length, a2.typeState.length);
+		toRet.typeState = new BitSet[maxSize];
+		for(int i = 0; i < commonSize; i++) {
+			toRet.typeState[i] = new BitSet(typeSize);
+			toRet.typeState[i].or(a1.typeState[i]);
+			toRet.typeState[i].or(a2.typeState[i]);
+		}
+		for(int i = commonSize; i < maxSize; i++) {
+			if(a1.typeState.length > i) {
+				toRet.typeState[i] = (BitSet) a1.typeState[i].clone();
+			} else {
+				toRet.typeState[i] = (BitSet) a2.typeState[i].clone();
+			}
+		}
+		return toRet;
+	}
+
+	@Override
+	protected void copy(ArrayState source, ArrayState dest) {
+		dest.active = source.active;
+		dest.state = source.state;
+	}
+
+	public boolean isConstantBefore(Stmt s, Local arrayLocal) {
+		ArrayState flowResults = getFlowBefore(s);
+		int varRef = localToInt.get(arrayLocal);
+		return flowResults.active.get(varRef) && flowResults.state[varRef] != null;
+	}
+	
+	@SuppressWarnings("unchecked")
+	public ArrayTypes getArrayTypesBefore(Stmt s, Local arrayLocal) {
+		if(!isConstantBefore(s, arrayLocal)) {
+			return null;
+		}
+		ArrayTypes toRet = new ArrayTypes();
+		int varRef = localToInt.get(arrayLocal);
+		ArrayTypesInternal ati = getFlowBefore(s).state[varRef];
+		toRet.possibleSizes = new HashSet<Integer>();
+		toRet.possibleTypes = new Set[ati.typeState.length];
+		for(int i = ati.sizeState.nextSetBit(0); i >= 0; i = ati.sizeState.nextSetBit(i + 1)) {
+			toRet.possibleSizes.add(rvSizeToInt.get(i));
+		}
+		for(int i = 0; i < toRet.possibleTypes.length; i++) {
+			toRet.possibleTypes[i] = new HashSet<Type>();
+			for(int j = ati.typeState[i].nextSetBit(0); j >= 0; j = ati.typeState[i].nextSetBit(j + 1)) {
+				toRet.possibleTypes[i].add(rvTypeToInt.get(j));
+			}
+		}
+		return toRet;
+	}
+	
+}

--- a/src/soot/jimple/toolkits/callgraph/InvokeCallSite.java
+++ b/src/soot/jimple/toolkits/callgraph/InvokeCallSite.java
@@ -1,0 +1,54 @@
+package soot.jimple.toolkits.callgraph;
+
+import soot.Local;
+import soot.SootMethod;
+import soot.jimple.InstanceInvokeExpr;
+import soot.jimple.Stmt;
+import soot.jimple.toolkits.callgraph.ConstantArrayAnalysis.ArrayTypes;
+
+public class InvokeCallSite {
+	public static final int MUST_BE_NULL = 0;
+	public static final int MUST_NOT_BE_NULL = 1;
+	public static final int MAY_BE_NULL = -1;
+	
+    private InstanceInvokeExpr iie;
+    private Stmt stmt;
+    private SootMethod container;
+	private Local argArray;
+	private Local base;
+	private int nullnessCode;
+	private ArrayTypes reachingTypes;
+
+    public InvokeCallSite(Stmt stmt, SootMethod container,
+            InstanceInvokeExpr iie, Local base) {
+    	this(stmt, container, iie, base, (Local)null, 0);
+    }
+    public InvokeCallSite(Stmt stmt, SootMethod container, InstanceInvokeExpr iie,
+			Local base, Local argArray, int nullnessCode) {
+    	this.stmt = stmt;
+        this.container = container;
+        this.iie = iie;
+        this.base = base;
+        this.argArray = argArray;
+        this.nullnessCode = nullnessCode;
+	}
+    
+    
+	public InvokeCallSite(Stmt stmt, SootMethod container, InstanceInvokeExpr iie,
+			Local base, ArrayTypes reachingArgTypes, int nullnessCode) {
+		this.stmt = stmt;
+		this.container = container;
+		this.iie = iie;
+		this.base = base;
+		this.nullnessCode = nullnessCode;
+		this.argArray = null;
+		this.reachingTypes = reachingArgTypes;
+	}
+	public Stmt stmt() { return stmt; }
+    public SootMethod container() { return container; }
+    public InstanceInvokeExpr iie() { return iie; }
+	public Local base() { return base; }
+	public Local argArray() { return argArray; }
+	public int nullnessCode() { return nullnessCode; }
+	public ArrayTypes reachingTypes() { return reachingTypes; }
+}

--- a/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -464,17 +464,17 @@ public final class OnFlyCallGraphBuilder
     
     // type based reflection resolution state
     
-    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeBases = new LargeNumberedMap<>(Scene.v().getMethodNumberer());
-    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeArgs = new LargeNumberedMap<>(Scene.v().getMethodNumberer());
+    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeBases = new LargeNumberedMap<SootMethod, List<Local>>(Scene.v().getMethodNumberer());
+    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeArgs = new LargeNumberedMap<SootMethod, List<Local>>(Scene.v().getMethodNumberer());
     public LargeNumberedMap<SootMethod, List<Local>> methodToInvokeArgs() { return methodToInvokeArgs; }
     public LargeNumberedMap<SootMethod, List<Local>> methodToInvokeBases() { return methodToInvokeBases; }
     
-    private final Map<Local, List<InvokeCallSite>> baseToInvokeSite = new IdentityHashMap<>();
-    private final Map<Local, List<InvokeCallSite>> invokeArgsToInvokeSite = new IdentityHashMap<>();
-    private final Map<Local, Set<Integer>> invokeArgsToSize = new IdentityHashMap<>();
-    private final Map<AllocDotField, Set<Local>> allocDotFieldToLocal = new IdentityHashMap<>();
-    private final Map<Local, Set<Type>> reachingArgTypes = new IdentityHashMap<>();
-    private final Map<Local, Set<Type>> reachingBaseTypes = new IdentityHashMap<>();
+    private final Map<Local, List<InvokeCallSite>> baseToInvokeSite = new IdentityHashMap<Local, List<InvokeCallSite>>();
+    private final Map<Local, List<InvokeCallSite>> invokeArgsToInvokeSite = new IdentityHashMap<Local, List<InvokeCallSite>>();
+    private final Map<Local, Set<Integer>> invokeArgsToSize = new IdentityHashMap<Local, Set<Integer>>();
+    private final Map<AllocDotField, Set<Local>> allocDotFieldToLocal = new IdentityHashMap<AllocDotField, Set<Local>>();
+    private final Map<Local, Set<Type>> reachingArgTypes = new IdentityHashMap<Local, Set<Type>>();
+    private final Map<Local, Set<Type>> reachingBaseTypes = new IdentityHashMap<Local, Set<Type>>();
     
     // end type based reflection resolution
     

--- a/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,19 +31,30 @@ import java.util.Set;
 
 import soot.ArrayType;
 import soot.Body;
+import soot.BooleanType;
+import soot.ByteType;
+import soot.CharType;
 import soot.Context;
+import soot.DoubleType;
 import soot.EntryPoints;
 import soot.FastHierarchy;
+import soot.FloatType;
 import soot.G;
+import soot.IntType;
 import soot.Kind;
 import soot.Local;
+import soot.LongType;
 import soot.MethodContext;
 import soot.MethodOrMethodContext;
+import soot.NullType;
 import soot.PackManager;
 import soot.PhaseOptions;
+import soot.PrimType;
+import soot.RefLikeType;
 import soot.RefType;
 import soot.Scene;
 import soot.SceneTransformer;
+import soot.ShortType;
 import soot.SootClass;
 import soot.SootMethod;
 import soot.SootMethodRef;
@@ -61,16 +73,22 @@ import soot.jimple.Jimple;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.NewExpr;
 import soot.jimple.NewMultiArrayExpr;
+import soot.jimple.NullConstant;
 import soot.jimple.SpecialInvokeExpr;
 import soot.jimple.StaticFieldRef;
 import soot.jimple.StaticInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.StringConstant;
 import soot.jimple.VirtualInvokeExpr;
+import soot.jimple.spark.pag.AllocDotField;
 import soot.jimple.spark.pag.PAG;
+import soot.jimple.toolkits.annotation.nullcheck.NullnessAnalysis;
+import soot.jimple.toolkits.callgraph.ConstantArrayAnalysis.ArrayTypes;
 import soot.jimple.toolkits.reflection.ReflectionTraceInfo;
 import soot.options.CGOptions;
 import soot.options.Options;
+import soot.options.SparkOptions;
+import soot.toolkits.graph.ExceptionalUnitGraph;
 import soot.util.LargeNumberedMap;
 import soot.util.NumberedString;
 import soot.util.SmallNumberedMap;
@@ -82,12 +100,60 @@ import soot.util.queue.QueueReader;
  */
 public final class OnFlyCallGraphBuilder
 { 
+	private static final PrimType[] CHAR_NARROWINGS = new PrimType[]{
+		CharType.v()
+	};
+	private static final PrimType[] INT_NARROWINGS = new PrimType[]{
+		IntType.v(),
+		CharType.v(),
+		ShortType.v(),
+		ByteType.v(),
+		ShortType.v()
+	};
+	private static final PrimType[] SHORT_NARROWINGS = new PrimType[]{
+		ShortType.v(),
+		ByteType.v()
+	};
+	private static final PrimType[] LONG_NARROWINGS = new PrimType[]{
+		LongType.v(),
+		IntType.v(),
+		CharType.v(),
+		ShortType.v(),
+		ByteType.v(),
+		ShortType.v()
+	};
+	private static final ByteType[] BYTE_NARROWINGS = new ByteType[]{
+		ByteType.v()
+	};
+	private static final PrimType[] FLOAT_NARROWINGS = new PrimType[]{
+		FloatType.v(),
+		LongType.v(),
+		IntType.v(),
+		CharType.v(),
+		ShortType.v(),
+		ByteType.v(),
+		ShortType.v(),
+	};
+	private static final PrimType[] BOOLEAN_NARROWINGS = new PrimType[]{
+		BooleanType.v()
+	};
+	private static final PrimType[] DOUBLE_NARROWINGS = new PrimType[]{
+		DoubleType.v(),
+		FloatType.v(),
+		LongType.v(),
+		IntType.v(),
+		CharType.v(),
+		ShortType.v(),
+		ByteType.v(),
+		ShortType.v(),	
+	};
 	public class DefaultReflectionModel implements ReflectionModel {
 		
 	    protected CGOptions options = new CGOptions( PhaseOptions.v().getPhaseOptions("cg") );
 	    
 	    protected HashSet<SootMethod> warnedAlready = new HashSet<SootMethod>();
 
+		@Override
 		public void classForName(SootMethod source, Stmt s) {
 	        List<Local> stringConstants = methodToStringConstants.get(source);
 	        if( stringConstants == null )
@@ -120,6 +186,7 @@ public final class OnFlyCallGraphBuilder
 	        }        
 		}
 
+		@Override
 		public void classNewInstance(SootMethod source, Stmt s) {
 			if( options.safe_newinstance() ) {
 				for (SootMethod tgt : EntryPoints.v().inits()) {
@@ -142,6 +209,7 @@ public final class OnFlyCallGraphBuilder
 			} 
 		}
 
+		@Override
 		public void contructorNewInstance(SootMethod source, Stmt s) {
 			if( options.safe_newinstance() ) {
 				for (SootMethod tgt : EntryPoints.v().allInits()) {
@@ -164,6 +232,7 @@ public final class OnFlyCallGraphBuilder
 			} 
 		}
 
+		@Override
 		public void methodInvoke(SootMethod container, Stmt invokeStmt) {
 			if( !warnedAlready(container) ) {
 				if( options.verbose() ) {
@@ -182,7 +251,25 @@ public final class OnFlyCallGraphBuilder
 		private boolean warnedAlready(SootMethod m) {
 			return warnedAlready.contains(m);
 		}
-
+	}
+	
+	public class TypeBasedReflectionModel extends DefaultReflectionModel {
+		@Override
+		public void methodInvoke(SootMethod container, Stmt invokeStmt) {
+			if(container.getDeclaringClass().isJavaLibraryClass()) {
+				super.methodInvoke(container, invokeStmt);
+				return;
+			}
+			InstanceInvokeExpr d = (InstanceInvokeExpr) invokeStmt.getInvokeExpr();
+			Value base = d.getArg(0);
+			// no support for statics at the moment
+			if(base instanceof NullConstant) {
+				super.methodInvoke(container, invokeStmt);
+				return;
+			}
+			assert base instanceof Local;
+			addInvokeCallSite(invokeStmt, container, d);
+		}
 	}
 
 	
@@ -220,6 +307,7 @@ public final class OnFlyCallGraphBuilder
 		 * Adds an edge to all class initializers of all possible receivers
 		 * of Class.forName() calls within source.
 		 */
+		@Override
 		public void classForName(SootMethod container, Stmt forNameInvokeStmt) {
 			Set<String> classNames = reflectionInfo.classForNameClassNames(container);
 			if(classNames==null || classNames.isEmpty()) {
@@ -235,6 +323,7 @@ public final class OnFlyCallGraphBuilder
 		 * Adds an edge to the constructor of the target class from this call to
 		 * {@link Class#newInstance()}.
 		 */
+		@Override
 		public void classNewInstance(SootMethod container, Stmt newInstanceInvokeStmt) {
 			Set<String> classNames = reflectionInfo.classNewInstanceClassNames(container);
 			if(classNames==null || classNames.isEmpty()) {
@@ -258,6 +347,7 @@ public final class OnFlyCallGraphBuilder
 		 * {@link Constructor#newInstance(Object...)}.
 		 * @see PAG#addCallTarget(Edge) 
 		 */
+		@Override
 		public void contructorNewInstance(SootMethod container, Stmt newInstanceInvokeStmt) {
 			Set<String> constructorSignatures = reflectionInfo.constructorNewInstanceSignatures(container);
 			if(constructorSignatures==null || constructorSignatures.isEmpty()) {
@@ -278,6 +368,7 @@ public final class OnFlyCallGraphBuilder
 		 * {@link Method#invoke(Object, Object...)}.
 		 * @see PAG#addCallTarget(Edge) 
 		 */
+		@Override
 		public void methodInvoke(SootMethod container, Stmt invokeStmt) {
 			Set<String> methodSignatures = reflectionInfo.methodInvokeSignatures(container);
 			if (methodSignatures == null || methodSignatures.isEmpty()) {
@@ -370,7 +461,23 @@ public final class OnFlyCallGraphBuilder
     private final LargeNumberedMap<Local, List<VirtualCallSite>> receiverToSites = new LargeNumberedMap<Local, List<VirtualCallSite>>( Scene.v().getLocalNumberer() ); // Local -> List(VirtualCallSite)
     private final LargeNumberedMap<SootMethod, List<Local>> methodToReceivers = new LargeNumberedMap<SootMethod, List<Local>>( Scene.v().getMethodNumberer() ); // SootMethod -> List(Local)
     public LargeNumberedMap<SootMethod, List<Local>> methodToReceivers() { return methodToReceivers; }
-
+    
+    // type based reflection resolution state
+    
+    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeBases = new LargeNumberedMap<>(Scene.v().getMethodNumberer());
+    private final LargeNumberedMap<SootMethod, List<Local>> methodToInvokeArgs = new LargeNumberedMap<>(Scene.v().getMethodNumberer());
+    public LargeNumberedMap<SootMethod, List<Local>> methodToInvokeArgs() { return methodToInvokeArgs; }
+    public LargeNumberedMap<SootMethod, List<Local>> methodToInvokeBases() { return methodToInvokeBases; }
+    
+    private final Map<Local, List<InvokeCallSite>> baseToInvokeSite = new IdentityHashMap<>();
+    private final Map<Local, List<InvokeCallSite>> invokeArgsToInvokeSite = new IdentityHashMap<>();
+    private final Map<Local, Set<Integer>> invokeArgsToSize = new IdentityHashMap<>();
+    private final Map<AllocDotField, Set<Local>> allocDotFieldToLocal = new IdentityHashMap<>();
+    private final Map<Local, Set<Type>> reachingArgTypes = new IdentityHashMap<>();
+    private final Map<Local, Set<Type>> reachingBaseTypes = new IdentityHashMap<>();
+    
+    // end type based reflection resolution
+    
     private final SmallNumberedMap<List<VirtualCallSite>> stringConstToSites = new SmallNumberedMap<List<VirtualCallSite>>( Scene.v().getLocalNumberer() ); // Local -> List(VirtualCallSite)
     private final LargeNumberedMap<SootMethod, List<Local>> methodToStringConstants = new LargeNumberedMap<SootMethod, List<Local>>( Scene.v().getMethodNumberer() ); // SootMethod -> List(Local)
     public LargeNumberedMap<SootMethod, List<Local>> methodToStringConstants() { return methodToStringConstants; }
@@ -387,6 +494,7 @@ public final class OnFlyCallGraphBuilder
 
     private final ChunkedQueue<SootMethod> targetsQueue = new ChunkedQueue<SootMethod>();
     private final QueueReader<SootMethod> targets = targetsQueue.reader();
+	private FastHierarchy fh;
 
 
     public OnFlyCallGraphBuilder( ContextManager cm, ReachableMethods rm ) {
@@ -399,10 +507,15 @@ public final class OnFlyCallGraphBuilder
         }
         
         if(options.reflection_log()==null || options.reflection_log().length()==0) {
-        	reflectionModel = new DefaultReflectionModel();
+        	if(options.types_for_invoke() && new SparkOptions(PhaseOptions.v().getPhaseOptions("cg.spark")).enabled()) {
+        		reflectionModel = new TypeBasedReflectionModel();
+        	} else {
+        		reflectionModel = new DefaultReflectionModel();
+        	}
         } else {
         	reflectionModel = new TraceBasedReflectionModel();
         }
+        this.fh = Scene.v().getOrMakeFastHierarchy();
     }
     public OnFlyCallGraphBuilder( ContextManager cm, ReachableMethods rm, boolean appOnly ) {
         this( cm, rm );
@@ -414,7 +527,7 @@ public final class OnFlyCallGraphBuilder
                 rm.update();
                 if( !worklist.hasNext() ) break;
             }
-            MethodOrMethodContext momc = (MethodOrMethodContext) worklist.next();
+            MethodOrMethodContext momc = worklist.next();
             SootMethod m = momc.method();
             if( appOnly && !m.getDeclaringClass().isApplicationClass() ) continue;
             if( analyzedMethods.add( m ) ) processNewMethod( m );
@@ -422,49 +535,367 @@ public final class OnFlyCallGraphBuilder
         }
     }
     public boolean wantTypes( Local receiver ) {
-        return receiverToSites.get(receiver) != null;
+        return receiverToSites.get(receiver) != null || baseToInvokeSite.get(receiver) != null;
     }
-    public void addType( Local receiver, Context srcContext, Type type, Context typeContext ) {
-        FastHierarchy fh = Scene.v().getOrMakeFastHierarchy();
-        for( Iterator<VirtualCallSite> siteIt = receiverToSites.get( receiver ).iterator(); siteIt.hasNext(); ) {
-            final VirtualCallSite site = siteIt.next();
-            if( site.kind() == Kind.THREAD && !fh.canStoreType( type, clRunnable))
-                continue;
-            if( site.kind() == Kind.EXECUTOR && !fh.canStoreType( type, clRunnable))
-                continue;
-            if( site.kind() == Kind.ASYNCTASK && !fh.canStoreType( type, clAsyncTask ))
-                continue;
+    
+    public void addBaseType(Local base, Context context, Type ty) {
+		assert context == null;
+		if(!baseToInvokeSite.containsKey(base)) {
+			return;
+		}
+		if(!reachingBaseTypes.containsKey(base)) {
+			reachingBaseTypes.put(base, new HashSet<Type>());
+		}
+		if(reachingBaseTypes.get(base).add(ty)) {
+			resolveInvoke(baseToInvokeSite.get(base));
+		}
+	}
+    
+    public void addInvokeArgType(Local argArray, Context context, Type t) {
+		assert context == null;
+		if(!invokeArgsToInvokeSite.containsKey(argArray)) {
+			return;
+		}
+		if(!reachingArgTypes.containsKey(argArray)) {
+			reachingArgTypes.put(argArray, new HashSet<Type>());
+		}
+		if(reachingArgTypes.get(argArray).add(t)) {
+			resolveInvoke(invokeArgsToInvokeSite.get(argArray));
+		}
+	}
+    
+    public void setArgArrayNonDetSize(Local argArray, Context context) {
+    	assert context == null;
+    	if(!invokeArgsToInvokeSite.containsKey(argArray)) {
+    		return;
+    	}
+    	if(invokeArgsToSize.containsKey(argArray) && invokeArgsToInvokeSite.get(argArray) == null) {
+    		return;
+    	}
+    	invokeArgsToSize.put(argArray, null);
+    	resolveInvoke(invokeArgsToInvokeSite.get(argArray));
+	}
+    
+    public void addPossibleArgArraySize(Local argArray, int value, Context context) {
+		assert context == null;
+		if(!invokeArgsToInvokeSite.containsKey(argArray)) {
+			return;
+		}
+		// non-det size
+		if(invokeArgsToSize.containsKey(argArray) && invokeArgsToSize.get(argArray) == null) {
+			return;
+		} else {
+			if(!invokeArgsToSize.containsKey(argArray)) {
+				invokeArgsToSize.put(argArray, new HashSet<Integer>());
+			}
+			if(invokeArgsToSize.get(argArray).add(value)) {
+				resolveInvoke(invokeArgsToInvokeSite.get(argArray));
+			}
+		}
+	}
+    
+    private void resolveInvoke(List<InvokeCallSite> list) {
+		for(InvokeCallSite ics : list) {
+			Set<Type> s = reachingBaseTypes.get(ics.base());
+			if(s == null || s.isEmpty()) {
+				continue;
+			}
+			if(ics.reachingTypes() != null) {
+				assert ics.nullnessCode() == InvokeCallSite.MUST_NOT_BE_NULL;
+				resolveStaticTypes(s, ics);
+				return;
+			}
+			boolean mustNotBeNull = ics.nullnessCode() == InvokeCallSite.MUST_NOT_BE_NULL;
+			boolean mustBeNull = ics.nullnessCode() == InvokeCallSite.MUST_BE_NULL;
+			//  if the arg array may be null and we haven't seen a size or type yet, then generate nullary methods
+			if(mustBeNull || (ics.nullnessCode() == InvokeCallSite.MAY_BE_NULL && (!invokeArgsToSize.containsKey(ics.argArray()) || !reachingArgTypes.containsKey(ics.argArray())))) {
+				for(Type bType : s) {
+					assert bType instanceof RefType;
+					SootClass baseClass = ((RefType) bType).getSootClass();
+					assert !baseClass.isInterface();
+					Iterator<SootMethod> mIt = getPublicNullaryMethodIterator(baseClass);
+					while(mIt.hasNext()) {
+						SootMethod sm = mIt.next();
+						cm.addVirtualEdge(ics.container(), ics.stmt(), sm, Kind.REFL_INVOKE, null);
+					}
+				}
+			} else {
+				/*
+				 * In this branch, either the invoke arg must not be null, or may be null and we have size and type information.
+				 * Invert the above condition:
+				 * ~mustBeNull && (~mayBeNull || (has-size && has-type)) 
+				 * => (~mustBeNull && ~mayBeNull) || (~mustBeNull && has-size && has-type)
+				 * => mustNotBeNull || (~mustBeNull && has-types && has-size)
+				 * => mustNotBeNull || (mayBeNull && has-types && has-size) 
+				 */
+				Set<Type> reachingTypes = reachingArgTypes.get(ics.argArray());
+				/* 
+				 * the path condition allows must-not-be null without type and size info.
+				 * Do nothing in this case. THIS IS UNSOUND if default null values in
+				 * an argument array are used.
+				 */
+				if(reachingTypes == null || !invokeArgsToSize.containsKey(ics.argArray())) {
+					assert ics.nullnessCode() == InvokeCallSite.MUST_NOT_BE_NULL : ics;
+					return;
+				}
+				assert reachingTypes != null && invokeArgsToSize.containsKey(ics.argArray());
+				Set<Integer> methodSizes = invokeArgsToSize.get(ics.argArray());
+				for(Type bType : s) {
+					assert bType instanceof RefLikeType;
+					// we do not handle static methods or array reflection
+					if(bType instanceof NullType || bType instanceof ArrayType) {
+						continue;
+					} else {
+						SootClass baseClass = ((RefType)bType).getSootClass();
+						Iterator<SootMethod> mIt = getPublicMethodIterator(baseClass, reachingTypes, methodSizes, mustNotBeNull);
+						while(mIt.hasNext()) {
+							SootMethod sm = mIt.next();
+							cm.addVirtualEdge(ics.container(), ics.stmt(), sm, Kind.REFL_INVOKE, null);
+						}
+					}
+				}
+			}
+		}
+	}
+    
+    private void resolveStaticTypes(Set<Type> s, InvokeCallSite ics) {
+    	ArrayTypes at = ics.reachingTypes();
+		for(Type bType : s) {
+			SootClass baseClass = ((RefType)bType).getSootClass();
+			Iterator<SootMethod> mIt = getPublicMethodIterator(baseClass, at);
+			while(mIt.hasNext()) {
+				SootMethod sm = mIt.next();
+				cm.addVirtualEdge(ics.container(), ics.stmt(), sm, Kind.REFL_INVOKE, null);
+			}
+		}
+	}
+	private Iterator<SootMethod> getPublicMethodIterator(SootClass baseClass, final ArrayTypes at) {
+		return new AbstractMethodIterator(baseClass) {
+			@Override
+			protected boolean acceptMethod(SootMethod m) {
+				if(!at.possibleSizes.contains(m.getParameterCount())) {
+					return false;
+				}
+				for(int i = 0; i < m.getParameterCount(); i++) {
+					if(at.possibleTypes[i].isEmpty()) {
+						continue;
+					}
+					if(!isReflectionCompatible(m.getParameterType(i), at.possibleTypes[i])) {
+						return false;
+					}
+				}
+				return true;
+			}
+			
+		};
+	}
+	
+	private PrimType[] narrowings(PrimType f) {
+		if(f instanceof IntType) {
+			return INT_NARROWINGS;
+		} else if(f instanceof ShortType) {
+			return SHORT_NARROWINGS;
+		} else if(f instanceof LongType) {
+			return LONG_NARROWINGS;
+		} else if(f instanceof ByteType) {
+			return BYTE_NARROWINGS;
+		} else if(f instanceof FloatType) {
+			return FLOAT_NARROWINGS;
+		} else if(f instanceof BooleanType) {
+			return BOOLEAN_NARROWINGS;
+		} else if(f instanceof DoubleType) {
+			return DOUBLE_NARROWINGS;
+		} else if(f instanceof CharType) {
+			return CHAR_NARROWINGS;
+		} else {
+			throw new RuntimeException("Unexpected primitive type: " + f);
+		}
+	}
 
-            if( site.iie() instanceof SpecialInvokeExpr && site.kind != Kind.THREAD
-            		&& site.kind != Kind.EXECUTOR
-            		&& site.kind != Kind.ASYNCTASK ) {
-            	SootMethod target = VirtualCalls.v().resolveSpecial( 
-                            (SpecialInvokeExpr) site.iie(),
-                            site.subSig(),
-                            site.container(),
-                            appOnly );
-            	//if the call target resides in a phantom class then "target" will be null;
-            	//simply do not add the target in that case
-            	if(target!=null) {
-            		targetsQueue.add( target );
-            	}
-            } else {
-                VirtualCalls.v().resolve( type,
-                        receiver.getType(),
-                        site.subSig(),
-                        site.container(), 
-                        targetsQueue,
-                        appOnly);
-            }
-            while(targets.hasNext()) {
-                SootMethod target = (SootMethod) targets.next();
-                cm.addVirtualEdge(
-                        MethodContext.v( site.container(), srcContext ),
-                        site.stmt(),
-                        target,
-                        site.kind(),
-                        typeContext );
-            }
+	private boolean isReflectionCompatible(Type paramType, Set<Type> reachingTypes) {
+		/* 
+		 * attempting to pass in a null will match any type (although attempting to pass it
+		 * to a primitive arg will give an NPE)
+		 */
+		if(reachingTypes.contains(NullType.v())) {
+			return true;
+		}
+		if(paramType instanceof RefLikeType) {
+			for(Type rType : reachingTypes) {
+				if(fh.canStoreType(paramType, rType)) {
+					return true;
+				}
+			}
+			return false;
+		} else if(paramType instanceof PrimType) {
+			PrimType primType = (PrimType) paramType;
+			/*
+			 * It appears, java reflection allows for unboxing followed by widening, so if 
+			 * there is a wrapper type that whose corresponding primitive type
+			 * can be widened into the expected primitive type, we're set
+			 */
+			for(PrimType narrowings : narrowings(primType)) {
+				if(reachingTypes.contains(narrowings.boxedType())) {
+					return true;
+				}
+			}
+			return false;
+		} else {
+			// impossible?
+			return false;
+		}
+	}
+
+	
+	private abstract class AbstractMethodIterator implements Iterator<SootMethod> {
+		private SootMethod next;
+		private SootClass currClass;
+		private Iterator<SootMethod> methodIterator;
+
+		AbstractMethodIterator(SootClass baseClass) {
+			this.currClass = baseClass;
+			this.next = null;
+			this.methodIterator = baseClass.methodIterator();
+			this.findNextMethod();
+		}
+		
+		protected void findNextMethod() {
+			next = null;
+			if(methodIterator == null) {
+				return;
+			}
+			do {
+				while(methodIterator.hasNext()) {
+					SootMethod n = methodIterator.next();
+					if (!n.isPublic()) {
+						continue;
+					}
+					if (n.isStatic() || n.isConstructor() || n.isStaticInitializer() || !n.isConcrete()) {
+						continue;
+					}
+					if(!acceptMethod(n)) {
+						continue;
+					}
+					next = n;
+					return;
+				}
+				if(currClass.hasSuperclass() && !currClass.getSuperclass().isPhantom() && !currClass.getSuperclass().getName().equals("java.lang.Object")) {
+					currClass = currClass.getSuperclass();
+					methodIterator = currClass.methodIterator();
+					continue;
+				} else {
+					methodIterator = null;
+					return;
+				}
+			} while(true);
+		}
+		
+		@Override
+		public boolean hasNext() {
+			return next != null;
+		}
+
+		@Override
+		public SootMethod next() {
+			SootMethod toRet = next;
+			findNextMethod();
+			return toRet;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+		
+		protected abstract boolean acceptMethod(SootMethod m);
+	}
+	
+	private Iterator<SootMethod> getPublicMethodIterator(final SootClass baseClass, final Set<Type> reachingTypes, final Set<Integer> methodSizes, final boolean mustNotBeNull) {
+    	if(baseClass.isPhantom()) {
+    		return Collections.emptyIterator();
+    	}
+    	return new AbstractMethodIterator(baseClass) {
+			@Override
+			protected boolean acceptMethod(SootMethod n) {
+				int nParams = n.getParameterCount();
+				if(methodSizes != null) {
+					// if the arg array can be null we have to still allow for nullary methods
+					boolean compatibleSize = methodSizes.contains(nParams) || (!mustNotBeNull && nParams == 0);
+					if(!compatibleSize) {
+						return false;
+					}
+				}
+				List<Type> t = n.getParameterTypes();
+				for(Type pTy : t) {
+					if(!isReflectionCompatible(pTy, reachingTypes)) {
+						return false;
+					}
+				}
+				return true;
+			}
+    		
+    	};
+	}
+	
+	private Iterator<SootMethod> getPublicNullaryMethodIterator(final SootClass baseClass) {
+    	if(baseClass.isPhantom()) {
+    		return Collections.emptyIterator();
+    	}
+    	return new AbstractMethodIterator(baseClass) {
+			@Override
+			protected boolean acceptMethod(SootMethod n) {
+				int nParams = n.getParameterCount();
+				return nParams == 0;
+			}
+    	};
+	}
+	
+	public void addType( Local receiver, Context srcContext, Type type, Context typeContext ) {
+        FastHierarchy fh = Scene.v().getOrMakeFastHierarchy();
+        if(receiverToSites.get(receiver) != null) {
+	        for( Iterator<VirtualCallSite> siteIt = receiverToSites.get( receiver ).iterator(); siteIt.hasNext(); ) {
+	            final VirtualCallSite site = siteIt.next();
+	            if( site.kind() == Kind.THREAD && !fh.canStoreType( type, clRunnable))
+	                continue;
+	            if( site.kind() == Kind.EXECUTOR && !fh.canStoreType( type, clRunnable))
+	                continue;
+	            if( site.kind() == Kind.ASYNCTASK && !fh.canStoreType( type, clAsyncTask ))
+	                continue;
+	
+	            if( site.iie() instanceof SpecialInvokeExpr && site.kind != Kind.THREAD
+	            		&& site.kind != Kind.EXECUTOR
+	            		&& site.kind != Kind.ASYNCTASK ) {
+	            	SootMethod target = VirtualCalls.v().resolveSpecial( 
+	                            (SpecialInvokeExpr) site.iie(),
+	                            site.subSig(),
+	                            site.container(),
+	                            appOnly );
+	            	//if the call target resides in a phantom class then "target" will be null;
+	            	//simply do not add the target in that case
+	            	if(target!=null) {
+	            		targetsQueue.add( target );
+	            	}
+	            } else {
+	                VirtualCalls.v().resolve( type,
+	                        receiver.getType(),
+	                        site.subSig(),
+	                        site.container(), 
+	                        targetsQueue,
+	                        appOnly);
+	            }
+	            while(targets.hasNext()) {
+	                SootMethod target = targets.next();
+	                cm.addVirtualEdge(
+	                        MethodContext.v( site.container(), srcContext ),
+	                        site.stmt(),
+	                        target,
+	                        site.kind(),
+	                        typeContext );
+	            }
+	        }
+        }
+        if(baseToInvokeSite.get(receiver) != null) {
+        	addBaseType(receiver, srcContext, type);
         }
     }
     public boolean wantStringConstants( Local stringConst ) {
@@ -495,6 +926,9 @@ public final class OnFlyCallGraphBuilder
                     }
                 } else {
                     SootClass sootcls = Scene.v().getSootClass( constant );
+                    if(sootcls.isPhantom()) {
+                    	continue;
+                    }
                     if( !sootcls.isApplicationClass() ) {
                         sootcls.setLibraryClass();
                     }
@@ -509,15 +943,111 @@ public final class OnFlyCallGraphBuilder
             }
         }
     }
+    
+    public boolean wantArrayField(AllocDotField df) {
+    	return allocDotFieldToLocal.containsKey(df);
+	}
+    
+    public void addInvokeArgType(AllocDotField df, Context context, Type type) {
+		if(!allocDotFieldToLocal.containsKey(df)) {
+			return;
+		}
+		for(Local l : allocDotFieldToLocal.get(df)) {
+			addInvokeArgType(l, context, type);
+		}
+	}
+    
+	public boolean wantInvokeArg(Local receiver) {
+		return invokeArgsToInvokeSite.containsKey(receiver);
+	}
+	
+	public void addInvokeArgDotField(Local receiver, AllocDotField dot) {
+		if(!allocDotFieldToLocal.containsKey(dot)) {
+			allocDotFieldToLocal.put(dot, new HashSet<Local>());
+		}
+		allocDotFieldToLocal.get(dot).add(receiver);
+	}
+	
+	private NullnessAnalysis nullnessCache = null;
+	private ConstantArrayAnalysis arrayCache = null;
+	private SootMethod analysisKey = null;
 
     /* End of public methods. */
-
-    private void addVirtualCallSite( Stmt s, SootMethod m, Local receiver,
+    
+    /*
+     * How type based reflection resolution works:
+     * 
+     * In general, for each call to invoke(), we record the local of the 
+     * receiver argument and the argument array. Whenever a new type is added 
+     * to the points to set of the receiver argument we add that type to the reachingBaseTypes
+     * and try to resolve the reflective method call (see addType, addBaseType, and updatedNode() in OnFlyCallGraph).
+     * 
+     * For added precision, we also record the second argument to invoke. If it is always null, this means the
+     * invoke() call resolves only to nullary methods.
+     * 
+     * When the second argument is a variable that must not be null we can narrow down the called method based
+     * on the possible sizes of the argument array and the types it contains. Whenever a new allocation reaches
+     * this variable we record the possible size of the array (by looking at the allocation site) and the possible
+     * types stored in the array (see updatedNode in OnFlyCallGraph in the branch wantInvokeArg()). If the size of the array
+     * isn't statically known, the analysis considers methods of all possible arities.
+     * In addition, we track the PAG node
+     * corresponding to the array contents. If a new type reaches this node, we update the possible
+     * argument types. (see propagate() in PropWorklist and the visitor, and updatedFieldRef in OnFlyCallGraph).
+     * 
+     * For details on the method resolution process, see resolveInvoke()
+     * 
+     * Finally, for cases like o.invoke(b, foo, bar, baz); it is very easy to statically determine
+     * precisely which types are in which argument positions. This is computed using the
+     * ConstantArrayAnalysis and are resolved using resolveStaticTypes().
+     */
+    private void addInvokeCallSite(Stmt s, SootMethod container, InstanceInvokeExpr d) {
+    	Local l = (Local) d.getArg(0);
+    	Value argArray = d.getArg(1);
+    	InvokeCallSite ics;
+    	if(argArray instanceof NullConstant) {
+    		ics = new InvokeCallSite(s, container, d, l);
+    	} else {
+    		if(analysisKey != container) {
+    			ExceptionalUnitGraph graph = new ExceptionalUnitGraph(container.getActiveBody());
+				nullnessCache = new NullnessAnalysis(graph);
+    			arrayCache = new ConstantArrayAnalysis(graph, container.getActiveBody());
+    			analysisKey = container;
+    		}
+    		Local argLocal = (Local) argArray;
+    		int nullnessCode;
+    		if(nullnessCache.isAlwaysNonNullBefore(s, argLocal)) {
+    			nullnessCode = InvokeCallSite.MUST_NOT_BE_NULL;
+    		} else if(nullnessCache.isAlwaysNullBefore(s, argLocal)) {
+    			nullnessCode = InvokeCallSite.MUST_BE_NULL;
+    		} else {
+    			nullnessCode = InvokeCallSite.MAY_BE_NULL;
+    		}
+    		if(nullnessCode != 0 && arrayCache.isConstantBefore(s, argLocal)) {
+    			ArrayTypes reachingArgTypes = arrayCache.getArrayTypesBefore(s, argLocal);
+    			if(nullnessCode == -1) {
+    				reachingArgTypes.possibleSizes.add(0);
+    			}
+    			ics = new InvokeCallSite(s, container, d, l, reachingArgTypes, nullnessCode);
+    		} else {
+	    		ics = new InvokeCallSite(s, container, d, l, argLocal, nullnessCode);
+	    		if(!invokeArgsToInvokeSite.containsKey(argLocal)) {
+	    			invokeArgsToInvokeSite.put(argLocal, new ArrayList<InvokeCallSite>());
+	    		}
+	    		invokeArgsToInvokeSite.get(argLocal).add(ics);
+    		}
+    	}
+    	if(!baseToInvokeSite.containsKey(l)) {
+    		baseToInvokeSite.put(l, new ArrayList<InvokeCallSite>());
+    	}
+    	baseToInvokeSite.get(l).add(ics);
+    }
+    
+	private void addVirtualCallSite( Stmt s, SootMethod m, Local receiver,
             InstanceInvokeExpr iie, NumberedString subSig, Kind kind ) {
-        List<VirtualCallSite> sites = (List<VirtualCallSite>) receiverToSites.get(receiver);
+        List<VirtualCallSite> sites = receiverToSites.get(receiver);
         if (sites == null) {
             receiverToSites.put(receiver, sites = new ArrayList<VirtualCallSite>());
-            List<Local> receivers = (List<Local>) methodToReceivers.get(m);
+            List<Local> receivers = methodToReceivers.get(m);
             if( receivers == null )
                 methodToReceivers.put(m, receivers = new ArrayList<Local>());
             receivers.add(receiver);
@@ -661,7 +1191,7 @@ public final class OnFlyCallGraphBuilder
         SootMethod m = momc.method();
         Iterator<Edge> it = cicg.edgesOutOf(m);
         while( it.hasNext() ) {
-            Edge e = (Edge) it.next();
+            Edge e = it.next();
             cm.addStaticEdge( momc, e.srcUnit(), e.tgt(), e.kind() );
         }
     }
@@ -746,6 +1276,5 @@ public final class OnFlyCallGraphBuilder
         findOrAdd( "java.lang.Class forName(java.lang.String)" );
     protected final RefType clRunnable = RefType.v("java.lang.Runnable");
     protected final RefType clAsyncTask = RefType.v("android.os.AsyncTask");
-    
 }
 

--- a/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -601,7 +601,7 @@ public final class OnFlyCallGraphBuilder
 				continue;
 			}
 			if(ics.reachingTypes() != null) {
-				assert ics.nullnessCode() == InvokeCallSite.MUST_NOT_BE_NULL;
+				assert ics.nullnessCode() != InvokeCallSite.MUST_BE_NULL;
 				resolveStaticTypes(s, ics);
 				return;
 			}
@@ -1022,9 +1022,9 @@ public final class OnFlyCallGraphBuilder
     		} else {
     			nullnessCode = InvokeCallSite.MAY_BE_NULL;
     		}
-    		if(nullnessCode != 0 && arrayCache.isConstantBefore(s, argLocal)) {
+    		if(nullnessCode != InvokeCallSite.MUST_BE_NULL && arrayCache.isConstantBefore(s, argLocal)) {
     			ArrayTypes reachingArgTypes = arrayCache.getArrayTypesBefore(s, argLocal);
-    			if(nullnessCode == -1) {
+    			if(nullnessCode == InvokeCallSite.MAY_BE_NULL) {
     				reachingArgTypes.possibleSizes.add(0);
     			}
     			ics = new InvokeCallSite(s, container, d, l, reachingArgTypes, nullnessCode);

--- a/src/soot/options/soot_options.xml
+++ b/src/soot/options/soot_options.xml
@@ -2061,6 +2061,17 @@ print: the program prints a stack trace when reaching a porgram location that wa
 the program throws an Error instead.                                                                                                
 </long_desc>
                                 </stropt>
+								<boolopt>
+								  <name>Types for invoke</name>
+								  <alias>types-for-invoke</alias>
+								  <default>false</default>
+								  <short_desc>Uses reaching types inferred by the pointer analysis to resolve reflective calls.</short_desc>
+								  <long_desc>For each call to Method.invoke(), use the possible types of the first receiver
+								  argument and the possible types stored in the second argument array to resolve calls to
+								  Method.invoke(). This strategy makes no attempt to resolve reflectively invoked static methods.
+								  Currently only works for context insensitive pointer analyses.
+								  </long_desc>
+								</boolopt>
 				<sub_phase>
 					<name>Class Hierarchy Analysis</name>
 					<alias>cg.cha</alias>


### PR DESCRIPTION
Adds an unsound approach for statically resolving calls to invoke().
The OnFlyCallGraphBuilder hooks into Spark and uses the reaching types
of the 'obj' argument and contents of the 'args' array to find methods
to invoke. In some cases it is possible to compute the positions in
the argument array of these reaching types, in which case the
resolution can be made more precise. This types-for-invoke approach
is still unsound:

* It doesn't handle arrays receivers
* It doesn't handle static methods
* It fails to account for default nulls in the argument array