### PR TITLE
Basic support for Method Handle Constants (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ a dependency via Maven, Gradle, SBT, etc using the following coordinates:
   <dependency>
     <groupId>ca.mcgill.sable</groupId>
     <artifactId>soot</artifactId>
-    <version>RELEASE/version>
+    <version>RELEASE</version>
   </dependency>
 </dependencies>
 <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>tests</testSourceDirectory>
 
+    <resources>
+      <resource>
+        <directory>src</directory>
+        <includes>
+          <include>**/*.dat</include>
+        </includes>
+      </resource>
+    </resources>
+    
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -42,7 +51,6 @@
       </plugin>
     </plugins>
   </build>
-
 
   <dependencies>
     <dependency>

--- a/src/soot/asm/MethodBuilder.java
+++ b/src/soot/asm/MethodBuilder.java
@@ -18,13 +18,11 @@
  */
 package soot.asm;
 
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Attribute;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.*;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
 
 import soot.*;
+import soot.Type;
 import soot.tagkit.AnnotationConstants;
 import soot.tagkit.AnnotationDefaultTag;
 import soot.tagkit.AnnotationTag;
@@ -146,7 +144,17 @@ class MethodBuilder extends JSRInlinerAdapter {
 		
 		scb.addDep(AsmUtil.toBaseType(owner));
 	}
-	
+
+	@Override
+	public void visitLdcInsn(Object cst) {
+		super.visitLdcInsn(cst);
+		
+		if(cst instanceof Handle) {
+			Handle methodHandle = (Handle) cst;
+			scb.addDep(AsmUtil.toBaseType(methodHandle.getOwner()));
+		}
+	}
+
 	private void addDeps(Type t) {
 		if (t instanceof RefType)
 			scb.addDep(t);

--- a/src/soot/baf/BafASMBackend.java
+++ b/src/soot/baf/BafASMBackend.java
@@ -414,6 +414,20 @@ public class BafASMBackend extends AbstractASMBackend {
 					}
 				} else if (c instanceof NullConstant) {
 					mv.visitInsn(Opcodes.ACONST_NULL);
+				} else if (c instanceof MethodHandle) {
+					SootMethodRef ref = ((MethodHandle) c).getMethodRef();
+					int tag;
+					if(ref.isStatic()) {
+						tag = Opcodes.H_INVOKESTATIC;
+					} else if(ref.declaringClass().isInterface()) {
+						tag = Opcodes.H_INVOKEINTERFACE;
+					} else {
+						tag = Opcodes.H_INVOKEVIRTUAL;
+					}
+					Handle handle = new Handle(tag, ref.declaringClass().getName(), ref.name(), ref.getSignature(), 
+							ref.declaringClass().isInnerClass());
+					
+					mv.visitLdcInsn(handle);
 				} else {
 					throw new RuntimeException("unsupported opcode");
 				}

--- a/src/soot/baf/JasminClass.java
+++ b/src/soot/baf/JasminClass.java
@@ -60,18 +60,7 @@ import soot.TypeSwitch;
 import soot.Unit;
 import soot.UnitBox;
 import soot.Value;
-import soot.jimple.CaughtExceptionRef;
-import soot.jimple.ClassConstant;
-import soot.jimple.DoubleConstant;
-import soot.jimple.FloatConstant;
-import soot.jimple.IdentityRef;
-import soot.jimple.IntConstant;
-import soot.jimple.JimpleBody;
-import soot.jimple.LongConstant;
-import soot.jimple.NullConstant;
-import soot.jimple.ParameterRef;
-import soot.jimple.StringConstant;
-import soot.jimple.ThisRef;
+import soot.jimple.*;
 import soot.options.Options;
 import soot.tagkit.JasminAttribute;
 import soot.tagkit.LineNumberTag;
@@ -483,8 +472,11 @@ public class JasminClass extends AbstractJasminClass {
 						emit("lconst_1");
 					else
 						emit("ldc2_w " + v.toString());
-				} else if (i.getConstant() instanceof NullConstant)
+				} else if (i.getConstant() instanceof NullConstant) {
 					emit("aconst_null");
+				} else if (i.getConstant() instanceof MethodHandle) {
+					throw new RuntimeException("MethodHandle constants not supported by Jasmin. Please use -asm-backend.");
+				}
 				else
 					throw new RuntimeException("unsupported opcode");
 			}

