### PR TITLE
Fix typing of long bit shift expressions in Grimp

### DIFF
--- a/src/soot/grimp/internal/GShlExpr.java
+++ b/src/soot/grimp/internal/GShlExpr.java
@@ -42,6 +42,23 @@ public class GShlExpr extends AbstractGrimpIntLongBinopExpr implements ShlExpr
     public int getPrecedence() { return 650; }
     public void apply(Switch sw) { ((ExprSwitch) sw).caseShlExpr(this); }
 
+    @Override
+    public Type getType()
+    {
+        Value op1 = op1Box.getValue();
+        Value op2 = op2Box.getValue();
+
+        if (!isIntLikeType(op2.getType()))
+            return UnknownType.v();
+
+        if (isIntLikeType(op1.getType()))
+            return IntType.v();
+        if (op1.getType().equals(LongType.v()))
+            return LongType.v();
+
+        return UnknownType.v();
+    }
+
     public Object clone() 
     {
         return new GShlExpr(Grimp.cloneIfNecessary(getOp1()), Grimp.cloneIfNecessary(getOp2()));

--- a/src/soot/grimp/internal/GShrExpr.java
+++ b/src/soot/grimp/internal/GShrExpr.java
@@ -41,7 +41,24 @@ public class GShrExpr extends AbstractGrimpIntLongBinopExpr implements ShrExpr
     public String getSymbol() { return " >> "; }
     public int getPrecedence() { return 650; }
     public void apply(Switch sw) { ((ExprSwitch) sw).caseShrExpr(this); }
-     
+
+    @Override
+    public Type getType()
+    {
+        Value op1 = op1Box.getValue();
+        Value op2 = op2Box.getValue();
+
+        if (!isIntLikeType(op2.getType()))
+            return UnknownType.v();
+
+        if (isIntLikeType(op1.getType()))
+            return IntType.v();
+        if (op1.getType().equals(LongType.v()))
+            return LongType.v();
+
+        return UnknownType.v();
+    }
+
     public Object clone() 
     {
         return new GShrExpr(Grimp.cloneIfNecessary(getOp1()), Grimp.cloneIfNecessary(getOp2()));

--- a/src/soot/grimp/internal/GUshrExpr.java
+++ b/src/soot/grimp/internal/GUshrExpr.java
@@ -43,6 +43,23 @@ public class GUshrExpr extends AbstractGrimpIntLongBinopExpr
     public int getPrecedence() { return 650; }
     public void apply(Switch sw) { ((ExprSwitch) sw).caseUshrExpr(this); }
 
+    @Override
+    public Type getType()
+    {
+        Value op1 = op1Box.getValue();
+        Value op2 = op2Box.getValue();
+
+        if (!isIntLikeType(op2.getType()))
+            return UnknownType.v();
+
+        if (isIntLikeType(op1.getType()))
+            return IntType.v();
+        if (op1.getType().equals(LongType.v()))
+            return LongType.v();
+
+        return UnknownType.v();
+    }
+
     public Object clone() 
     {
         return new GUshrExpr(Grimp.cloneIfNecessary(getOp1()), Grimp.cloneIfNecessary(getOp2()));


### PR DESCRIPTION
The type of a bit shift expression only depends on its left operand -
the type of the right operand is always int. However, unlike the Jimple
variants (JShlExpr, JShrExpr and JUshrExpr), the Grimp shift expression
classes (GShlExpr, GShrExpr and GUshrExpr) do not override getType() and
use the default AbstractIntLongBinopExpr implementation, which sets the
type to long only if both operands are longs.

This causes a RuntimeException when converting long shifts from Java
bytecode to Grimp and then back to Java bytecode again, as the Grimp to
Java bytecode conversion code does not expect getType() to return
UnknownType.

This commit fixes the problem by copying the getType() method from the
Jimple shift expression classes to the equivalent Grimp classes.