### PR TITLE
new option: ignore-dex-loading-errors

### DIFF
--- a/doc/soot_options.htm
+++ b/doc/soot_options.htm
@@ -684,6 +684,11 @@ packages in the Java runtime.</p>
 </td><td colspan="2">Process all DEX files found in APK.</td>
 </tr>
 <tr>
+<td><tt>-ignore-dex-loading-errors </tt>
+<br>
+</td><td colspan="2">Ignore errors when loading DEX files found in APK/ZIP</td>
+</tr>
+<tr>
 <td><tt>-process-path <var>dir</var></tt>
 <br>
 <tt>-process-dir <var>dir</var></tt>

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -2140,6 +2140,16 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 			getConfig().put(getInput_Optionsprocess_multiple_dex_widget().getAlias(), new Boolean(boolRes));
 		}
 		
+		boolRes = getInput_Optionsignore_dex_loading_errors_widget().getButton().getSelection();
+		
+		
+		defBoolRes = false;
+		
+
+		if (boolRes != defBoolRes) {
+			getConfig().put(getInput_Optionsignore_dex_loading_errors_widget().getAlias(), new Boolean(boolRes));
+		}
+		
 		boolRes = getInput_Optionsoaat_widget().getButton().getSelection();
 		
 		
@@ -6959,6 +6969,16 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 		return Input_Optionsprocess_multiple_dex_widget;
 	}	
 	
+	private BooleanOptionWidget Input_Optionsignore_dex_loading_errors_widget;
+	
+	private void setInput_Optionsignore_dex_loading_errors_widget(BooleanOptionWidget widget) {
+		Input_Optionsignore_dex_loading_errors_widget = widget;
+	}
+	
+	public BooleanOptionWidget getInput_Optionsignore_dex_loading_errors_widget() {
+		return Input_Optionsignore_dex_loading_errors_widget;
+	}	
+	
 	private BooleanOptionWidget Input_Optionsoaat_widget;
 	
 	private void setInput_Optionsoaat_widget(BooleanOptionWidget widget) {
@@ -10938,6 +10958,22 @@ Composite dbdb_force_recompileChild = dbdb_force_recompileCreate(getPageContaine
 		}
 
 		setInput_Optionsprocess_multiple_dex_widget(new BooleanOptionWidget(editGroupInput_Options, SWT.NONE, new OptionData("Process all DEX files in APK", "", "","process-multiple-dex", "\nAndroid APKs can have more than one default classes.dex. By \ndefault Soot loads only classes from the default one. This \noption enables loading of all DEX files from an APK. ", defaultBool)));
+		
+		
+		
+		defKey = ""+" "+""+" "+"ignore-dex-loading-errors";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultBool = getBoolDef(defKey);	
+		}
+		else {
+			
+			defaultBool = false;
+			
+		}
+
+		setInput_Optionsignore_dex_loading_errors_widget(new BooleanOptionWidget(editGroupInput_Options, SWT.NONE, new OptionData("Ignore DEX loading errors", "", "","ignore-dex-loading-errors", "\nAndroid APKs can have more than one default classes.dex. If the \noption process-multiple-dex is set Soot tries to load all of \nthem, however sometimes files with the file extension .dex can \nnot be loaded for different reasons. In such a case loading the \nAPK file will completely fail if the option \nignore-dex-loading-errors is not set to true. If it is set only \nthe DEX file that can not be loaded will be ignored. ", defaultBool)));
 		
 		
 		

--- a/generated/options/soot/AntTask.java
+++ b/generated/options/soot/AntTask.java
@@ -201,6 +201,10 @@ public class AntTask extends MatchingTask {
             if(arg) addArg("-process-multiple-dex");
         }
   
