### PR TITLE
Extract interface + bug fixes

### DIFF
--- a/src/soot/jimple/toolkits/thread/synchronization/DeadlockDetector.java
+++ b/src/soot/jimple/toolkits/thread/synchronization/DeadlockDetector.java
@@ -19,6 +19,7 @@ import soot.jimple.spark.sets.HashPointsToSet;
 import soot.jimple.spark.sets.PointsToSetInternal;
 import soot.jimple.toolkits.callgraph.Filter;
 import soot.jimple.toolkits.callgraph.TransitiveTargets;
+import soot.toolkits.graph.DirectedGraph;
 import soot.toolkits.graph.HashMutableDirectedGraph;
 import soot.toolkits.graph.HashMutableEdgeLabelledDirectedGraph;
 import soot.toolkits.graph.MutableDirectedGraph;
@@ -378,8 +379,8 @@ public class DeadlockDetector {
                     if (!tnsShareAStaticLock || tn == otherTn) // if tns don't share any static lock, or if tns are the same one
                     {
                         // add these orderings to tn's visible order
-                        MutableDirectedGraph<Integer> orderings = lockOrder.getEdgesForLabel(otherTn);
-                        for (Integer node1 : orderings.getNodes()) {
+                        DirectedGraph<Integer> orderings = lockOrder.getEdgesForLabel(otherTn);
+                        for (Integer node1 : orderings) {
                             if (!visibleOrder.containsNode(node1)) {
                                 visibleOrder.addNode(node1);
                             }

--- a/src/soot/jimple/toolkits/thread/synchronization/DeadlockDetector.java
+++ b/src/soot/jimple/toolkits/thread/synchronization/DeadlockDetector.java
@@ -25,261 +25,238 @@ import soot.toolkits.graph.MutableEdgeLabelledDirectedGraph;
 
 public class DeadlockDetector {
 
-	boolean optionPrintDebug;
-	boolean optionRepairDeadlock;
-	boolean optionAllowSelfEdges;
-	List<CriticalSection> criticalSections;
-	TransitiveTargets tt;
-	
-	public DeadlockDetector(boolean optionPrintDebug, boolean optionRepairDeadlock, boolean optionAllowSelfEdges, List<CriticalSection> criticalSections)
-	{
-		this.optionPrintDebug = optionPrintDebug;
-		this.optionRepairDeadlock = optionRepairDeadlock;
-		this.optionAllowSelfEdges = optionAllowSelfEdges && !optionRepairDeadlock; // can only do this if not repairing
-		this.criticalSections = criticalSections;
-		this.tt = new TransitiveTargets(Scene.v().getCallGraph(), new Filter(new CriticalSectionVisibleEdgesPred(null)));
-	}
-	
-	public MutableDirectedGraph<CriticalSectionGroup> detectComponentBasedDeadlock()
-	{
-		MutableDirectedGraph<CriticalSectionGroup> lockOrder;
-		boolean foundDeadlock;
-		int iteration = 0;
-		do
-		{
-			iteration++;
-			G.v().out.println("[DeadlockDetector] Deadlock Iteration #" + iteration);
-			foundDeadlock = false;
-			lockOrder = new HashMutableDirectedGraph(); // start each iteration with a fresh graph
+    boolean optionPrintDebug;
+    boolean optionRepairDeadlock;
+    boolean optionAllowSelfEdges;
+    List<CriticalSection> criticalSections;
+    TransitiveTargets tt;
 
-			// Assemble the partial ordering of locks
-			Iterator<CriticalSection> deadlockIt1 = criticalSections.iterator();
-			while(deadlockIt1.hasNext() && !foundDeadlock)
-			{
-				CriticalSection tn1 = deadlockIt1.next();
+    public DeadlockDetector(boolean optionPrintDebug, boolean optionRepairDeadlock, boolean optionAllowSelfEdges, List<CriticalSection> criticalSections) {
+        this.optionPrintDebug = optionPrintDebug;
+        this.optionRepairDeadlock = optionRepairDeadlock;
+        this.optionAllowSelfEdges = optionAllowSelfEdges && !optionRepairDeadlock; // can only do this if not repairing
+        this.criticalSections = criticalSections;
+        this.tt = new TransitiveTargets(Scene.v().getCallGraph(), new Filter(new CriticalSectionVisibleEdgesPred(null)));
+    }
 
-				// skip if unlocked
-				if( tn1.setNumber <= 0 )
-					continue;
+    public MutableDirectedGraph<CriticalSectionGroup> detectComponentBasedDeadlock() {
+        MutableDirectedGraph<CriticalSectionGroup> lockOrder;
+        boolean foundDeadlock;
+        int iteration = 0;
+        do {
+            iteration++;
+            G.v().out.println("[DeadlockDetector] Deadlock Iteration #" + iteration);
+            foundDeadlock = false;
+            lockOrder = new HashMutableDirectedGraph(); // start each iteration with a fresh graph
 
-				// add a node for this set
-				if( !lockOrder.containsNode(tn1.group) )
-				{
-					lockOrder.addNode(tn1.group);
-				}
+            // Assemble the partial ordering of locks
+            Iterator<CriticalSection> deadlockIt1 = criticalSections.iterator();
+            while (deadlockIt1.hasNext() && !foundDeadlock) {
+                CriticalSection tn1 = deadlockIt1.next();
 
-				// Get list of tn1's target methods
-				if(tn1.transitiveTargets == null)
-				{
-					tn1.transitiveTargets = new HashSet<MethodOrMethodContext>();
-					for(Unit tn1Invoke : tn1.invokes)
-					{
-						Iterator<MethodOrMethodContext> targetIt = tt.iterator(tn1Invoke);
-						while(targetIt.hasNext())
-							tn1.transitiveTargets.add(targetIt.next());
-					}
-				}
+                // skip if unlocked
+                if (tn1.setNumber <= 0) {
+                    continue;
+                }
 
-				// compare to each other tn
-				Iterator<CriticalSection> deadlockIt2 = criticalSections.iterator();
-				while(deadlockIt2.hasNext() && (!optionRepairDeadlock || !foundDeadlock))
-				{
-					CriticalSection tn2 = deadlockIt2.next();
+                // add a node for this set
+                if (!lockOrder.containsNode(tn1.group)) {
+                    lockOrder.addNode(tn1.group);
+                }
 
-					// skip if unlocked or in same set as tn1
-					if( tn2.setNumber <= 0 || (tn2.setNumber == tn1.setNumber && !optionAllowSelfEdges) ) // this is wrong... dynamic locks in same group can be diff locks
-						continue;
+                // Get list of tn1's target methods
+                if (tn1.transitiveTargets == null) {
+                    tn1.transitiveTargets = new HashSet<MethodOrMethodContext>();
+                    for (Unit tn1Invoke : tn1.invokes) {
+                        Iterator<MethodOrMethodContext> targetIt = tt.iterator(tn1Invoke);
+                        while (targetIt.hasNext()) {
+                            tn1.transitiveTargets.add(targetIt.next());
+                        }
+                    }
+                }
 
-					// add a node for this set
-					if( !lockOrder.containsNode(tn2.group) )
-					{
-						lockOrder.addNode(tn2.group);
-					}	
+                // compare to each other tn
+                Iterator<CriticalSection> deadlockIt2 = criticalSections.iterator();
+                while (deadlockIt2.hasNext() && (!optionRepairDeadlock || !foundDeadlock)) {
+                    CriticalSection tn2 = deadlockIt2.next();
 
-					if( tn1.transitiveTargets.contains(tn2.method) )
-					{
-						// This implies the partial ordering tn1lock before tn2lock
-						if(optionPrintDebug)
-						{
-							G.v().out.println("group" + (tn1.setNumber) + " before group" + (tn2.setNumber) + ": " +
-									"outer: " + tn1.name + " inner: " + tn2.name);
-						}
+                    // skip if unlocked or in same set as tn1
+                    if (tn2.setNumber <= 0 || (tn2.setNumber == tn1.setNumber && !optionAllowSelfEdges)) // this is wrong... dynamic locks in same group can be diff locks
+                    {
+                        continue;
+                    }
 
-						// Check if tn2lock before tn1lock is in our lock order
-						List afterTn2 = new ArrayList();
-						afterTn2.addAll( lockOrder.getSuccsOf(tn2.group) );
-						for( int i = 0; i < afterTn2.size(); i++ )
-						{
-							List succs = lockOrder.getSuccsOf((CriticalSectionGroup) afterTn2.get(i));
-							for( Object o : succs )
-							{
-								if(!afterTn2.contains(o))
-									afterTn2.add(o);
-							}
-						}
+                    // add a node for this set
+                    if (!lockOrder.containsNode(tn2.group)) {
+                        lockOrder.addNode(tn2.group);
+                    }
 
-						if( afterTn2.contains(tn1.group) )
-						{
-							if(!optionRepairDeadlock)
-							{
-								G.v().out.println("[DeadlockDetector]  DEADLOCK HAS BEEN DETECTED: not correcting");
-								foundDeadlock = true;
-							}
-							else
-							{
-								G.v().out.println("[DeadlockDetector]  DEADLOCK HAS BEEN DETECTED: merging group" +
-										(tn1.setNumber) + " and group" + (tn2.setNumber) +
-								" and restarting deadlock detection");
+                    if (tn1.transitiveTargets.contains(tn2.method)) {
+                        // This implies the partial ordering tn1lock before tn2lock
+                        if (optionPrintDebug) {
+                            G.v().out.println("group" + (tn1.setNumber) + " before group" + (tn2.setNumber) + ": "
+                                    + "outer: " + tn1.name + " inner: " + tn2.name);
+                        }
 
-								if(optionPrintDebug)
-								{
-									G.v().out.println("tn1.setNumber was " + tn1.setNumber + " and tn2.setNumber was " + tn2.setNumber);
-									G.v().out.println("tn1.group.size was " + tn1.group.criticalSections.size() +
-											" and tn2.group.size was " + tn2.group.criticalSections.size());
-									G.v().out.println("tn1.group.num was  " + tn1.group.num() + " and tn2.group.num was  " + tn2.group.num());
-								}
-								tn1.group.mergeGroups(tn2.group);
-								if(optionPrintDebug)
-								{
-									G.v().out.println("tn1.setNumber is  " + tn1.setNumber + " and tn2.setNumber is  " + tn2.setNumber);
-									G.v().out.println("tn1.group.size is  " + tn1.group.criticalSections.size() +
-											" and tn2.group.size is  " + tn2.group.criticalSections.size());
-								}
+                        // Check if tn2lock before tn1lock is in our lock order
+                        List afterTn2 = new ArrayList();
+                        afterTn2.addAll(lockOrder.getSuccsOf(tn2.group));
+                        for (int i = 0; i < afterTn2.size(); i++) {
+                            List succs = lockOrder.getSuccsOf((CriticalSectionGroup) afterTn2.get(i));
+                            for (Object o : succs) {
+                                if (!afterTn2.contains(o)) {
+                                    afterTn2.add(o);
+                                }
+                            }
+                        }
 
-								foundDeadlock = true;
-							}
-						}
+                        if (afterTn2.contains(tn1.group)) {
+                            if (!optionRepairDeadlock) {
+                                G.v().out.println("[DeadlockDetector]  DEADLOCK HAS BEEN DETECTED: not correcting");
+                                foundDeadlock = true;
+                            } else {
+                                G.v().out.println("[DeadlockDetector]  DEADLOCK HAS BEEN DETECTED: merging group"
+                                        + (tn1.setNumber) + " and group" + (tn2.setNumber)
+                                        + " and restarting deadlock detection");
 
-						lockOrder.addEdge(tn1.group, tn2.group);
-					}
-				}
-			}
-		} while(foundDeadlock && optionRepairDeadlock);
-		return lockOrder;
-	}
+                                if (optionPrintDebug) {
+                                    G.v().out.println("tn1.setNumber was " + tn1.setNumber + " and tn2.setNumber was " + tn2.setNumber);
+                                    G.v().out.println("tn1.group.size was " + tn1.group.criticalSections.size()
+                                            + " and tn2.group.size was " + tn2.group.criticalSections.size());
+                                    G.v().out.println("tn1.group.num was  " + tn1.group.num() + " and tn2.group.num was  " + tn2.group.num());
+                                }
+                                tn1.group.mergeGroups(tn2.group);
+                                if (optionPrintDebug) {
+                                    G.v().out.println("tn1.setNumber is  " + tn1.setNumber + " and tn2.setNumber is  " + tn2.setNumber);
+                                    G.v().out.println("tn1.group.size is  " + tn1.group.criticalSections.size()
+                                            + " and tn2.group.size is  " + tn2.group.criticalSections.size());
+                                }
 
-	public MutableEdgeLabelledDirectedGraph detectLocksetDeadlock(
-			Map<Value, Integer> lockToLockNum, List<PointsToSetInternal> lockPTSets) {
-		MutableEdgeLabelledDirectedGraph permanentOrder = new HashMutableEdgeLabelledDirectedGraph();
-		MutableEdgeLabelledDirectedGraph lockOrder;
-		boolean foundDeadlock;
-		int iteration = 0;
-		do
-		{
-			iteration++;
-			G.v().out.println("[DeadlockDetector] Deadlock Iteration #" + iteration);
-			foundDeadlock = false;
-			lockOrder = (HashMutableEdgeLabelledDirectedGraph) ((HashMutableEdgeLabelledDirectedGraph) permanentOrder).clone(); // start each iteration with a fresh copy of the permanent orders
-			
-			// Assemble the partial ordering of locks
-			Iterator<CriticalSection> deadlockIt1 = criticalSections.iterator();
-			while(deadlockIt1.hasNext() && !foundDeadlock)
-			{
-				CriticalSection tn1 = deadlockIt1.next();
-				
-				// skip if unlocked
-				if( tn1.group == null )
-					continue;
-					
-				// add a node for each lock in this lockset
-				for( EquivalentValue lockEqVal : tn1.lockset )
-				{
-					Value lock = lockEqVal.getValue();
-				
-					if( !lockOrder.containsNode(lockToLockNum.get(lock)) )
-						lockOrder.addNode(lockToLockNum.get(lock));
-				}
-					
-				// Get list of tn1's target methods
-				if(tn1.transitiveTargets == null)
-				{
-		    		tn1.transitiveTargets = new HashSet<MethodOrMethodContext>();
-		    		for(Unit tn1Invoke : tn1.invokes)
-		    		{
-		    			Iterator<MethodOrMethodContext> targetIt = tt.iterator(tn1Invoke);
-		    			while(targetIt.hasNext())
-		    				tn1.transitiveTargets.add(targetIt.next());
-		    		}
-		    	}
-				
-				// compare to each other tn
-				Iterator<CriticalSection> deadlockIt2 = criticalSections.iterator();
-				while(deadlockIt2.hasNext() && !foundDeadlock)
-				{
-					CriticalSection tn2 = deadlockIt2.next();
-					
-					// skip if unlocked
-					if( tn2.group == null )
-						continue;
-					
-					// add a node for each lock in this lockset
-					for( EquivalentValue lockEqVal : tn2.lockset )
-					{
-						Value lock = lockEqVal.getValue();
-			    		
-			    		if( !lockOrder.containsNode(lockToLockNum.get(lock)) )
-			    			lockOrder.addNode(lockToLockNum.get(lock));
-			    	}
-			    				    			
-		    		if( tn1.transitiveTargets.contains(tn2.method) && !foundDeadlock )
-		    		{
-		    			// This implies the partial ordering (locks in tn1) before (locks in tn2)
-		    			if(true) //optionPrintDebug)
-		    			{
-			    			G.v().out.println("[DeadlockDetector] locks in " + (tn1.name) + " before locks in " + (tn2.name) + ": " +
-			    				"outer: " + tn1.name + " inner: " + tn2.name);
-			    		}
-		    			
-		    			// Check if tn2locks before tn1locks is in our lock order
-						for( EquivalentValue lock2EqVal : tn2.lockset )
-						{
-							Value lock2 = lock2EqVal.getValue();
-							Integer lock2Num = lockToLockNum.get(lock2);
+                                foundDeadlock = true;
+                            }
+                        }
 
-			    			List afterTn2 = new ArrayList();
-							afterTn2.addAll( lockOrder.getSuccsOf(lock2Num) ); // filter here!
-							ListIterator lit = afterTn2.listIterator();
-							while(lit.hasNext())
-							{
-								Integer to = (Integer) lit.next(); // node the edges go to
-								List labels = lockOrder.getLabelsForEdges(lock2Num, to);
-								boolean keep = false;
-								if(labels != null) // this shouldn't really happen... is something wrong with the edge-labelled graph?
-								{
-									for(Object l : labels)
-									{
-										CriticalSection labelTn = (CriticalSection) l;
-										
-										// Check if labelTn and tn1 share a static lock
-										boolean tnsShareAStaticLock = false;
-										for( EquivalentValue tn1LockEqVal : tn1.lockset )
-										{
-											Integer tn1LockNum = lockToLockNum.get(tn1LockEqVal.getValue());
-											if(tn1LockNum < 0)
-											{
-												// this is a static lock... see if some lock in labelTn has the same #
-												for( EquivalentValue labelTnLockEqVal : labelTn.lockset )
-												{
-													if(lockToLockNum.get(labelTnLockEqVal.getValue()) == tn1LockNum)
-													{
-														tnsShareAStaticLock = true;
-													}
-												}
-											}
-										}
-										
-										if(!tnsShareAStaticLock) // !hasStaticLockInCommon(tn1, labelTn))
-										{
-											keep = true;
-											break;
-										}
-									}
-								}
-								if(!keep)
-									lit.remove();
-							}
+                        lockOrder.addEdge(tn1.group, tn2.group);
+                    }
+                }
+            }
+        } while (foundDeadlock && optionRepairDeadlock);
+        return lockOrder;
+    }
 
-/*				    			for( int i = 0; i < afterTn2.size(); i++ )
+    public MutableEdgeLabelledDirectedGraph detectLocksetDeadlock(
+            Map<Value, Integer> lockToLockNum, List<PointsToSetInternal> lockPTSets) {
+        MutableEdgeLabelledDirectedGraph permanentOrder = new HashMutableEdgeLabelledDirectedGraph();
+        MutableEdgeLabelledDirectedGraph lockOrder;
+        boolean foundDeadlock;
+        int iteration = 0;
+        do {
+            iteration++;
+            G.v().out.println("[DeadlockDetector] Deadlock Iteration #" + iteration);
+            foundDeadlock = false;
+            lockOrder = (HashMutableEdgeLabelledDirectedGraph) ((HashMutableEdgeLabelledDirectedGraph) permanentOrder).clone(); // start each iteration with a fresh copy of the permanent orders
+
+            // Assemble the partial ordering of locks
+            Iterator<CriticalSection> deadlockIt1 = criticalSections.iterator();
+            while (deadlockIt1.hasNext() && !foundDeadlock) {
+                CriticalSection tn1 = deadlockIt1.next();
+
+                // skip if unlocked
+                if (tn1.group == null) {
+                    continue;
+                }
+
+                // add a node for each lock in this lockset
+                for (EquivalentValue lockEqVal : tn1.lockset) {
+                    Value lock = lockEqVal.getValue();
+
+                    if (!lockOrder.containsNode(lockToLockNum.get(lock))) {
+                        lockOrder.addNode(lockToLockNum.get(lock));
+                    }
+                }
+
+                // Get list of tn1's target methods
+                if (tn1.transitiveTargets == null) {
+                    tn1.transitiveTargets = new HashSet<MethodOrMethodContext>();
+                    for (Unit tn1Invoke : tn1.invokes) {
+                        Iterator<MethodOrMethodContext> targetIt = tt.iterator(tn1Invoke);
+                        while (targetIt.hasNext()) {
+                            tn1.transitiveTargets.add(targetIt.next());
+                        }
+                    }
+                }
+
+                // compare to each other tn
+                Iterator<CriticalSection> deadlockIt2 = criticalSections.iterator();
+                while (deadlockIt2.hasNext() && !foundDeadlock) {
+                    CriticalSection tn2 = deadlockIt2.next();
+
+                    // skip if unlocked
+                    if (tn2.group == null) {
+                        continue;
+                    }
+
+                    // add a node for each lock in this lockset
+                    for (EquivalentValue lockEqVal : tn2.lockset) {
+                        Value lock = lockEqVal.getValue();
+
+                        if (!lockOrder.containsNode(lockToLockNum.get(lock))) {
+                            lockOrder.addNode(lockToLockNum.get(lock));
+                        }
+                    }
+
+                    if (tn1.transitiveTargets.contains(tn2.method) && !foundDeadlock) {
+                        // This implies the partial ordering (locks in tn1) before (locks in tn2)
+                        if (true) //optionPrintDebug)
+                        {
+                            G.v().out.println("[DeadlockDetector] locks in " + (tn1.name) + " before locks in " + (tn2.name) + ": "
+                                    + "outer: " + tn1.name + " inner: " + tn2.name);
+                        }
+
+                        // Check if tn2locks before tn1locks is in our lock order
+                        for (EquivalentValue lock2EqVal : tn2.lockset) {
+                            Value lock2 = lock2EqVal.getValue();
+                            Integer lock2Num = lockToLockNum.get(lock2);
+
+                            List afterTn2 = new ArrayList();
+                            afterTn2.addAll(lockOrder.getSuccsOf(lock2Num)); // filter here!
+                            ListIterator lit = afterTn2.listIterator();
+                            while (lit.hasNext()) {
+                                Integer to = (Integer) lit.next(); // node the edges go to
+                                List labels = lockOrder.getLabelsForEdges(lock2Num, to);
+                                boolean keep = false;
+                                if (labels != null) // this shouldn't really happen... is something wrong with the edge-labelled graph?
+                                {
+                                    for (Object l : labels) {
+                                        CriticalSection labelTn = (CriticalSection) l;
+
+                                        // Check if labelTn and tn1 share a static lock
+                                        boolean tnsShareAStaticLock = false;
+                                        for (EquivalentValue tn1LockEqVal : tn1.lockset) {
+                                            Integer tn1LockNum = lockToLockNum.get(tn1LockEqVal.getValue());
+                                            if (tn1LockNum < 0) {
+                                                // this is a static lock... see if some lock in labelTn has the same #
+                                                for (EquivalentValue labelTnLockEqVal : labelTn.lockset) {
+                                                    if (lockToLockNum.get(labelTnLockEqVal.getValue()) == tn1LockNum) {
+                                                        tnsShareAStaticLock = true;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        if (!tnsShareAStaticLock) // !hasStaticLockInCommon(tn1, labelTn))
+                                        {
+                                            keep = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                                if (!keep) {
+                                    lit.remove();
+                                }
+                            }
+
+                            /*				    			for( int i = 0; i < afterTn2.size(); i++ )
 			    			{
 			    				List succs = lockOrder.getSuccsOf(afterTn2.get(i)); // but not here
 			    				for( Object o : succs )
@@ -288,186 +265,167 @@ public class DeadlockDetector {
 					    				afterTn2.add(o);
 				    			}
 			    			}
-*/
-		    				
-							for( EquivalentValue lock1EqVal : tn1.lockset )
-							{
-								Value lock1 = lock1EqVal.getValue();
-								Integer lock1Num = lockToLockNum.get(lock1);
-								
-					    		if( ( lock1Num != lock2Num || 
-					    			  lock1Num > 0 ) &&
-						    		  afterTn2.contains(lock1Num) )
-				    			{
-				    				if(!optionRepairDeadlock)
-				    				{
-					    				G.v().out.println("[DeadlockDetector] DEADLOCK HAS BEEN DETECTED: not correcting");
-										foundDeadlock = true;
-					    			}
-					    			else
-					    			{
-					    				G.v().out.println("[DeadlockDetector] DEADLOCK HAS BEEN DETECTED while inspecting " + lock1Num + " ("+lock1+") and " + lock2Num + " ("+lock2+") ");
-		    					
-										// Create a deadlock avoidance edge
-										DeadlockAvoidanceEdge dae = new DeadlockAvoidanceEdge(tn1.method.getDeclaringClass());
-										EquivalentValue daeEqVal = new EquivalentValue(dae);
-										
-										// Register it as a static lock
-										Integer daeNum = new Integer(-lockPTSets.size()); // negative indicates a static lock
-										permanentOrder.addNode(daeNum);
-										lockToLockNum.put(dae, daeNum);
-										PointsToSetInternal dummyLockPT = new HashPointsToSet(lock1.getType(), (PAG) Scene.v().getPointsToAnalysis());
-										lockPTSets.add(dummyLockPT);
+                             */
+                            for (EquivalentValue lock1EqVal : tn1.lockset) {
+                                Value lock1 = lock1EqVal.getValue();
+                                Integer lock1Num = lockToLockNum.get(lock1);
 
-										// Add it to the locksets of tn1 and whoever says l2 before l1
-										for(EquivalentValue lockEqVal : tn1.lockset)
-										{
-											Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
-											if(!permanentOrder.containsNode(lockNum))
-												permanentOrder.addNode(lockNum);
-											permanentOrder.addEdge(daeNum, lockNum, tn1);
-										}
-										tn1.lockset.add(daeEqVal);
+                                if ((lock1Num != lock2Num
+                                        || lock1Num > 0)
+                                        && afterTn2.contains(lock1Num)) {
+                                    if (!optionRepairDeadlock) {
+                                        G.v().out.println("[DeadlockDetector] DEADLOCK HAS BEEN DETECTED: not correcting");
+                                        foundDeadlock = true;
+                                    } else {
+                                        G.v().out.println("[DeadlockDetector] DEADLOCK HAS BEEN DETECTED while inspecting " + lock1Num + " (" + lock1 + ") and " + lock2Num + " (" + lock2 + ") ");
 
-										List forwardLabels = lockOrder.getLabelsForEdges(lock1Num, lock2Num);
-										if(forwardLabels != null)
-										{
-											for(Object t : forwardLabels)
-											{
-												CriticalSection tn = (CriticalSection) t;
-												if(!tn.lockset.contains(daeEqVal))
-												{
-													for(EquivalentValue lockEqVal : tn.lockset)
-													{
-														Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
-														if(!permanentOrder.containsNode(lockNum))
-															permanentOrder.addNode(lockNum);
-														permanentOrder.addEdge(daeNum, lockNum, tn);
-													}
-													tn.lockset.add(daeEqVal);
-												}
-											}
-										}
-										
-										List backwardLabels = lockOrder.getLabelsForEdges(lock2Num, lock1Num);
-										if(backwardLabels != null)
-										{
-											for(Object t : backwardLabels)
-											{
-												CriticalSection tn = (CriticalSection) t;
-												if(!tn.lockset.contains(daeEqVal))
-												{
-													for(EquivalentValue lockEqVal : tn.lockset)
-													{
-														Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
-														if(!permanentOrder.containsNode(lockNum))
-															permanentOrder.addNode(lockNum);
-														permanentOrder.addEdge(daeNum, lockNum, tn);
-													}
-													tn.lockset.add(daeEqVal);
-						    						G.v().out.println("[DeadlockDetector]   Adding deadlock avoidance edge between " +
-						    							(tn1.name) + " and " + (tn.name));
-						    					}
-											}
-											G.v().out.println("[DeadlockDetector]   Restarting deadlock detection");
-										}
-										
-										foundDeadlock = true;
-										break;
-					    			}
-				    			}
-				    			
-				    			if(lock1Num != lock2Num)
-									lockOrder.addEdge(lock1Num, lock2Num, tn1);
-				    		}
-				    		if(foundDeadlock)
-				    			break;
-				    	}
-			    	}
-				}
-			}
-		} while(foundDeadlock && optionRepairDeadlock);
-		return lockOrder;
-	}
+                                        // Create a deadlock avoidance edge
+                                        DeadlockAvoidanceEdge dae = new DeadlockAvoidanceEdge(tn1.method.getDeclaringClass());
+                                        EquivalentValue daeEqVal = new EquivalentValue(dae);
 
-	public void reorderLocksets(Map<Value, Integer> lockToLockNum, MutableEdgeLabelledDirectedGraph lockOrder) {
-		for(CriticalSection tn : criticalSections)
-		{
-			// Get the portion of the lock order that is visible to tn
-			HashMutableDirectedGraph visibleOrder = new HashMutableDirectedGraph();
-			if(tn.group != null)
-			{
-				for(CriticalSection otherTn : criticalSections)
-				{
-					// Check if otherTn and tn share a static lock
-					boolean tnsShareAStaticLock = false;
-					for( EquivalentValue tnLockEqVal : tn.lockset )
-					{
-						Integer tnLockNum = lockToLockNum.get(tnLockEqVal.getValue());
-						if(tnLockNum < 0)
-						{
-							// this is a static lock... see if some lock in labelTn has the same #
-							if(otherTn.group != null)
-							{
-								for( EquivalentValue otherTnLockEqVal : otherTn.lockset )
-								{
-									if(lockToLockNum.get(otherTnLockEqVal.getValue()) == tnLockNum)
-									{
-										tnsShareAStaticLock = true;
-									}
-								}
-							}
-							else
-								tnsShareAStaticLock = true; // not really... but we want to skip this one
-						}
-					}
-					
-					if(!tnsShareAStaticLock || tn == otherTn) // if tns don't share any static lock, or if tns are the same one
-					{
-						// add these orderings to tn's visible order
-						MutableDirectedGraph orderings = lockOrder.getEdgesForLabel(otherTn);
-						for(Object node1 : orderings.getNodes())
-						{
-							if(!visibleOrder.containsNode(node1))
-								visibleOrder.addNode(node1);
-							for(Object node2 : orderings.getSuccsOf(node1))
-							{
-								if(!visibleOrder.containsNode(node2))
-									visibleOrder.addNode(node2);
-								visibleOrder.addEdge(node1, node2);
-							}
-						}
-					}
-				}
+                                        // Register it as a static lock
+                                        Integer daeNum = new Integer(-lockPTSets.size()); // negative indicates a static lock
+                                        permanentOrder.addNode(daeNum);
+                                        lockToLockNum.put(dae, daeNum);
+                                        PointsToSetInternal dummyLockPT = new HashPointsToSet(lock1.getType(), (PAG) Scene.v().getPointsToAnalysis());
+                                        lockPTSets.add(dummyLockPT);
 
-				G.v().out.println("VISIBLE ORDER FOR " + tn.name);
-				visibleOrder.printGraph();
-			
-				// Order locks in tn's lockset according to the visible order (insertion sort)
-				List<EquivalentValue> newLockset = new ArrayList();
-				for(EquivalentValue lockEqVal : tn.lockset)
-				{
-					Value lockToInsert = lockEqVal.getValue();
-					Integer lockNumToInsert = lockToLockNum.get(lockToInsert);
-					int i = 0;
-					while( i < newLockset.size() )
-					{
-						EquivalentValue existingLockEqVal = newLockset.get(i);
-						Value existingLock = existingLockEqVal.getValue();
-						Integer existingLockNum = lockToLockNum.get(existingLock);
-						if( visibleOrder.containsEdge(lockNumToInsert, existingLockNum) ||
-							lockNumToInsert < existingLockNum )
-//							!visibleOrder.containsEdge(existingLockNum, lockNumToInsert) ) // if(! existing before toinsert )
-							break;
-						i++;
-					}
-					newLockset.add(i, lockEqVal);
-				}
-				G.v().out.println("reordered from " + LockAllocator.locksetToLockNumString(tn.lockset, lockToLockNum) +
-								" to " + LockAllocator.locksetToLockNumString(newLockset, lockToLockNum));
+                                        // Add it to the locksets of tn1 and whoever says l2 before l1
+                                        for (EquivalentValue lockEqVal : tn1.lockset) {
+                                            Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
+                                            if (!permanentOrder.containsNode(lockNum)) {
+                                                permanentOrder.addNode(lockNum);
+                                            }
+                                            permanentOrder.addEdge(daeNum, lockNum, tn1);
+                                        }
+                                        tn1.lockset.add(daeEqVal);
 
-				tn.lockset = newLockset;
-			}
-		}
-	}
+                                        List forwardLabels = lockOrder.getLabelsForEdges(lock1Num, lock2Num);
+                                        if (forwardLabels != null) {
+                                            for (Object t : forwardLabels) {
+                                                CriticalSection tn = (CriticalSection) t;
+                                                if (!tn.lockset.contains(daeEqVal)) {
+                                                    for (EquivalentValue lockEqVal : tn.lockset) {
+                                                        Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
+                                                        if (!permanentOrder.containsNode(lockNum)) {
+                                                            permanentOrder.addNode(lockNum);
+                                                        }
+                                                        permanentOrder.addEdge(daeNum, lockNum, tn);
+                                                    }
+                                                    tn.lockset.add(daeEqVal);
+                                                }
+                                            }
+                                        }
+
+                                        List backwardLabels = lockOrder.getLabelsForEdges(lock2Num, lock1Num);
+                                        if (backwardLabels != null) {
+                                            for (Object t : backwardLabels) {
+                                                CriticalSection tn = (CriticalSection) t;
+                                                if (!tn.lockset.contains(daeEqVal)) {
+                                                    for (EquivalentValue lockEqVal : tn.lockset) {
+                                                        Integer lockNum = lockToLockNum.get(lockEqVal.getValue());
+                                                        if (!permanentOrder.containsNode(lockNum)) {
+                                                            permanentOrder.addNode(lockNum);
+                                                        }
+                                                        permanentOrder.addEdge(daeNum, lockNum, tn);
+                                                    }
+                                                    tn.lockset.add(daeEqVal);
+                                                    G.v().out.println("[DeadlockDetector]   Adding deadlock avoidance edge between "
+                                                            + (tn1.name) + " and " + (tn.name));
+                                                }
+                                            }
+                                            G.v().out.println("[DeadlockDetector]   Restarting deadlock detection");
+                                        }
+
+                                        foundDeadlock = true;
+                                        break;
+                                    }
+                                }
+
+                                if (lock1Num != lock2Num) {
+                                    lockOrder.addEdge(lock1Num, lock2Num, tn1);
+                                }
+                            }
+                            if (foundDeadlock) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } while (foundDeadlock && optionRepairDeadlock);
+        return lockOrder;
+    }
+
+    public void reorderLocksets(Map<Value, Integer> lockToLockNum, MutableEdgeLabelledDirectedGraph lockOrder) {
+        for (CriticalSection tn : criticalSections) {
+            // Get the portion of the lock order that is visible to tn
+            HashMutableDirectedGraph visibleOrder = new HashMutableDirectedGraph();
+            if (tn.group != null) {
+                for (CriticalSection otherTn : criticalSections) {
+                    // Check if otherTn and tn share a static lock
+                    boolean tnsShareAStaticLock = false;
+                    for (EquivalentValue tnLockEqVal : tn.lockset) {
+                        Integer tnLockNum = lockToLockNum.get(tnLockEqVal.getValue());
+                        if (tnLockNum < 0) {
+                            // this is a static lock... see if some lock in labelTn has the same #
+                            if (otherTn.group != null) {
+                                for (EquivalentValue otherTnLockEqVal : otherTn.lockset) {
+                                    if (lockToLockNum.get(otherTnLockEqVal.getValue()) == tnLockNum) {
+                                        tnsShareAStaticLock = true;
+                                    }
+                                }
+                            } else {
+                                tnsShareAStaticLock = true; // not really... but we want to skip this one
+                            }
+                        }
+                    }
+
+                    if (!tnsShareAStaticLock || tn == otherTn) // if tns don't share any static lock, or if tns are the same one
+                    {
+                        // add these orderings to tn's visible order
+                        MutableDirectedGraph orderings = lockOrder.getEdgesForLabel(otherTn);
+                        for (Object node1 : orderings.getNodes()) {
+                            if (!visibleOrder.containsNode(node1)) {
+                                visibleOrder.addNode(node1);
+                            }
+                            for (Object node2 : orderings.getSuccsOf(node1)) {
+                                if (!visibleOrder.containsNode(node2)) {
+                                    visibleOrder.addNode(node2);
+                                }
+                                visibleOrder.addEdge(node1, node2);
+                            }
+                        }
+                    }
+                }
+
+                G.v().out.println("VISIBLE ORDER FOR " + tn.name);
+                visibleOrder.printGraph();
+
+                // Order locks in tn's lockset according to the visible order (insertion sort)
+                List<EquivalentValue> newLockset = new ArrayList();
+                for (EquivalentValue lockEqVal : tn.lockset) {
+                    Value lockToInsert = lockEqVal.getValue();
+                    Integer lockNumToInsert = lockToLockNum.get(lockToInsert);
+                    int i = 0;
+                    while (i < newLockset.size()) {
+                        EquivalentValue existingLockEqVal = newLockset.get(i);
+                        Value existingLock = existingLockEqVal.getValue();
+                        Integer existingLockNum = lockToLockNum.get(existingLock);
+                        if (visibleOrder.containsEdge(lockNumToInsert, existingLockNum)
+                                || lockNumToInsert < existingLockNum) //							!visibleOrder.containsEdge(existingLockNum, lockNumToInsert) ) // if(! existing before toinsert )
+                        {
+                            break;
+                        }
+                        i++;
+                    }
+                    newLockset.add(i, lockEqVal);
+                }
+                G.v().out.println("reordered from " + LockAllocator.locksetToLockNumString(tn.lockset, lockToLockNum)
+                        + " to " + LockAllocator.locksetToLockNumString(newLockset, lockToLockNum));
+
+                tn.lockset = newLockset;
+            }
+        }
+    }
 }

--- a/src/soot/toolkits/graph/EdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/EdgeLabelledDirectedGraph.java
@@ -1,0 +1,66 @@
+package soot.toolkits.graph;
+
+import java.util.List;
+
+/**
+ * A {@link DirectedGraph} with labels on the edges.
+ *
+ * @param <N> type of the nodes
+ * @param <L> type of the labels
+ */
+public interface EdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N> {
+
+    /**
+     * Returns a list of labels for which an edge exists between from and to
+     *
+     * @param from out node of the edges to get labels for
+     * @param to   in node of the edges to get labels for
+     *
+     * @return
+     */
+    public List<L> getLabelsForEdges(N from, N to);
+
+    /**
+     * Returns a DirectedGraph consisting of all edges with the given label and
+     * their nodes. Nodes without edges are not included in the new graph.
+     *
+     * @param label edge label to use as a filter in building the subgraph
+     *
+     * @return
+     */
+    public DirectedGraph<N> getEdgesForLabel(L label);
+
+    /**
+     * @param from
+     * @param to
+     * @param label
+     *
+     * @return true if the graph contains an edge between the 2 nodes with the
+     *         given label, false otherwise
+     */
+    public boolean containsEdge(N from, N to, L label);
+
+    /**
+     * @param from out node for the edges
+     * @param to   in node for the edges
+     *
+     * @return true if the graph contains any edges between the 2 nodes, false,
+     *         otherwise
+     */
+    public boolean containsAnyEdge(N from, N to);
+
+    /**
+     * @param label label for the edges
+     *
+     * @return true if the graph contains any edges with the given label, false
+     *         otherwise
+     */
+    public boolean containsAnyEdge(L label);
+
+    /**
+     * @param node node that we want to know if the graph contains
+     *
+     * @return true if the graph contains the node, false otherwise
+     */
+    public boolean containsNode(N node);
+}

--- a/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
@@ -298,7 +298,7 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
             throw new RuntimeException("edge " + edge + " not in graph!");
         }
 
-        for (L label : labels) {
+        for (L label : getCopy(labels)) {
             removeEdge(from, to, label);
         }
     }
@@ -314,35 +314,30 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
             throw new RuntimeException("label " + label + " not in graph!");
         }
 
