### PR TITLE
Fix the line numbers

### DIFF
--- a/src/soot/dexpler/DexBody.java
+++ b/src/soot/dexpler/DexBody.java
@@ -522,10 +522,22 @@ public class DexBody {
 		for (DeferableInstruction instruction : deferredInstructions) {
 			instruction.deferredJimplify(this);
 		}
-
+		
 		if (tries != null)
 			addTraps();
 
+		int prevLn = -1;
+		for (DexlibAbstractInstruction instruction : instructions) {
+			Unit unit = instruction.getUnit();
+			int lineNumber = unit.getJavaSourceStartLineNumber();
+			if (Options.v().keep_line_number() && lineNumber < 0) {
+				unit.addTag(new LineNumberTag(prevLn));
+				unit.addTag(new SourceLineNumberTag(prevLn));
+			} else {
+				prevLn = lineNumber;
+			}
+		}
+		
 		// At this point Jimple code is generated
 		// Cleaning...
 

--- a/src/soot/dexpler/DexReturnInliner.java
+++ b/src/soot/dexpler/DexReturnInliner.java
@@ -92,6 +92,8 @@ public class DexReturnInliner extends DexTransformer {
 						
 						while (!u.getBoxesPointingToThis().isEmpty())
 							u.getBoxesPointingToThis().get(0).setUnit(stmt);
+						//the cloned return stmt gets the tags of u
+						stmt.addAllTagsOf(u);
 						body.getUnits().swapWith(u, stmt);
 						
 						mayBeMore = true;
@@ -111,7 +113,15 @@ public class DexReturnInliner extends DexTransformer {
 							ifstmt.setTarget(newTarget);
 						}
 					}
+				}else if(isInstanceofReturn(u))
+				{
+					//the original return stmt gets the tags of its predecessor
+					if (last != null) {
+						u.removeAllTags();
+						u.addAllTagsOf(last);
+					}
 				}
+				last = (Stmt) u;
 			}
 		} while (mayBeMore);
     }


### PR DESCRIPTION
Changes in DexBody.java forces stmts without line number get the last valid line number.
Changes in DexReturnInliner.java  fix the wrong line number at return stmts.