### PR TITLE
Change the exit code when RuntimeException occurs

### DIFF
--- a/src/soot/Main.java
+++ b/src/soot/Main.java
@@ -193,7 +193,14 @@ public class Main {
 				sb.append("    information on how to reproduce the problem. Thanks!");
 
 				System.err.println(sb);
+				
+				// Exit with an exit code 1
+				System.exit(1);
+				
 			} catch (UnsupportedEncodingException e1) {
+				
+				// Exit with an exit code 1
+				System.exit(1);
 			}
 		}
 	}


### PR DESCRIPTION
When using scripts to run soot, changing the exit code will help in determining if the execution of soot failed.