### PR TITLE
Memory usage reduction

### DIFF
--- a/src/soot/SootClass.java
+++ b/src/soot/SootClass.java
@@ -95,8 +95,6 @@ public class SootClass extends AbstractHost implements Numberable {
 		if (Options.v().debug_resolver())
 			G.v().out.println("created " + name + " with modifiers " + modifiers);
 		setResolvingLevel(BODIES);
-
-		Scene.v().getClassNumberer().add(this);
 	}
 
 	/**
@@ -199,6 +197,8 @@ public class SootClass extends AbstractHost implements Numberable {
 	/** Tells this class if it is being managed by a Scene. */
 	public void setInScene(boolean isInScene) {
 		this.isInScene = isInScene;
+
+		Scene.v().getClassNumberer().add(this);
 	}
 
 	/**

--- a/src/soot/SootField.java
+++ b/src/soot/SootField.java
@@ -49,8 +49,6 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 		this.name = name;
 		this.type = type;
 		this.modifiers = modifiers;
-		if (type instanceof RefLikeType)
-			Scene.v().getFieldNumberer().add(this);
 	}
 
 	/** Constructs a Soot field with the given name, type and no modifiers. */
@@ -58,8 +56,6 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 		this.name = name;
 		this.type = type;
 		this.modifiers = 0;
-		if (type instanceof RefLikeType)
-			Scene.v().getFieldNumberer().add(this);
 	}
 
 	public int equivHashCode() {
@@ -183,7 +179,7 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 		String qualifiers = Modifier.toString(modifiers) + " " + type.toString();
 		qualifiers = qualifiers.trim();
 
-		if (qualifiers.equals(""))
+		if (qualifiers.isEmpty())
 			return Scene.v().quotedNameOf(name);
 		else
 			return qualifiers + " " + Scene.v().quotedNameOf(name) + "";
@@ -214,5 +210,7 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 
 	public void setDeclaringClass(SootClass sc) {
 		this.declaringClass = sc;
+		if (type instanceof RefLikeType)
+			Scene.v().getFieldNumberer().add(this);
 	}
 }

--- a/src/soot/SootMethod.java
+++ b/src/soot/SootMethod.java
@@ -186,7 +186,6 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
 			 */
 		}
 		final Scene scene = Scene.v();
-		scene.getMethodNumberer().add(this);
 		subsignature = scene.getSubSigNumberer().findOrAdd(getSubSignature());
 
 	}
@@ -211,6 +210,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
 			declaringClass = declClass;
 			// setDeclared(true);
 		}
+		Scene.v().getMethodNumberer().add(this);
 	}
 
 	/** Returns the class which declares the current <code>SootMethod</code>. */

--- a/src/soot/toDex/TemporaryRegisterLocal.java
+++ b/src/soot/toDex/TemporaryRegisterLocal.java
@@ -1,0 +1,84 @@
+package soot.toDex;
+
+import java.util.Collections;
+import java.util.List;
+
+import soot.Local;
+import soot.Type;
+import soot.UnitPrinter;
+import soot.ValueBox;
+import soot.jimple.JimpleValueSwitch;
+import soot.util.Switch;
+
+public class TemporaryRegisterLocal implements Local {
+	private static final long serialVersionUID = 1L;
+	private Type type;
+
+	public TemporaryRegisterLocal(Type regType) {
+		setType(regType);
+	}
+	
+	public Local clone() {
+		throw new RuntimeException("Not implemented");
+	}
+
+	@Override
+	public final List<ValueBox> getUseBoxes() {
+		return Collections.emptyList();
+	}
+
+
+	@Override
+	public Type getType() {
+		return type;
+	}
+
+	@Override
+	public void toString(UnitPrinter up) {
+		throw new RuntimeException("Not implemented.");
+	}
+
+	@Override
+	public void apply(Switch sw) {
+		((JimpleValueSwitch) sw).caseLocal(this);
+	}
+
+	@Override
+	public boolean equivTo(Object o) {
+		return this.equals(o);
+	}
+
+	@Override
+	public int equivHashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
+
+	@Override
+	public void setNumber(int number) {
+		throw new RuntimeException("Not implemented.");
+	}
+
+	@Override
+	public int getNumber() {
+		throw new RuntimeException("Not implemented.");
+	}
+
+	@Override
+	public String getName() {
+		throw new RuntimeException("Not implemented.");
+	}
+
+	@Override
+	public void setName(String name) {
+		throw new RuntimeException("Not implemented.");
+	}
+
+	@Override
+	public void setType(Type t) {
+		this.type = t;
+	}
+
+}


### PR DESCRIPTION
Do not number all fields, methods and classes directly.
Reduced DexPrinter's RegisterAllocator memory usage.