### PR TITLE
Fix class name parsing in dexpler and add outer/inner class hierarchy construction to jimple parser

### DIFF
--- a/src/soot/SourceLocator.java
+++ b/src/soot/SourceLocator.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -748,12 +747,13 @@ public class SourceLocator
    
     /** Returns the name of the class in which the (possibly inner) class
      * className appears. */
-    public String getSourceForClass( String className ) {
+    public String getSourceForClass(String className) {
         String javaClassName = className;
-        if (className.indexOf("$") != -1) {
+        int i = className.indexOf("$");
+        if (i > -1) {
             // class is an inner class and will be in
             // Outer of Outer$Inner
-            javaClassName = className.substring(0, className.indexOf("$"));
+            javaClassName = className.substring(0, i);
         }
         return javaClassName;
     }

--- a/src/soot/dexpler/DexClassLoader.java
+++ b/src/soot/dexpler/DexClassLoader.java
@@ -126,7 +126,22 @@ public class DexClassLoader {
         			
         			String outer = null;
 					if (ict.getOuterClass() == null) { // anonymous and local classes
-						outer = ict.getInnerClass().replaceAll("\\$[0-9].*$", "").replaceAll("/", ".");
+						if(inner.contains("$-")) {
+							/* This is a special case for generated lambda classes of jack and jill compiler.
+							 * Generated lambda classes may contain '$' which do not indicate an inner/outer 
+							 * class separator if the '$' occurs after a inner class with a name starting with
+							 * '-'. Thus we search for '$-' and anything after it including '-' is the inner
+							 * classes name and anything before it is the outer classes name.
+							 */
+							outer = inner.substring(0, inner.indexOf("$-"));
+						} else if(inner.contains("$")) {
+							//remove everything after the last '$' including the last '$'
+							outer = inner.substring(0, inner.lastIndexOf('$'));
+						} else {
+							//no '$' in a inner class ???
+							//outer = inner;
+							throw new RuntimeException("Error: Could not identify the outer class of the inner class '" + inner + "'.");
+						}
         			} else {
         				outer = ict.getOuterClass().replaceAll("/", ".");
         			}

--- a/src/soot/toDex/DexPrinter.java
+++ b/src/soot/toDex/DexPrinter.java
@@ -890,8 +890,25 @@ public class DexPrinter {
 
 	private String getOuterClassNameFromTag(InnerClassTag icTag) {
 		String outerClass;
-		if (icTag.getOuterClass() == null) { // anonymous inner classes
-			outerClass = icTag.getInnerClass().replaceAll("\\$[0-9,a-z,A-Z]*$", "").replaceAll("/", ".");
+		
+		if (icTag.getOuterClass() == null) { // anonymous and local classes
+			String inner = icTag.getInnerClass().replaceAll("/", ".");
+			if(inner.contains("$-")) {
+				/* This is a special case for generated lambda classes of jack and jill compiler.
+				 * Generated lambda classes may contain '$' which do not indicate an inner/outer 
+				 * class separator if the '$' occurs after a inner class with a name starting with
+				 * '-'. Thus we search for '$-' and anything after it including '-' is the inner
+				 * classes name and anything before it is the outer classes name.
+				 */
+				outerClass = inner.substring(0, inner.indexOf("$-"));
+			} else if(inner.contains("$")) {
+				//remove everything after the last '$' including the last '$'
+				outerClass = inner.substring(0, inner.lastIndexOf('$'));
+			} else {
+				//no '$' in a inner class ???
+				//outer = inner;
+				throw new RuntimeException("Error: Could not identify the outer class of the inner class '" + inner + "'.");
+			}
 		} else {
 			outerClass = icTag.getOuterClass().replaceAll("/", ".");
 		}


### PR DESCRIPTION
This pull request fixes three issues:

    1. When determining the outer class of a inner class, dexpler used several different regular
       expressions, some were equivalent and others were not. Moreover, because of the ways these
       were written, some would return the outer most class instead of the first outer class of
       an inner class. The changes in this commit make sure that given a string such as
       'com.package.path.OuterMostClassName$1$MiddleOuterClass$InnerClass', dexpler returns
       'com.package.path.OuterMostClassName$1$MiddleOuterClass' as the outer class.

    2. Lambda classes generated by the jack and jill compiler contain extremely abnormal class
       names that may include the '$' which is normally reserved for indicating the outer and
       inner class hierarchy for a specific class. As such, a '$' does not always indicate
       the separation of the name of an outer class from one of its inner classes. Luckily,
       all the jack and jill generated lambda class names begin with a '-' and are always the
       inner class of class containing the lambda operation. Moreover, generated lambda
       classes are always the last class in the outer/inner class hierarchy specification of
       a class name. Therefore, dexpler can use the first occurrence of '$-' as a special indicator
       that we are dealing with a jack and jill generated lambda class and also as a separator
       for the inner class name and the outer class name.

    3. Previously, the jimple parser completly omitted the setup of the inner/outer
       class hierarchy as it read in classes from jimple. This just adds a bit of code
       to the JimpleClassSource file that uses the class hierarchy laid out in a classes
       full name to determine if it has an outer class, what the outer class is, and
       to set the classes outer class. The name parsing procedure is the same as the
       parsing procedure used in dexpler (i.e. it handles the jack and jill generated
       lambda classes).

In terms of the changes in dexpler, I am pretty sure I caught all the places in dexpler that handled inner/outer classes. I am also fairly certain that the parsing procedure I added works in all cases since I ran it on all the classes in the system image of AOSP 7.0 and everything seemed to work fine. However, I did replace code using 'replaceAll' with code that searches for the last or first occurrences of string indicators and then splits the string based on the index of these indicators. In other words, the functionality is not exactly equal. However, for all the classes of the system image of AOSP 7.0, I never encountered a inner class whose name was more than something like `Lcom.package.path.OuterMostClassName$1$MiddleOuterClass$InnerClass;` (i.e. no class names inside of '<>', more class names after the ';', more that one ';', or more than one 'L') so I did not see much reason in complicating the procedure by using a 'replaceAll'.

In terms of the changes to the jimple parsing procedure, when constructing the outer/inner class hierarchy, I simply copied the procedure used in dexpler and asm. Therefore, except for the fact that there are not any tags being set for inner classes or enclosing methods, everything should be fine. I did not set the tags because I was not entirely sure how and I was also not sure if they were really needed.