### PR TITLE
Remove nops before building Shimple or else Jimple validation may fail

### DIFF
--- a/src/soot/jimple/toolkits/scalar/NopEliminator.java
+++ b/src/soot/jimple/toolkits/scalar/NopEliminator.java
@@ -17,14 +17,13 @@
  * Boston, MA 02111-1307, USA.
  */
 
-/*
+ /*
  * Modified by the Sable Research Group and others 1997-1999.  
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
-
-
 package soot.jimple.toolkits.scalar;
+
 import java.util.Iterator;
 import java.util.Map;
 
@@ -34,53 +33,49 @@ import soot.G;
 import soot.Singletons;
 import soot.Trap;
 import soot.Unit;
-import soot.jimple.JimpleBody;
 import soot.jimple.NopStmt;
 import soot.options.Options;
 import soot.util.Chain;
 
-public class NopEliminator extends BodyTransformer
-{
-    public NopEliminator( Singletons.Global g ) {}
-    public static NopEliminator v() { return G.v().soot_jimple_toolkits_scalar_NopEliminator(); }
+public class NopEliminator extends BodyTransformer {
 
-    /** Removes {@link NopStmt}s from the passed body (which must be
-	a {@link JimpleBody}).  Complexity is linear 
-        with respect to the statements.
-    */
-    
-    protected void internalTransform(Body b, String phaseName, Map<String, String> options)
-    {
-        JimpleBody body = (JimpleBody)b;
-        
-        if(Options.v().verbose())
-            G.v().out.println("[" + body.getMethod().getName() +
-                "] Removing nops...");
-                
-        Chain<Unit> units = body.getUnits();
-        
+    public NopEliminator(Singletons.Global g) {
+    }
+
+    public static NopEliminator v() {
+        return G.v().soot_jimple_toolkits_scalar_NopEliminator();
+    }
+
+    /**
+     * Removes {@link NopStmt}s from the passed body . Complexity is linear with
+     * respect to the statements.
+     */
+    @Override
+    protected void internalTransform(Body b, String phaseName, Map<String, String> options) {
+        if (Options.v().verbose()) {
+            G.v().out.println("[" + b.getMethod().getName() + "] Removing nops...");
+        }
+
+        Chain<Unit> units = b.getUnits();
+
         // Just do one trivial pass.
-        {
-            Iterator<Unit> stmtIt = units.snapshotIterator();
-            
-            while(stmtIt.hasNext()) 
-            {
-                Unit u = stmtIt.next();
-				if (u instanceof NopStmt) {
-					// Hack: do not remove nop, if is is used for a Trap which
-					// is at the very end of the code.
-					boolean keepNop = false;
-					if (b.getUnits().getLast() == u) {
-						for (Trap t : b.getTraps()) {
-							if (t.getEndUnit() == u) {
-								keepNop = true;
-							}
-						}
-					}
-					if (!keepNop) {
-						units.remove(u);
-					}
-				}
+        Iterator<Unit> stmtIt = units.snapshotIterator();
+        while (stmtIt.hasNext()) {
+            Unit u = stmtIt.next();
+            if (u instanceof NopStmt) {
+                // Hack: do not remove nop, if is is used for a Trap which
+                // is at the very end of the code.
+                boolean keepNop = false;
+                if (b.getUnits().getLast() == u) {
+                    for (Trap t : b.getTraps()) {
+                        if (t.getEndUnit() == u) {
+                            keepNop = true;
+                        }
+                    }
+                }
+                if (!keepNop) {
+                    units.remove(u);
+                }
             }
         }
     }

--- a/src/soot/shimple/internal/ShimpleBodyBuilder.java
+++ b/src/soot/shimple/internal/ShimpleBodyBuilder.java
@@ -77,6 +77,13 @@ public class ShimpleBodyBuilder
      **/
     public ShimpleBodyBuilder(ShimpleBody body)
     {
+        //Must remove nops prior to building the CFG because NopStmt appearing
+        //  before the IdentityStmt in a trap handler that is itself protected
+        //  by a trap cause Phi nodes to be inserted before the NopStmt and
+        //  therefore before the IdentityStmt. This introduces a validation
+        //  problem if the Phi nodes leave residual assignment statements after
+        //  their removal.
+        NopEliminator.v().transform(body);
         this.body = body;
         sf = G.v().shimpleFactory;
         sf.setBody(body);


### PR DESCRIPTION
Must remove nops prior to building the CFG because NopStmt appearing before the IdentityStmt in a trap handler that is itself protected by a trap cause Phi nodes to be inserted before the NopStmt and therefore before the IdentityStmt. This introduces a validation problem if the Phi nodes leave residual assignment statements after their removal.

Generalized NopEliminator to work on any type of Body by removing the cast of the body to JimpleBody