### PR TITLE
Fix for potential class cast exceptions

### DIFF
--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -633,8 +633,12 @@ public class PackManager {
 		}
 
 		// If something went wrong, we tell the world
-		if (executor.getException() != null)
-			throw (RuntimeException) executor.getException();
+		if (executor.getException() != null) {
+			if (executor.getException() instanceof RuntimeException)
+				throw (RuntimeException) executor.getException();
+			else
+				throw new RuntimeException(executor.getException());
+		}
 	}
 
 	private void handleInnerClasses() {
@@ -1225,10 +1229,14 @@ public class PackManager {
 			// Something went horribly wrong
 			throw new RuntimeException("Could not wait for loader threads to " + "finish: " + e.getMessage(), e);
 		}
-
+	
 		// If something went wrong, we tell the world
-		if (executor.getException() != null)
-			throw (RuntimeException) executor.getException();
+		if (executor.getException() != null) {
+			if (executor.getException() instanceof RuntimeException)
+				throw (RuntimeException) executor.getException();
+			else
+				throw new RuntimeException(executor.getException());
+		}
 	}
 
 }


### PR DESCRIPTION
I encountered a class cast exception converting Jimple to Class files and tracked it down to line 637. It seems there were 2/3 locations where instance of RuntimeException was not checked before the cast occurs. This patch adds the check to the remaining 2 locations in this class.