--- a/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
+++ b/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
@@ -229,6 +229,10 @@ public class AugEvalFunction implements IEvalFunction
 			return RefType.v("java.lang.String");
 		else if ( expr instanceof ClassConstant )
 			return RefType.v("java.lang.Class");
-		else throw new RuntimeException("Unhandled expression: " + expr);
+		else if ( expr instanceof MethodHandle) {
+			return RefType.v("java.lang.invoke.MethodHandle");
+		} else {
+			throw new RuntimeException("Unhandled expression: " + expr);
+		}
 	}
 }

--- a/tests/soot/jimple/MethodHandleTest.java
+++ b/tests/soot/jimple/MethodHandleTest.java
@@ -8,12 +8,13 @@ import soot.Main;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.*;
 import java.util.Arrays;
 
 public class MethodHandleTest {
   
   @Test
-  public void test() throws IOException {
+  public void testConstant() throws IOException {
 
     // First generate a classfile with a MethodHnadle
     ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
@@ -22,12 +23,6 @@ public class MethodHandleTest {
         Type.getMethodDescriptor(Type.getType(java.lang.invoke.MethodHandle.class)), null, null);
 
     mv.visitCode();
-
-    // Workaround to ensure java.lang.Math is resolved.
-    // TODO: MethodHandle constants should be included in HIERARCHY resolution??
-//    mv.visitInsn(Opcodes.DCONST_0);
-//    mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", "(D)D", false);
-//    mv.visitInsn(Opcodes.POP2);
 
     mv.visitLdcInsn(new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(Math.class), "sqrt",
         Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE), false));
@@ -45,6 +40,47 @@ public class MethodHandleTest {
     G.reset();
 
     String[] commandLine = {"-asm-backend", "-pp", "-cp", tempDir.getAbsolutePath(), "-O", "HelloMethodHandles", };
+
+    System.out.println("Command Line: " + Arrays.toString(commandLine));
+
+    Main.main(commandLine);
+  }
+
+
+  @Test
+  public void testInvoke() throws IOException {
+
+    // First generate a classfile with a MethodHnadle
+    ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cv.visit(Opcodes.V1_7, Opcodes.ACC_PUBLIC, "UniformDistribution", null, Type.getInternalName(Object.class), null);
+    
+    MethodVisitor mv = cv.visitMethod(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC, "sample",
+        Type.getMethodDescriptor(
+            Type.DOUBLE_TYPE, 
+            Type.getType(java.lang.invoke.MethodHandle.class) /* rng method */, 
+            Type.DOUBLE_TYPE  /* max */), null, null);
+ 
+    mv.visitCode();
+
+    mv.visitVarInsn(Opcodes.ALOAD, 0); // load MethodHandle
+    
+    // Call MethodHandle.invoke() with polymorphic signature: ()D
+    mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(java.lang.invoke.MethodHandle.class), 
+          "invoke", Type.getMethodDescriptor(Type.DOUBLE_TYPE), false);
+    
+    mv.visitVarInsn(Opcodes.DLOAD, 1);
+    mv.visitInsn(Opcodes.DMUL);
+    mv.visitInsn(Opcodes.DRETURN);
+    mv.visitEnd();
+    cv.visitEnd();
+
+    File tempDir = Files.createTempDir();
+    File classFile = new File(tempDir, "UniformDistribution.class");
+    Files.write(cv.toByteArray(), classFile);
+
+    G.reset();
+
+    String[] commandLine = {"-asm-backend", "-pp", "-cp", tempDir.getAbsolutePath(), "-O", "UniformDistribution", };
 
     System.out.println("Command Line: " + Arrays.toString(commandLine));
 

--- a/tests/soot/jimple/MethodHandleTest.java
+++ b/tests/soot/jimple/MethodHandleTest.java
@@ -14,28 +14,28 @@ public class MethodHandleTest {
   
   @Test
   public void test() throws IOException {
-    
+
     // First generate a classfile with a MethodHnadle
     ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
     cv.visit(Opcodes.V1_7, Opcodes.ACC_PUBLIC, "HelloMethodHandles", null, Type.getInternalName(Object.class), null);
     MethodVisitor mv = cv.visitMethod(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC, "getSquareRoot",
         Type.getMethodDescriptor(Type.getType(java.lang.invoke.MethodHandle.class)), null, null);
-    
+
     mv.visitCode();
 
     // Workaround to ensure java.lang.Math is resolved.
     // TODO: MethodHandle constants should be included in HIERARCHY resolution??
-    mv.visitInsn(Opcodes.DCONST_0);
-    mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", "(D)D", false);
-    mv.visitInsn(Opcodes.POP2);
+//    mv.visitInsn(Opcodes.DCONST_0);
+//    mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", "(D)D", false);
+//    mv.visitInsn(Opcodes.POP2);
 
-    mv.visitLdcInsn(new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", 
+    mv.visitLdcInsn(new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(Math.class), "sqrt",
         Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE), false));
-    
-    
+
+
     mv.visitInsn(Opcodes.ARETURN);
     mv.visitEnd();
-    
+
     cv.visitEnd();
 
     File tempDir = Files.createTempDir();
@@ -43,12 +43,11 @@ public class MethodHandleTest {
     Files.write(cv.toByteArray(), classFile);
 
     G.reset();
-    
+
     String[] commandLine = {"-asm-backend", "-pp", "-cp", tempDir.getAbsolutePath(), "-O", "HelloMethodHandles", };
-    
+
     System.out.println("Command Line: " + Arrays.toString(commandLine));
-    
+
     Main.main(commandLine);
-    
   }
 }

--- a/tests/soot/jimple/MethodHandleTest.java
+++ b/tests/soot/jimple/MethodHandleTest.java
@@ -22,9 +22,17 @@ public class MethodHandleTest {
         Type.getMethodDescriptor(Type.getType(java.lang.invoke.MethodHandle.class)), null, null);
     
     mv.visitCode();
+
+    // Workaround to ensure java.lang.Math is resolved.
+    // TODO: MethodHandle constants should be included in HIERARCHY resolution??
+    mv.visitInsn(Opcodes.DCONST_0);
+    mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", "(D)D", false);
+    mv.visitInsn(Opcodes.POP2);
+
     mv.visitLdcInsn(new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", 
         Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE), false));
