### PR TITLE
Fix lgtm.com alert: cannot test value equality of Integers using '==' operator

### DIFF
--- a/src/soot/jimple/spark/solver/PropCycle.java
+++ b/src/soot/jimple/spark/solver/PropCycle.java
@@ -103,8 +103,12 @@ public final class PropCycle extends Propagator {
 			return false;
 		}
 
-		if (currentIteration == varNodeToIteration.get(v))
+		final Integer vnIteration = varNodeToIteration.get(v);
+		if (currentIteration != null && vnIteration != null && 
+				currentIteration.intValue() == vnIteration.intValue()){
 			return false;
+		}
+		
 		varNodeToIteration.put(v, currentIteration);
 
 		path.add(v);


### PR DESCRIPTION
This PR addresses an alert reported by lgtm.com: value equality of boxed Integers cannot be tested using the '==' operator.

There are about 130 other alerts (https://lgtm.com/projects/g/Sable/soot/alerts/) - most of which really look like they're worth fixing. However, they need someone with more knowledge of the Soot codebase to decide what's the best way to fix. 

If you like you can enable PR check integration: lgtm will automatically review your changes and flag up any new alerts that are introduced. Other projects are actively using it - here's an example from NASA's OpenMBEE project fixing a potential resource leak before merging the PR: https://github.com/Open-MBEE/mdk/pull/105

Details: https://lgtm.com/projects/g/Sable/soot/snapshot/dist-1791462132-1492508422322/files/src/soot/jimple/spark/solver/PropCycle.java#V106

Hope this is the right way to contribute - let me know if there's anything else I can do!