+        public void setignore_dex_loading_errors(boolean arg) {
+            if(arg) addArg("-ignore-dex-loading-errors");
+        }
+  
         public void setprocess_dir(Path arg) {
             if(process_dir == null )
                 process_dir = new Path(getProject());

--- a/generated/options/soot/options/Options.java
+++ b/generated/options/soot/options/Options.java
@@ -258,6 +258,11 @@ public class Options extends OptionsBase {
             )
                 process_multiple_dex = true;
     	
+            else if( false 
+            || option.equals( "ignore-dex-loading-errors" )
+            )
+                ignore_dex_loading_errors = true;
+    	
             else if( false
             || option.equals( "process-path" )
             || option.equals( "process-dir" )
@@ -1478,6 +1483,10 @@ public class Options extends OptionsBase {
     private boolean process_multiple_dex = false;
     public void set_process_multiple_dex( boolean setting ) { process_multiple_dex = setting; }
   
+    public boolean ignore_dex_loading_errors() { return ignore_dex_loading_errors; }
+    private boolean ignore_dex_loading_errors = false;
+    public void set_ignore_dex_loading_errors( boolean setting ) { ignore_dex_loading_errors = setting; }
+  
     public List<String> process_dir() { 
         if( process_dir == null )
             return java.util.Collections.emptyList();
@@ -1741,6 +1750,7 @@ public class Options extends OptionsBase {
 +padOpt(" -pp -prepend-classpath", "Prepend the given soot classpath to the default classpath." )
 +padOpt(" -ice -ignore-classpath-errors", "Ignores invalid entries on the Soot classpath." )
 +padOpt(" -process-multiple-dex", "Process all DEX files found in APK." )
++padOpt(" -ignore-dex-loading-errors", "Ignore errors when loading DEX files found in APK/ZIP" )
 +padOpt(" -process-path DIR -process-dir DIR", "Process all classes found in DIR" )
 +padOpt(" -oaat", "From the process-dir, processes one class at a time." )
 +padOpt(" -android-jars PATH", "Use PATH as the path for finding the android.jar file" )

--- a/src/soot/DexClassProvider.java
+++ b/src/soot/DexClassProvider.java
@@ -35,11 +35,10 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.jf.dexlib2.DexFileFactory;
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
 import org.jf.dexlib2.iface.ClassDef;
+import org.jf.dexlib2.iface.DexFile;
 
+import soot.dexpler.DexlibWrapper;
 import soot.dexpler.Util;
 import soot.options.Options;
 
@@ -198,9 +197,10 @@ public class DexClassProvider implements ClassProvider {
 	 *            file to dex/apk file. Can be the path of a zip file.
 	 *
 	 * @return set of class names
+	 * @throws IOException
 	 */
 	public static Set<String> classesOfDex(File file) throws IOException {
-		return classesOfDex(file, null);
+		return classesOfDex(DexlibWrapper.loadDex(file, null));
 	}
 	
 	/**
@@ -212,14 +212,23 @@ public class DexClassProvider implements ClassProvider {
 	 * 				a name of a given dex file
 	 *
 	 * @return set of class names
+	 * @throws IOException
 	 */
 	public static Set<String> classesOfDex(File file, String dexName) throws IOException {
-		Set<String> classes = new HashSet<String>();
-		int api = Scene.v().getAndroidAPIVersion();
-		DexBackedDexFile d = dexName != null  
-				? DexFileFactory.loadDexEntry(file, dexName, true, Opcodes.forApi(api))  
-				: DexFileFactory.loadDexFile(file, Opcodes.forApi(api));  
-		for (ClassDef c : d.getClasses()) {
+			return classesOfDex(DexlibWrapper.loadDex(file, null));
+	}
+
+	/**
+	 * Return names of classes in the given {@link DexFile}.
+	 * 
+	 * @param dexFile
+	 * @return set of class names
+	 * @throws IOException
+	 */
+	public static Set<String> classesOfDex(DexFile dexFile) throws IOException {
+		Set<? extends ClassDef> dexClasses = dexFile.getClasses();
+		Set<String> classes = new HashSet<String>(dexClasses.size());
+		for (ClassDef c : dexClasses) {
 			String name = Util.dottedClassName(c.getType());
 			classes.add(name);
 		}

--- a/src/soot/options/soot_options.xml
+++ b/src/soot/options/soot_options.xml
@@ -441,6 +441,19 @@ enables loading of all DEX files from an APK.
 </p>
 </long_desc>
 		</boolopt>
+		<boolopt>
+			<name>Ignore DEX loading errors</name>
+			<alias>ignore-dex-loading-errors</alias>
+			<short_desc>Ignore errors when loading DEX files found in APK/ZIP</short_desc>
+			<long_desc>
+<p>
+Android APKs can have more than one default classes.dex. If the option process-multiple-dex is set Soot tries to load 
+all of them, however sometimes files with the file extension .dex can not be loaded for different reasons.
+In such a case loading the APK file will completely fail if the option ignore-dex-loading-errors is not set to true.
+If it is set only the DEX file that can not be loaded will be ignored. 
+</p>
+</long_desc>
+		</boolopt>
 		<listopt>
 			<name>Process Directories</name>
 			<alias>process-path</alias>


### PR DESCRIPTION
If Soot fails to load one dex file from an APK file that contains multiple dex files the overall loading process fails. 

If ignore-dex-loading-errors is set to true those dex files that can not be loaded are now ignored so that at least the classes from the other dex files can be used via Soot.