### PR TITLE
Handle negative values of (-0x1) for boolean types.

### DIFF
--- a/src/soot/dexpler/instructions/FillArrayDataInstruction.java
+++ b/src/soot/dexpler/instructions/FillArrayDataInstruction.java
@@ -168,8 +168,8 @@ public class FillArrayDataInstruction extends PseudoInstruction {
     if (elementType instanceof BooleanType) {
       value = IntConstant.v(element.intValue());
       IntConstant ic = (IntConstant)value;
-      if (!(ic.value == 0 || ic.value == 1)) {
-        throw new RuntimeException("ERROR: Invalid value for boolean: "+ value);
+      if (ic.value != 0) {
+        value = IntConstant.v(1);
       }
     } else if(elementType instanceof ByteType) {
       value = IntConstant.v(element.byteValue());


### PR DESCRIPTION
Although the dex documentation [1] defines only 0x0 and 0x1 as valid values, bionic/ART handles negative values like -0x1 just fine and some obfuscators seem to use them. Instead of throwing RuntimeException, dexpler should handle booleans according to C99 standard.

[App for testing](https://github.com/Sable/soot/files/1082145/regression_negative_booleans.apk.zip)

[1] https://source.android.com/devices/tech/dalvik/dex-format