-        for (DGEdge<N> edge : edges) {
+        for (DGEdge<N> edge : getCopy(edges)) {
             removeEdge(edge.from(), edge.to(), label);
         }
     }
 
     @Override
+
     public boolean containsEdge(N from, N to, L label) {
-        DGEdge<N> edge = new DGEdge<N>(from, to);
-        if (edgeToLabels.get(edge) != null && edgeToLabels.get(edge).contains(label)) {
-            return true;
-        }
-        return false;
+        List<L> labels = edgeToLabels.get(new DGEdge<>(from, to));
+        return labels != null && labels.contains(label);
     }
 
     @Override
+
     public boolean containsAnyEdge(N from, N to) {
-        DGEdge<N> edge = new DGEdge<N>(from, to);
-        if (edgeToLabels.get(edge) != null && edgeToLabels.get(edge).isEmpty()) {
-            return false;
-        }
-        return true;
+        List<L> labels = edgeToLabels.get(new DGEdge<>(from, to));
+        return labels != null && !labels.isEmpty();
     }
 
     @Override
+
     public boolean containsAnyEdge(L label) {
-        if (labelToEdges.get(label) != null && labelToEdges.get(label).isEmpty()) {
-            return false;
-        }
-        return true;
+        List<DGEdge<N>> edges = labelToEdges.get(label);
+        return edges != null && !edges.isEmpty();
     }
 
     @Override

