### PR TITLE
Fixes dynamic class loading

### DIFF
--- a/src/soot/SourceLocator.java
+++ b/src/soot/SourceLocator.java
@@ -361,7 +361,9 @@ public class SourceLocator
                 Scene.v().getSootClassPath(), String.valueOf(File.pathSeparatorChar));
         while (strtok.hasMoreTokens()) {
             String path = strtok.nextToken();
-
+            if(getClassSourceType(path) != ClassSourceType.directory) {
+            	continue;
+            }
             // For jimple files
             List<String> l = getClassesUnder(path);
             for (String filename : l) {
@@ -370,12 +372,12 @@ public class SourceLocator
             }
 
             // For class files;
-            path = path + File.pathSeparatorChar;
+            path = path + File.separatorChar;
             StringTokenizer tokenizer = new StringTokenizer(str, ".");
             while (tokenizer.hasMoreTokens()) {
                 path = path + tokenizer.nextToken();
                 if (tokenizer.hasMoreTokens())
-                    path = path + File.pathSeparatorChar;
+                    path = path + File.separatorChar;
             }
             l = getClassesUnder(path);
             for (String string : l)


### PR DESCRIPTION
When looking for loadable dynamic class, the File.pathSeparator
was used, which is the ":" or ";" character. As dynamic classes
are intended to be loaded from directories, this was almost
certainly meant to be "/" or "\". Also, if you had a non-directory
path on the soot classpath the dynamic class resolution would fail,
as Soot would attempt to load from the
directory /foo/bar/baz.jar/com/example/package.