### PR TITLE
Fix quoting and unquoting issues for .jimple format

### DIFF
--- a/src/soot/ArrayType.java
+++ b/src/soot/ArrayType.java
@@ -131,6 +131,20 @@ public class ArrayType extends RefLikeType
 
         return buffer.toString();
     }
+    
+    /** Returns a textual representation, quoted as needed, of this type for serialization, e.g. to .jimple format */
+    @Override
+    public String toQuotedString() {
+        StringBuilder buffer = new StringBuilder();
+
+        buffer.append(baseType.toQuotedString());
+
+        for(int i = 0; i < numDimensions; i++)
+            buffer.append("[]");
+
+        return buffer.toString();
+    }
+
 
     public int hashCode()
     {

--- a/src/soot/NormalUnitPrinter.java
+++ b/src/soot/NormalUnitPrinter.java
@@ -30,8 +30,7 @@ public class NormalUnitPrinter extends LabeledUnitPrinter {
 
     public void type( Type t ) { 
         handleIndent();
-        String s = t==null ? "<null>"  : t.toString();
-        if( t instanceof RefType ) s = Scene.v().quotedNameOf(s);
+        String s = t==null ? "<null>"  : t.toQuotedString();
         output.append( s );
     }
     public void methodRef( SootMethodRef m ) {

--- a/src/soot/RefType.java
+++ b/src/soot/RefType.java
@@ -148,6 +148,12 @@ public class RefType extends RefLikeType implements Comparable<RefType> {
 		return className;
 	}
 
+    /** Returns a textual representation, quoted as needed, of this type for serialization, e.g. to .jimple format */
+	@Override
+    public String toQuotedString() {
+    	return Scene.v().quotedNameOf(className);
+    }
+
 	public int hashCode() {
 		return className.hashCode();
 	}
@@ -255,9 +261,4 @@ public class RefType extends RefLikeType implements Comparable<RefType> {
 		return true;
 	}
 	
-	@Override
-    public String getEscapedName() {
-    	return Scene.v().quotedNameOf(getClassName());
-    }
-
 }

--- a/src/soot/Scene.java
+++ b/src/soot/Scene.java
@@ -942,7 +942,7 @@ public class Scene  //extends AbstractHost
      */
     public RefType getRefTypeUnsafe(String className) 
     {
-        RefType refType = nameToClass.get(unescapeName(className));
+        RefType refType = nameToClass.get(className);
 		return refType;
     }
     

--- a/src/soot/SootField.java
+++ b/src/soot/SootField.java
@@ -81,7 +81,7 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
         StringBuffer buffer = new StringBuffer();
 
         buffer.append("<" + Scene.v().quotedNameOf(cl.getName()) + ": ");
-        buffer.append(type + " " + Scene.v().quotedNameOf(name) + ">");
+        buffer.append(type.toQuotedString() + " " + Scene.v().quotedNameOf(name) + ">");
 
         return buffer.toString().intern();
 
@@ -204,7 +204,7 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 
     private String getOriginalStyleDeclaration()
     {
-        String qualifiers = Modifier.toString(modifiers) + " " + type.toString();
+        String qualifiers = Modifier.toString(modifiers) + " " + type.toQuotedString();
         qualifiers = qualifiers.trim();
 
         if(qualifiers.equals(""))

--- a/src/soot/SootMethod.java
+++ b/src/soot/SootMethod.java
@@ -623,20 +623,17 @@ public class SootMethod
         return getSubSignatureImpl(name, params, returnType);
     }
     
-    private static String getSubSignatureImpl(
-        String name,
-        List<Type> params,
-        Type returnType) {
+	private static String getSubSignatureImpl(String name, List<Type> params, Type returnType) {
         StringBuilder buffer = new StringBuilder();
         
-        buffer.append(returnType.getEscapedName());
+        buffer.append(returnType.toQuotedString());
         
         buffer.append(" ");
         buffer.append(Scene.v().quotedNameOf(name));
         buffer.append("(");
 
         for (int i = 0; i < params.size(); i++) {
-            buffer.append(params.get(i).getEscapedName());
+            buffer.append(params.get(i).toQuotedString());
             if (i < params.size() - 1)
                 buffer.append(",");
         }
@@ -812,7 +809,7 @@ public class SootMethod
 
         // return type + name
 
-        buffer.append(this.getReturnType() + " ");
+        buffer.append(this.getReturnType().toQuotedString() + " ");
         buffer.append(Scene.v().quotedNameOf(this.getName()));
 
         buffer.append("(");
@@ -823,7 +820,7 @@ public class SootMethod
         while (typeIt.hasNext()) {
             Type t = (Type) typeIt.next();
 
-            buffer.append(t);
+            buffer.append(t.toQuotedString());
 
             if (typeIt.hasNext())
                 buffer.append(", ");
@@ -838,11 +835,11 @@ public class SootMethod
 
             if (exceptionIt.hasNext()) {
                 buffer.append(
-                    " throws " + exceptionIt.next().getName());
+                    " throws " + Scene.v().quotedNameOf(exceptionIt.next().getName()));
 
                 while (exceptionIt.hasNext()) {
                     buffer.append(
-                        ", " + exceptionIt.next().getName());
+                        ", " + Scene.v().quotedNameOf(exceptionIt.next().getName()));
                 }
             }
         }

--- a/src/soot/SootResolver.java
+++ b/src/soot/SootResolver.java
@@ -107,9 +107,6 @@ public class SootResolver {
 	 * SootClass.
 	 * */
 	public SootClass makeClassRef(String className) {
-		// If this class name is escaped, we need to un-escape it
-		className = Scene.v().unescapeName(className);
-		
 		if (Scene.v().containsClass(className))
 			return Scene.v().getSootClass(className);
 

--- a/src/soot/Type.java
+++ b/src/soot/Type.java
@@ -40,6 +40,11 @@ public abstract class Type implements Switchable, Serializable, Numberable
     /** Returns a textual representation of this type. */
     public abstract String toString();
     
+    /** Returns a textual (and quoted as needed) representation of this type for serialization, e.g. to .jimple format */
+    public String toQuotedString() {
+    	return toString();
+    }
+    
     /** Converts the int-like types (short, byte, boolean and char) to IntType. */
     public static Type toMachineType(Type t)
     {
@@ -85,15 +90,6 @@ public abstract class Type implements Switchable, Serializable, Numberable
     	return false;
     }
     
-    /**
-     * Gets the escaped name of this type. If the type name is a reserved word, this
-     * method makes sure to properly escape it.
-     * @return The (potentially escaped) type name.
-     */
-    public String getEscapedName() {
-    	return toString();
-    }
-
     public final int getNumber() { return number; }
     public final void setNumber( int number ) { this.number = number; }
 

--- a/src/soot/jimple/parser/BodyExtractorWalker.java
+++ b/src/soot/jimple/parser/BodyExtractorWalker.java
@@ -76,7 +76,7 @@ public class BodyExtractorWalker extends Walker {
 		}
 
 		String className = (String) mProductions.removeLast();
-		if (!className.equals(Scene.v().quotedNameOf(mSootClass.getName())))
+		if (!className.equals(mSootClass.getName()))
 			throw new RuntimeException("expected:  " + className
 					+ ", but got: " + mSootClass.getName());
 

--- a/src/soot/jimple/parser/CstPoolExtractor.java
+++ b/src/soot/jimple/parser/CstPoolExtractor.java
@@ -29,6 +29,7 @@ package soot.jimple.parser;
 import soot.util.*;
 
 import soot.jimple.parser.node.*;
+import soot.Scene;
 import soot.jimple.parser.analysis.*;
 
 import java.util.*;
@@ -95,6 +96,7 @@ class CstPoolExtractor
         public void outAFullIdentClassName(AFullIdentClassName node)
         {
 	    String tokenString = node.getFullIdentifier().getText();
+	    tokenString = Scene.v().unescapeName(tokenString);
 	    tokenString = StringTools.getUnEscapedStringOf(tokenString);
 	    
             mRefTypes.add(tokenString);
@@ -112,6 +114,7 @@ class CstPoolExtractor
         public void outAFullIdentNonvoidType(AFullIdentNonvoidType node)
         {
 	    String tokenString = node.getFullIdentifier().getText();
+	    tokenString = Scene.v().unescapeName(tokenString);
 	    tokenString = StringTools.getUnEscapedStringOf(tokenString);
 
             mRefTypes.add(tokenString);

--- a/src/soot/jimple/parser/SkeletonExtractorWalker.java
+++ b/src/soot/jimple/parser/SkeletonExtractorWalker.java
@@ -71,7 +71,7 @@ public class SkeletonExtractorWalker extends Walker
         
 
 	String className = (String) mProductions.removeLast();
-	className = Scene.v().unescapeName(className);
+
         if(mSootClass == null) {
             mSootClass = new SootClass(className);
             mSootClass.setResolvingLevel(SootClass.SIGNATURES);

--- a/src/soot/jimple/parser/Walker.java
+++ b/src/soot/jimple/parser/Walker.java
@@ -1412,6 +1412,8 @@ public class Walker extends DepthFirstAdapter {
 			if (node instanceof TStringConstant || node instanceof TQuotedName) {
 				tokenString = tokenString
 						.substring(1, tokenString.length() - 1);
+			} else if (node instanceof TFullIdentifier) {
+				tokenString = Scene.v().unescapeName(tokenString);
 			}
 
 			if (node instanceof TIdentifier || node instanceof TFullIdentifier


### PR DESCRIPTION
Escaping subparts of names introduced in
9a00dc779dbb1c2b29dc40dfa47604c66db644b9

Other related commits:
9a00dc779dbb1c2b29dc40dfa47604c66db644b9
8275282dec8c3dbc72307f25469e75ff4ddfa9f6
5f46195dcb3b5381c92a443b1932fffd0cb57969
804bf1f58d81df7a9ff8a0947815339fdc901b09
5bd57e5aa3734def55d592e18386cb5d6c196ed4
9ab0dc724d7e7f90dc1bf4571e297bc3891ecf9b