--- a/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
@@ -18,91 +18,78 @@
  * Boston, MA 02111-1307, USA.
  */
 
-/*
+ /*
  * Modified by the Sable Research Group and others 1997-1999.  
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
-
-
 package soot.toolkits.graph;
-
 
 import java.util.*;
 
 import soot.*;
 
+public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLabelledDirectedGraph<N, L> {
 
+    /**
+     * HashMap based implementation of a MutableEdgeLabelledDirectedGraph.
+     */
+    private static class DGEdge<N> {
 
+        N from;
+        N to;
 
+        public DGEdge(N from, N to) {
+            this.from = from;
+            this.to = to;
+        }
 
+        public N from() {
+            return from;
+        }
 
-public class HashMutableEdgeLabelledDirectedGraph<N,L> implements MutableEdgeLabelledDirectedGraph<N,L>
-{
-	/**
-	 *   HashMap based implementation of a MutableEdgeLabelledDirectedGraph.
-	 */
-	private static class DGEdge<N>
-	{
-		N from;
-		N to;
-		
-		public DGEdge(N from, N to)
-		{
-			this.from = from;
-			this.to = to;
-		}
-		
-		public N from()
-		{
-			return from;
-		}
-		
-		public N to()
-		{
-			return to;
-		}
-		
-		public boolean equals(Object o)
-		{
-			if(o instanceof DGEdge)
-			{
-				DGEdge<?> other = (DGEdge<?>) o;
-				return from.equals(other.from) && to.equals(other.to);
-			}
-			return false;
-		}
-		
-		public int hashCode()
-		{
-			return Arrays.hashCode(new Object[]{from,to});
-		}
-	}
-	
-    private static <T> List<T> getCopy(Collection<? extends T> c) {
-        return Collections.unmodifiableList(new ArrayList<T>(c));    	
+        public N to() {
+            return to;
+        }
+
+        public boolean equals(Object o) {
+            if (o instanceof DGEdge) {
+                DGEdge<?> other = (DGEdge<?>) o;
+                return from.equals(other.from) && to.equals(other.to);
+            }
+            return false;
+        }
+
+        public int hashCode() {
+            return Arrays.hashCode(new Object[]{from, to});
+        }
     }
-    
-    protected Map<N,List<N>> nodeToPreds;
-    protected Map<N,List<N>> nodeToSuccs;
-    
-    protected Map<DGEdge<N>,List<L>> edgeToLabels;
-    protected Map<L,List<DGEdge<N>>> labelToEdges;
+
+    private static <T> List<T> getCopy(Collection<? extends T> c) {
+        return Collections.unmodifiableList(new ArrayList<T>(c));
+    }
+
+    protected Map<N, List<N>> nodeToPreds;
+    protected Map<N, List<N>> nodeToSuccs;
+
+    protected Map<DGEdge<N>, List<L>> edgeToLabels;
+    protected Map<L, List<DGEdge<N>>> labelToEdges;
 
     protected Set<N> heads;
     protected Set<N> tails;
 
-    public HashMutableEdgeLabelledDirectedGraph()
-    {
-        nodeToPreds = new HashMap<N,List<N>>();
-        nodeToSuccs = new HashMap<N,List<N>>();
-        edgeToLabels = new HashMap<DGEdge<N>,List<L>>();
-        labelToEdges = new HashMap<L,List<DGEdge<N>>>();
+    public HashMutableEdgeLabelledDirectedGraph() {
+        nodeToPreds = new HashMap<N, List<N>>();
+        nodeToSuccs = new HashMap<N, List<N>>();
+        edgeToLabels = new HashMap<DGEdge<N>, List<L>>();
+        labelToEdges = new HashMap<L, List<DGEdge<N>>>();
         heads = new HashSet<N>();
         tails = new HashSet<N>();
     }
 
-    /** Removes all nodes and edges. */
+    /**
+     * Removes all nodes and edges.
+     */
     public void clearAll() {
         nodeToPreds.clear();
         nodeToSuccs.clear();
@@ -113,7 +100,7 @@ public class HashMutableEdgeLabelledDirectedGraph<N,L> implements MutableEdgeLab
     }
 
     public HashMutableEdgeLabelledDirectedGraph<N, L> clone() {
-        HashMutableEdgeLabelledDirectedGraph<N,L> g = new HashMutableEdgeLabelledDirectedGraph<N,L>();
+        HashMutableEdgeLabelledDirectedGraph<N, L> g = new HashMutableEdgeLabelledDirectedGraph<N, L>();
         g.nodeToPreds.putAll(nodeToPreds);
         g.nodeToSuccs.putAll(nodeToSuccs);
         g.edgeToLabels.putAll(edgeToLabels);
@@ -125,285 +112,289 @@ public class HashMutableEdgeLabelledDirectedGraph<N,L> implements MutableEdgeLab
 
     /* Returns an unbacked list of heads for this graph. */
     @Override
-    public List<N> getHeads()
-    {
+    public List<N> getHeads() {
         return getCopy(heads);
     }
 
     /* Returns an unbacked list of tails for this graph. */
     @Override
-    public List<N> getTails()
-    {
+    public List<N> getTails() {
         return getCopy(tails);
     }
 
     @Override
-    public List<N> getPredsOf(N s)
-    {
+    public List<N> getPredsOf(N s) {
         List<N> preds = nodeToPreds.get(s);
-        if (preds != null)
+        if (preds != null) {
             return Collections.unmodifiableList(preds);
-       
-        throw new RuntimeException(s+"not in graph!");
+        }
+
+        throw new RuntimeException(s + "not in graph!");
     }
 
     @Override
-    public List<N> getSuccsOf(N s)
-    {
-       List<N> succs = nodeToSuccs.get(s);
-        if (succs != null)
-        	return Collections.unmodifiableList(succs);
-        
-        throw new RuntimeException(s+"not in graph!");
+    public List<N> getSuccsOf(N s) {
+        List<N> succs = nodeToSuccs.get(s);
+        if (succs != null) {
+            return Collections.unmodifiableList(succs);
+        }
+
+        throw new RuntimeException(s + "not in graph!");
     }
 
     @Override
-    public int size()
-    {
+    public int size() {
         return nodeToPreds.keySet().size();
     }
 
     @Override
-    public Iterator<N> iterator()
-    {
+    public Iterator<N> iterator() {
         return nodeToPreds.keySet().iterator();
     }
 
     @Override
-    public void addEdge(N from, N to, L label)
-    {
-        if (from == null || to == null)
-						throw new RuntimeException("edge from or to null");
-						
-		if (label == null)
-						throw new RuntimeException("edge with null label");
+    public void addEdge(N from, N to, L label) {
+        if (from == null || to == null) {
+            throw new RuntimeException("edge from or to null");
+        }
 
-        if (containsEdge(from, to, label))
+        if (label == null) {
+            throw new RuntimeException("edge with null label");
+        }
+
+        if (containsEdge(from, to, label)) {
             return;
+        }
 
         List<N> succsList = nodeToSuccs.get(from);
-        if (succsList == null)
+        if (succsList == null) {
             throw new RuntimeException(from + " not in graph!");
+        }
 
         List<N> predsList = nodeToPreds.get(to);
-        if (predsList == null)
+        if (predsList == null) {
             throw new RuntimeException(to + " not in graph!");
+        }
 
         heads.remove(to);
         tails.remove(from);
-		
-		if(!succsList.contains(to))
-	        succsList.add(to);
-	    if(!predsList.contains(from))
-	        predsList.add(from);
-	    
-	    DGEdge<N> edge = new DGEdge<N>(from, to);
-		if(!edgeToLabels.containsKey(edge))
-			edgeToLabels.put(edge, new ArrayList<L>());
-	    List<L> labels = edgeToLabels.get(edge);
-	    
-	    if(!labelToEdges.containsKey(label))
-	    	labelToEdges.put(label, new ArrayList<DGEdge<N>>());
-	    List<DGEdge<N>> edges = labelToEdges.get(label);
-		
-//		if(!labels.contains(label))
-			labels.add(label);
-//		if(!edges.contains(edge))
-			edges.add(edge);
-    }
 
-    @Override
-	public List<L> getLabelsForEdges(N from, N to)
-	{
-		DGEdge<N> edge = new DGEdge<N>(from, to);
-		return edgeToLabels.get(edge);
-	}
-	
-    @Override
-	public MutableDirectedGraph<N> getEdgesForLabel(L label)
-	{
-		List<DGEdge<N>> edges = labelToEdges.get(label);
-		MutableDirectedGraph<N> ret = new HashMutableDirectedGraph<N>();
-		if(edges == null)
-			return ret;
-		for(DGEdge<N> edge : edges)
-		{
-			if(!ret.containsNode(edge.from()))
-				ret.addNode(edge.from());
-			if(!ret.containsNode(edge.to()))
-				ret.addNode(edge.to());
-			ret.addEdge(edge.from(), edge.to());
-		}
-		return ret;
-	}
+        if (!succsList.contains(to)) {
+            succsList.add(to);
+        }
+        if (!predsList.contains(from)) {
+            predsList.add(from);
+        }
 
-	@Override
-    public void removeEdge(N from, N to, L label)
-    {
-        if (!containsEdge(from, to, label))
-            return;
-            
         DGEdge<N> edge = new DGEdge<N>(from, to);
+        if (!edgeToLabels.containsKey(edge)) {
+            edgeToLabels.put(edge, new ArrayList<L>());
+        }
         List<L> labels = edgeToLabels.get(edge);
-        if( labels == null )
-        	throw new RuntimeException("edge " + edge + " not in graph!");
-        
+
+        if (!labelToEdges.containsKey(label)) {
+            labelToEdges.put(label, new ArrayList<DGEdge<N>>());
+        }
         List<DGEdge<N>> edges = labelToEdges.get(label);
-        if( edges == null )
-        	throw new RuntimeException("label " + label + " not in graph!");
 
-		labels.remove(label);
-		edges.remove(edge);
-		
-		// if this edge has no more labels, then it's gone!
-		if(labels.isEmpty())
-		{
-			edgeToLabels.remove(edge);
-
-	        List<N> succsList = nodeToSuccs.get(from);
-	        if (succsList == null)
-	            throw new RuntimeException(from + " not in graph!");
-
-	        List<N> predsList = nodeToPreds.get(to);
-	        if (predsList == null)
-	            throw new RuntimeException(to + " not in graph!");
-			
-	        succsList.remove(to);
-	        predsList.remove(from);
-
-	        if (succsList.isEmpty())
-	            tails.add(from);
-
-	        if (predsList.isEmpty())
-	            heads.add(to);
-	    }
-	    
-	    // if this label has no more edges, then who cares?
-	    if(edges.isEmpty())
-	    	labelToEdges.remove(label);
+//		if(!labels.contains(label))
+        labels.add(label);
+//		if(!edges.contains(edge))
+        edges.add(edge);
     }
 
-	@Override
-    public void removeAllEdges(N from, N to)
-	{
-        if (!containsAnyEdge(from, to))
+    @Override
+    public List<L> getLabelsForEdges(N from, N to) {
+        DGEdge<N> edge = new DGEdge<N>(from, to);
+        return edgeToLabels.get(edge);
+    }
+
+    @Override
+    public MutableDirectedGraph<N> getEdgesForLabel(L label) {
+        List<DGEdge<N>> edges = labelToEdges.get(label);
+        MutableDirectedGraph<N> ret = new HashMutableDirectedGraph<N>();
+        if (edges == null) {
+            return ret;
+        }
+        for (DGEdge<N> edge : edges) {
+            if (!ret.containsNode(edge.from())) {
+                ret.addNode(edge.from());
+            }
+            if (!ret.containsNode(edge.to())) {
+                ret.addNode(edge.to());
+            }
+            ret.addEdge(edge.from(), edge.to());
+        }
+        return ret;
+    }
+
+    @Override
+    public void removeEdge(N from, N to, L label) {
+        if (!containsEdge(from, to, label)) {
             return;
-            
+        }
+
         DGEdge<N> edge = new DGEdge<N>(from, to);
         List<L> labels = edgeToLabels.get(edge);
-        if( labels == null )
-        	throw new RuntimeException("edge " + edge + " not in graph!");
-        
-        for(L label : labels)
-        {        
-	        removeEdge(from, to, label);
-	    }
-	}
+        if (labels == null) {
+            throw new RuntimeException("edge " + edge + " not in graph!");
+        }
 
-	@Override
-    public void removeAllEdges(L label)
-    {
-		if( !containsAnyEdge(label) )
-			return;
-		
-		List<DGEdge<N>> edges = labelToEdges.get(label);
-		if( edges == null )
-			throw new RuntimeException("label " + label + " not in graph!");
-			
-		for(DGEdge<N> edge : edges)
-		{
-			removeEdge(edge.from(), edge.to(), label);
-		}
-	}
+        List<DGEdge<N>> edges = labelToEdges.get(label);
+        if (edges == null) {
+            throw new RuntimeException("label " + label + " not in graph!");
+        }
 
-	@Override
-    public boolean containsEdge(N from, N to, L label)
-    {
-		DGEdge<N> edge = new DGEdge<N>(from, to);
-		if(edgeToLabels.get(edge) != null && edgeToLabels.get(edge).contains(label))
-			return true;
-		return false;
+        labels.remove(label);
+        edges.remove(edge);
+
+        // if this edge has no more labels, then it's gone!
+        if (labels.isEmpty()) {
+            edgeToLabels.remove(edge);
+
+            List<N> succsList = nodeToSuccs.get(from);
+            if (succsList == null) {
+                throw new RuntimeException(from + " not in graph!");
+            }
+
+            List<N> predsList = nodeToPreds.get(to);
+            if (predsList == null) {
+                throw new RuntimeException(to + " not in graph!");
+            }
+
+            succsList.remove(to);
+            predsList.remove(from);
+
+            if (succsList.isEmpty()) {
+                tails.add(from);
+            }
+
+            if (predsList.isEmpty()) {
+                heads.add(to);
+            }
+        }
+
+        // if this label has no more edges, then who cares?
+        if (edges.isEmpty()) {
+            labelToEdges.remove(label);
+        }
     }
 
-	@Override
-    public boolean containsAnyEdge(N from, N to)
-    {
-		DGEdge<N> edge = new DGEdge<N>(from, to);
-		if(edgeToLabels.get(edge) != null && edgeToLabels.get(edge).isEmpty())
-			return false;
-		return true;
+    @Override
+    public void removeAllEdges(N from, N to) {
+        if (!containsAnyEdge(from, to)) {
+            return;
+        }
+
+        DGEdge<N> edge = new DGEdge<N>(from, to);
+        List<L> labels = edgeToLabels.get(edge);
+        if (labels == null) {
+            throw new RuntimeException("edge " + edge + " not in graph!");
+        }
+
+        for (L label : labels) {
+            removeEdge(from, to, label);
+        }
     }
 
-	@Override
-    public boolean containsAnyEdge(L label)
-    {
-		if(labelToEdges.get(label) != null && labelToEdges.get(label).isEmpty())
-			return false;
-		return true;
+    @Override
+    public void removeAllEdges(L label) {
+        if (!containsAnyEdge(label)) {
+            return;
+        }
+
+        List<DGEdge<N>> edges = labelToEdges.get(label);
+        if (edges == null) {
+            throw new RuntimeException("label " + label + " not in graph!");
+        }
+
+        for (DGEdge<N> edge : edges) {
+            removeEdge(edge.from(), edge.to(), label);
+        }
     }
 
-	@Override
-    public boolean containsNode(N node)
-    {
+    @Override
+    public boolean containsEdge(N from, N to, L label) {
+        DGEdge<N> edge = new DGEdge<N>(from, to);
+        if (edgeToLabels.get(edge) != null && edgeToLabels.get(edge).contains(label)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsAnyEdge(N from, N to) {
+        DGEdge<N> edge = new DGEdge<N>(from, to);
+        if (edgeToLabels.get(edge) != null && edgeToLabels.get(edge).isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean containsAnyEdge(L label) {
+        if (labelToEdges.get(label) != null && labelToEdges.get(label).isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean containsNode(N node) {
         return nodeToPreds.keySet().contains(node);
     }
 
     @Override
-    public List<N> getNodes()
-    {
+    public List<N> getNodes() {
         return getCopy(nodeToPreds.keySet());
     }
 
     @Override
-    public void addNode(N node)
-    {
-		if (containsNode(node))
-			throw new RuntimeException("Node already in graph");
-		
-		nodeToSuccs.put(node, new ArrayList<N>());
-		nodeToPreds.put(node, new ArrayList<N>());
-		heads.add(node); 
-		tails.add(node);
+    public void addNode(N node) {
+        if (containsNode(node)) {
+            throw new RuntimeException("Node already in graph");
+        }
+
+        nodeToSuccs.put(node, new ArrayList<N>());
+        nodeToPreds.put(node, new ArrayList<N>());
+        heads.add(node);
+        tails.add(node);
     }
 
     @Override
-    public void removeNode(N node)
-    {
-    	for (N n : new ArrayList<N>(nodeToSuccs.get(node))) {
-    		removeAllEdges(node, n);
-    	}
-    	nodeToSuccs.remove(node);
-    	
-    	for (N n : new ArrayList<N>(nodeToPreds.get(node))) {
-    		removeAllEdges(n, node);
-    	}
-    	nodeToPreds.remove(node);
-    	
-        heads.remove(node); 
-        tails.remove(node);    	
+    public void removeNode(N node) {
+        for (N n : new ArrayList<N>(nodeToSuccs.get(node))) {
+            removeAllEdges(node, n);
+        }
+        nodeToSuccs.remove(node);
+
+        for (N n : new ArrayList<N>(nodeToPreds.get(node))) {
+            removeAllEdges(n, node);
+        }
+        nodeToPreds.remove(node);
+
+        heads.remove(node);
+        tails.remove(node);
     }
 
-    public void printGraph()
-    {
-    	for (N node : this ) {
-		    G.v().out.println("Node = "+node);
-		    
-		    G.v().out.println("Preds:");
-		    for (N pred : getPredsOf(node)) {
-		        DGEdge<N> edge = new DGEdge<N>(pred, node);
-		        List<L> labels = edgeToLabels.get(edge);
-				G.v().out.println("     " + pred + " [" + labels + "]");
-		    }
-		    
-		    G.v().out.println("Succs:");
-		    for (N succ : getSuccsOf(node)) {
-		        DGEdge<N> edge = new DGEdge<N>(node, succ);
-		        List<L> labels = edgeToLabels.get(edge);
-				G.v().out.println("     " + succ + " [" + labels + "]");
-		    }
-		}
+    public void printGraph() {
+        for (N node : this) {
+            G.v().out.println("Node = " + node);
+
+            G.v().out.println("Preds:");
+            for (N pred : getPredsOf(node)) {
+                DGEdge<N> edge = new DGEdge<N>(pred, node);
+                List<L> labels = edgeToLabels.get(edge);
+                G.v().out.println("     " + pred + " [" + labels + "]");
+            }
+
+            G.v().out.println("Succs:");
+            for (N succ : getSuccsOf(node)) {
+                DGEdge<N> edge = new DGEdge<N>(node, succ);
+                List<L> labels = edgeToLabels.get(edge);
+                G.v().out.println("     " + succ + " [" + labels + "]");
+            }
+        }
     }
 
 }
-
- 

--- a/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
@@ -27,13 +27,16 @@ package soot.toolkits.graph;
 
 import java.util.*;
 
-import soot.*;
+import soot.G;
 
+/**
+ * HashMap based implementation of a MutableEdgeLabelledDirectedGraph.
+ *
+ * @param <N>
+ * @param <L>
+ */
 public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLabelledDirectedGraph<N, L> {
 
-    /**
-     * HashMap based implementation of a MutableEdgeLabelledDirectedGraph.
-     */
     private static class DGEdge<N> {
 
         N from;
@@ -52,6 +55,7 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
             return to;
         }
 
+        @Override
         public boolean equals(Object o) {
             if (o instanceof DGEdge) {
                 DGEdge<?> other = (DGEdge<?>) o;
@@ -60,6 +64,7 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
             return false;
         }
 
+        @Override
         public int hashCode() {
             return Arrays.hashCode(new Object[]{from, to});
         }
@@ -99,6 +104,7 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
         tails.clear();
     }
 
+    @Override
     public HashMutableEdgeLabelledDirectedGraph<N, L> clone() {
         HashMutableEdgeLabelledDirectedGraph<N, L> g = new HashMutableEdgeLabelledDirectedGraph<N, L>();
         g.nodeToPreds.putAll(nodeToPreds);
@@ -197,9 +203,9 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
         }
         List<DGEdge<N>> edges = labelToEdges.get(label);
 
-//		if(!labels.contains(label))
+        //if(!labels.contains(label))
         labels.add(label);
-//		if(!edges.contains(edge))
+        //if(!edges.contains(edge))
         edges.add(edge);
     }
 
@@ -396,5 +402,4 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
             }
         }
     }
-
 }

--- a/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/HashMutableEdgeLabelledDirectedGraph.java
@@ -351,11 +351,6 @@ public class HashMutableEdgeLabelledDirectedGraph<N, L> implements MutableEdgeLa
     }
 
     @Override
-    public List<N> getNodes() {
-        return getCopy(nodeToPreds.keySet());
-    }
-
-    @Override
     public void addNode(N node) {
         if (containsNode(node)) {
             throw new RuntimeException("Node already in graph");

--- a/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
@@ -24,11 +24,14 @@
  */
 package soot.toolkits.graph;
 
-import java.util.*;
+import java.util.List;
 
 /**
  * Defines a DirectedGraph which is modifiable and associates a label object
  * with every edge. Provides an interface to add/delete nodes and edges.
+ *
+ * @param <N>
+ * @param <L>
  */
 public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N> {
 
@@ -47,6 +50,8 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
      *
      * @param from out node for the edges to remove.
      * @param to   in node for the edges to remove.
+     *
+     * @return
      */
     public List<L> getLabelsForEdges(N from, N to);
 
@@ -56,6 +61,8 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
      * graph.
      *
      * @param label label for the edge to remove.
+     *
+     * @return
      */
     public MutableDirectedGraph<N> getEdgesForLabel(L label);
 
@@ -87,6 +94,10 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
     public void removeAllEdges(L label);
 
     /**
+     * @param from
+     * @param to
+     * @param label
+     *
      * @return true if the graph contains an edge between the 2 nodes with the
      *         given label, otherwise return false.
      */
@@ -110,7 +121,8 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
     public boolean containsAnyEdge(L label);
 
     /**
-     * @return a list of the nodes that compose the graph. No ordering is implied.
+     * @return a list of the nodes that compose the graph. No ordering is
+     *         implied.
      */
     public List<N> getNodes();
 

--- a/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
@@ -24,8 +24,6 @@
  */
 package soot.toolkits.graph;
 
-import java.util.List;
-
 /**
  * Defines a DirectedGraph which is modifiable and associates a label object
  * with every edge. Provides an interface to add/delete nodes and edges.
@@ -33,7 +31,7 @@ import java.util.List;
  * @param <N>
  * @param <L>
  */
-public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N> {
+public interface MutableEdgeLabelledDirectedGraph<N, L> extends EdgeLabelledDirectedGraph<N, L> {
 
     /**
      * Adds an edge to the graph between 2 nodes. If the edge is already present
@@ -44,27 +42,6 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
      * @param label label for the edge.
      */
     public void addEdge(N from, N to, L label);
-
-    /**
-     * Returns a list of labels for which an edge exists between from and to
-     *
-     * @param from out node for the edges to remove.
-     * @param to   in node for the edges to remove.
-     *
-     * @return
-     */
-    public List<L> getLabelsForEdges(N from, N to);
-
-    /**
-     * Returns a MutableDirectedGraph consisting of all edges with the given
-     * label and their nodes. Nodes without edges are not included in the new
-     * graph.
-     *
-     * @param label label for the edge to remove.
-     *
-     * @return
-     */
-    public MutableDirectedGraph<N> getEdgesForLabel(L label);
 
     /**
      * Removes an edge between 2 nodes in the graph. If the edge is not present
@@ -94,39 +71,6 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
     public void removeAllEdges(L label);
 
     /**
-     * @param from
-     * @param to
-     * @param label
-     *
-     * @return true if the graph contains an edge between the 2 nodes with the
-     *         given label, otherwise return false.
-     */
-    public boolean containsEdge(N from, N to, L label);
-
-    /**
-     * @return true if the graph contains any edges between the 2 nodes,
-     *         otherwise return false.
-     *
-     * @param from out node for the edges.
-     * @param to   in node for the edges.
-     */
-    public boolean containsAnyEdge(N from, N to);
-
-    /**
-     * @return true if the graph contains any edges with the given label,
-     *         otherwise return false.
-     *
-     * @param label label for the edges.
-     */
-    public boolean containsAnyEdge(L label);
-
-    /**
-     * @return a list of the nodes that compose the graph. No ordering is
-     *         implied.
-     */
-    public List<N> getNodes();
-
-    /**
      * Adds a node to the graph. Initially the added node has no successors or
      * predecessors. ; as a consequence it is considered both a head and tail
      * for the graph.
@@ -145,11 +89,4 @@ public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N>
      * @param node the node to be removed.
      */
     public void removeNode(N node);
-
-    /**
-     * @param node node that we want to know if the graph constains.
-     *
-     * @return true if the graph contains the node. false otherwise.
-     */
-    public boolean containsNode(N node);
 }

--- a/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
+++ b/src/soot/toolkits/graph/MutableEdgeLabelledDirectedGraph.java
@@ -17,135 +17,127 @@
  * Boston, MA 02111-1307, USA.
  */
 
-/*
+ /*
  * Modified by the Sable Research Group and others 1997-1999.  
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
-
-
 package soot.toolkits.graph;
 
 import java.util.*;
 
-
-
 /**
- *   Defines a DirectedGraph which is modifiable and associates
- *   a label object with every edge. Provides an interface to
- *   add/delete nodes and edges.
+ * Defines a DirectedGraph which is modifiable and associates a label object
+ * with every edge. Provides an interface to add/delete nodes and edges.
  */
+public interface MutableEdgeLabelledDirectedGraph<N, L> extends DirectedGraph<N> {
 
-public interface MutableEdgeLabelledDirectedGraph<N,L> extends DirectedGraph<N>
-{
     /**
-     *  Adds an edge to the graph between 2 nodes.
-     *  If the edge is already present no change is made.
-     *  @param from   out node for the edge.
-     *  @param to     in node for the edge.
-     *  @param label  label for the edge.
+     * Adds an edge to the graph between 2 nodes. If the edge is already present
+     * no change is made.
+     *
+     * @param from  out node for the edge.
+     * @param to    in node for the edge.
+     * @param label label for the edge.
      */
     public void addEdge(N from, N to, L label);
 
-
     /**
-     *  Returns a list of labels for which an edge exists between from and to
-     *  @param from   out node for the edges to remove.
-     *  @param to     in node for the edges to remove.
+     * Returns a list of labels for which an edge exists between from and to
+     *
+     * @param from out node for the edges to remove.
+     * @param to   in node for the edges to remove.
      */
     public List<L> getLabelsForEdges(N from, N to);
 
-
     /**
-     *  Returns a MutableDirectedGraph consisting of
-     *  all edges with the given label and their nodes.
-     *  Nodes without edges are not included in the new graph.
-     *  @param label  label for the edge to remove.
+     * Returns a MutableDirectedGraph consisting of all edges with the given
+     * label and their nodes. Nodes without edges are not included in the new
+     * graph.
+     *
+     * @param label label for the edge to remove.
      */
-	public MutableDirectedGraph<N> getEdgesForLabel(L label);
-
+    public MutableDirectedGraph<N> getEdgesForLabel(L label);
 
     /**
-     *  Removes an edge between 2 nodes in the graph.
-     *  If the edge is not present no change is made.
-     *  @param from   out node for the edges to remove.
-     *  @param to     in node for the edges to remove.
-     *  @param label  label for the edge to remove.
+     * Removes an edge between 2 nodes in the graph. If the edge is not present
+     * no change is made.
+     *
+     * @param from  out node for the edges to remove.
+     * @param to    in node for the edges to remove.
+     * @param label label for the edge to remove.
      */
     public void removeEdge(N from, N to, L label);
-    
-    
+
     /**
-     *  Removes all edges between 2 nodes in the graph.
-     *  If no edges are present, no change is made.
-     *  @param from  out node for the edges to remove.
-     *  @param to    in node for the edges to remove.
+     * Removes all edges between 2 nodes in the graph. If no edges are present,
+     * no change is made.
+     *
+     * @param from out node for the edges to remove.
+     * @param to   in node for the edges to remove.
      */
     public void removeAllEdges(N from, N to);
-    
-    
+
     /**
-     *  Removes all edges with the given label in the graph.
-     *  If no edges are present, no change is made.
-     *  @param label  label for the edge to remove.
+     * Removes all edges with the given label in the graph. If no edges are
+     * present, no change is made.
+     *
+     * @param label label for the edge to remove.
      */
     public void removeAllEdges(L label);
 
-
-    /** @return true if the graph contains an edge between 
-     *  the 2 nodes with the given label, otherwise return false.
-     */ 
+    /**
+     * @return true if the graph contains an edge between the 2 nodes with the
+     *         given label, otherwise return false.
+     */
     public boolean containsEdge(N from, N to, L label);
-    
-    
-    /** @return true if the graph contains any edges between 
-     *  the 2 nodes, otherwise return false.
-     *  @param from  out node for the edges.
-     *  @param to    in node for the edges.
-     */ 
-    public boolean containsAnyEdge(N from, N to);
-    
-    
-    /** @return true if the graph contains any edges
-     *  with the given label, otherwise return false.
-     *  @param label  label for the edges.
-     */ 
-    public boolean containsAnyEdge(L label);
-
-
-    /** @return a list of the nodes that compose the graph. No ordering is implied.*/
-    public List<N> getNodes();
-
 
     /**
-     *  Adds a node to the graph. Initially the added node has no successors or predecessors.
-     *  ; as a consequence it is considered both a head and tail for the graph.
-     *  @param node a node to add  to the graph.
-     *  @see #getHeads
-     *  @see #getTails
+     * @return true if the graph contains any edges between the 2 nodes,
+     *         otherwise return false.
+     *
+     * @param from out node for the edges.
+     * @param to   in node for the edges.
+     */
+    public boolean containsAnyEdge(N from, N to);
+
+    /**
+     * @return true if the graph contains any edges with the given label,
+     *         otherwise return false.
+     *
+     * @param label label for the edges.
+     */
+    public boolean containsAnyEdge(L label);
+
+    /**
+     * @return a list of the nodes that compose the graph. No ordering is implied.
+     */
+    public List<N> getNodes();
+
+    /**
+     * Adds a node to the graph. Initially the added node has no successors or
+     * predecessors. ; as a consequence it is considered both a head and tail
+     * for the graph.
+     *
+     * @param node a node to add to the graph.
+     *
+     * @see #getHeads
+     * @see #getTails
      */
     public void addNode(N node);
 
-
     /**
-     *  Removes a node from the graph. If the node is not
-     *  found in the graph, no change is made.
-     *  @param node the node to be removed.
+     * Removes a node from the graph. If the node is not found in the graph, no
+     * change is made.
+     *
+     * @param node the node to be removed.
      */
     public void removeNode(N node);
 
-
     /**
-     *   @param node node that we want to know if the graph constains.
-     *   @return  true if the graph contains the node.
-     *            false otherwise.
+     * @param node node that we want to know if the graph constains.
+     *
+     * @return true if the graph contains the node. false otherwise.
      */
     public boolean containsNode(N node);
 }
-
- 
-
-
-
-
-


### PR DESCRIPTION
1. Extract an EdgeLabelledDirectedGraph interface from the MutableEdgeLabelledDirectedGraph interface to allow non-mutable graphs (mirroring the hierarchy of the graphs without edge labels).
2. Fixed a couple of bugs in the implementation of HashMutableEdgeLabelledDirectedGraph that caused crashes or incorrect results.