### PR TITLE
Update `dexlib2` version in `pom.xml` to 2.2b3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.smali</groupId>
       <artifactId>dexlib2</artifactId>
-      <version>2.1.3</version>
+      <version>2.2b3</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Previously, a `mvn compile` in a clean Soot clone on the `develop` branch would not succeed, because of API changes in recent versions of `dexlib2` leveraged by recent Soot commits. This change updates the version of `dexlib2` pulled in by the Maven POM file to the one expected by the code.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sable/soot/663)
<!-- Reviewable:end -->