-//    mv.visitInsn(Opcodes.ACONST_NULL);
+    
+    
     mv.visitInsn(Opcodes.ARETURN);
     mv.visitEnd();
     
@@ -36,7 +44,7 @@ public class MethodHandleTest {
 
     G.reset();
     
-    String[] commandLine = {"-pp", "-cp", tempDir.getAbsolutePath(), "-O", "HelloMethodHandles", };
+    String[] commandLine = {"-asm-backend", "-pp", "-cp", tempDir.getAbsolutePath(), "-O", "HelloMethodHandles", };
     
     System.out.println("Command Line: " + Arrays.toString(commandLine));
     

--- a/tests/soot/jimple/MethodHandleTest.java
+++ b/tests/soot/jimple/MethodHandleTest.java
@@ -1,0 +1,46 @@
+package soot.jimple;
+
+import com.google.common.io.Files;
+import org.junit.Test;
+import org.objectweb.asm.*;
+import soot.G;
+import soot.Main;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class MethodHandleTest {
+  
+  @Test
+  public void test() throws IOException {
+    
+    // First generate a classfile with a MethodHnadle
+    ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cv.visit(Opcodes.V1_7, Opcodes.ACC_PUBLIC, "HelloMethodHandles", null, Type.getInternalName(Object.class), null);
+    MethodVisitor mv = cv.visitMethod(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC, "getSquareRoot",
+        Type.getMethodDescriptor(Type.getType(java.lang.invoke.MethodHandle.class)), null, null);
+    
+    mv.visitCode();
+    mv.visitLdcInsn(new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(Math.class), "sqrt", 
+        Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE), false));
+//    mv.visitInsn(Opcodes.ACONST_NULL);
+    mv.visitInsn(Opcodes.ARETURN);
+    mv.visitEnd();
+    
+    cv.visitEnd();
+
+    File tempDir = Files.createTempDir();
+    File classFile = new File(tempDir, "HelloMethodHandles.class");
+    Files.write(cv.toByteArray(), classFile);
+
+    G.reset();
+    
+    String[] commandLine = {"-pp", "-cp", tempDir.getAbsolutePath(), "-O", "HelloMethodHandles", };
+    
+    System.out.println("Command Line: " + Arrays.toString(commandLine));
+    
+    Main.main(commandLine);
+    
+  }
+}


### PR DESCRIPTION
Added enough support to ensure that a classfile with MethodHandles can be read in and written back out by Soot. Still need to add a test case for actually invoke method handle values.

I'm assuming that there's no interest in adding this to Jasmin, but @StevenArzt let me know if this is important and where to find the latest version of the project's fork of Jasmin.
