### PR TITLE
Flexible generics for ReachableMethods, TransitiveTargets

### DIFF
--- a/src/soot/jimple/toolkits/callgraph/ReachableMethods.java
+++ b/src/soot/jimple/toolkits/callgraph/ReachableMethods.java
@@ -36,10 +36,10 @@ public class ReachableMethods
     private QueueReader<MethodOrMethodContext> unprocessedMethods;
     private final QueueReader<MethodOrMethodContext> allReachables = reachables.reader();
     private Filter filter;
-    public ReachableMethods( CallGraph graph, Iterator<MethodOrMethodContext> entryPoints ) {
+    public ReachableMethods( CallGraph graph, Iterator<? extends MethodOrMethodContext> entryPoints ) {
         this( graph, entryPoints, null );
     }
-    public ReachableMethods( CallGraph graph, Iterator<MethodOrMethodContext> entryPoints, Filter filter ) {
+    public ReachableMethods( CallGraph graph, Iterator<? extends MethodOrMethodContext> entryPoints, Filter filter ) {
         this.filter = filter;
         this.cg = graph;
         addMethods( entryPoints );
@@ -50,7 +50,7 @@ public class ReachableMethods
     public ReachableMethods( CallGraph graph, Collection<MethodOrMethodContext> entryPoints ) {
     	this(graph, entryPoints.iterator());
     }
-    private void addMethods( Iterator<MethodOrMethodContext> methods ) {
+    private void addMethods( Iterator<? extends MethodOrMethodContext> methods ) {
         while( methods.hasNext() )
             addMethod( (MethodOrMethodContext) methods.next() );
     }

--- a/src/soot/jimple/toolkits/callgraph/ReachableMethods.java
+++ b/src/soot/jimple/toolkits/callgraph/ReachableMethods.java
@@ -47,7 +47,7 @@ public class ReachableMethods
         this.edgeSource = graph.listener();
         if( filter != null ) this.edgeSource = filter.wrap( this.edgeSource );
     }
-    public ReachableMethods( CallGraph graph, Collection<MethodOrMethodContext> entryPoints ) {
+    public ReachableMethods( CallGraph graph, Collection<? extends MethodOrMethodContext> entryPoints ) {
     	this(graph, entryPoints.iterator());
     }
     private void addMethods( Iterator<? extends MethodOrMethodContext> methods ) {

--- a/src/soot/jimple/toolkits/callgraph/TransitiveTargets.java
+++ b/src/soot/jimple/toolkits/callgraph/TransitiveTargets.java
@@ -38,7 +38,7 @@ public class TransitiveTargets
     }
     public Iterator<MethodOrMethodContext> iterator( Unit u ) {
         ArrayList<MethodOrMethodContext> methods = new ArrayList<MethodOrMethodContext>();
-        Iterator it = cg.edgesOutOf( u );
+        Iterator<Edge> it = cg.edgesOutOf( u );
         if( filter != null ) it = filter.wrap( it );
         while( it.hasNext() ) {
             Edge e = (Edge) it.next();
@@ -48,7 +48,7 @@ public class TransitiveTargets
     }
     public Iterator<MethodOrMethodContext> iterator( MethodOrMethodContext momc ) {
         ArrayList<MethodOrMethodContext> methods = new ArrayList<MethodOrMethodContext>();
-        Iterator it = cg.edgesOutOf( momc );
+        Iterator<Edge> it = cg.edgesOutOf( momc );
         if( filter != null ) it = filter.wrap( it );
         while( it.hasNext() ) {
             Edge e = (Edge) it.next();
@@ -56,7 +56,7 @@ public class TransitiveTargets
         }
         return iterator( methods.iterator() );
     }
-    public Iterator<MethodOrMethodContext> iterator( Iterator<MethodOrMethodContext> methods ) {
+    public Iterator<MethodOrMethodContext> iterator( Iterator<? extends MethodOrMethodContext> methods ) {
         Set<MethodOrMethodContext> s = new HashSet<MethodOrMethodContext>();
         ArrayList<MethodOrMethodContext> worklist = new ArrayList<MethodOrMethodContext>();
         while( methods.hasNext() ) {
@@ -68,7 +68,7 @@ public class TransitiveTargets
     private Iterator<MethodOrMethodContext> iterator( Set<MethodOrMethodContext> s, ArrayList<MethodOrMethodContext> worklist ) {
         for( int i = 0; i < worklist.size(); i++ ) {
             MethodOrMethodContext method = worklist.get(i);
-            Iterator it = cg.edgesOutOf( method );
+            Iterator<Edge> it = cg.edgesOutOf( method );
             if( filter != null ) it = filter.wrap( it );
             while( it.hasNext() ) {
                 Edge e = (Edge) it.next();


### PR DESCRIPTION
This allows for passing in iterators over SootMethods to transitive targets and reachable methods without having to unsafely cast the generic type or build a temporary container.

Having to do the above was a huge pain point in using these classes in a client analysis.

Also, since I was in the file, I added type arguments to some of the variable declarations, because why not?
