### PR TITLE
Added java.lang.Exception to basic classes

### DIFF
--- a/src/soot/Scene.java
+++ b/src/soot/Scene.java
@@ -1437,6 +1437,7 @@ public class Scene // extends AbstractHost
 		addBasicClass("java.lang.Error");
 		addBasicClass("java.lang.AssertionError", SootClass.SIGNATURES);
 		addBasicClass("java.lang.Throwable", SootClass.SIGNATURES);
+		addBasicClass("java.lang.Exception", SootClass.SIGNATURES);
 		addBasicClass("java.lang.NoClassDefFoundError", SootClass.SIGNATURES);
 		addBasicClass("java.lang.ExceptionInInitializerError");
 		addBasicClass("java.lang.RuntimeException");


### PR DESCRIPTION
In the set of basic classes the class java.lang.Exception is missing.
This leads to the fact that the resolution `superClassPath` of a `java.lang.RuntimeException` stops at Exception, and thus `java.lang.Object` is not contained in the hierachy in method `BytecodeHierarchy.public static RefType lcsc(RefType a, RefType b, RefType anchor)`.