### PR TITLE
Updated pom.xml and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](http://build.renjin.org/job/Soot/job/soot/badge/icon)](http://build.renjin.org/job/Soot/job/soot/)
+
 # What is Soot?
 
 Soot is a Java optimization framework. It provides four intermediate representations for analyzing and transforming Java bytecode:
@@ -12,6 +14,29 @@ See http://www.sable.mcgill.ca/soot/ for details.
 # How do I get started with Soot?
 
 We have some documentation on Soot in the [wiki](https://github.com/Sable/soot/wiki) and also a large range of [tutorials](http://www.sable.mcgill.ca/soot/tutorial/index.html) on Soot.
+
+# Including Soot in your Project
+
+A Soot "release" is currently built for each commit to the `develop` branch. You can include Soot as 
+a dependency via Maven, Gradle, SBT, etc using the following coordinates:
+
+
+```.xml
+<dependencies>
+  <dependency>
+    <groupId>ca.mcgill.sable</groupId>
+    <artifactId>soot</artifactId>
+    <version>RELEASE/version>
+  </dependency>
+</dependencies>
+<repositories>
+  <repository>
+    <id>bedatadriven</id>
+    <name>bedatadriven public repo</name>
+    <url>https://nexus.bedatadriven.com/content/groups/public/</url>
+  </repository>
+</repositories>
+```
 
 # How do I obtain the nightly builds
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,8 @@
     <dependency>
       <groupId>org.smali</groupId>
       <artifactId>dexlib2</artifactId>
-      <version>2.1.2</version>
+      <version>2.1.3</version>
     </dependency>
-
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-debug-all</artifactId>


### PR DESCRIPTION
Synced the pom with the dexlib2 dependencies checked into the repository. Is there any difference between the version of dexlib2 manually checked and the [official release](https://bitbucket.org/JesusFreke/smali/downloads) of dexlib2 2.3? I have linked to the [artifact](http://search.maven.org/#artifactdetails%7Corg.smali%7Cdexlib2%7C2.1.3%7Cjar) hosted on Maven Central.