### PR TITLE
MethodHandle constants and invocation

### DIFF
--- a/src/soot/SootMethodRefImpl.java
+++ b/src/soot/SootMethodRefImpl.java
@@ -164,10 +164,6 @@ class SootMethodRefImpl implements SootMethodRef {
 
 	private SootMethod tryResolve(StringBuffer trace) {
 
-		if(isSignaturePolymorphic()) {
-			return new SootMethod(name(), parameterTypes(), returnType(), Modifier.PUBLIC);
-		}
-
 		if (declaringClass.getName().equals("java.dyn.InvokeDynamic")) {
 			throw new IllegalStateException("Cannot resolve invokedynamic method references at compile time!");
 		}
@@ -178,6 +174,13 @@ class SootMethodRefImpl implements SootMethodRef {
 			SootMethod sm = cl.getMethodUnsafe(getSubSignature());
 			if (sm != null)
 				return checkStatic(sm);
+
+			if (isSignaturePolymorphic()) {
+				SootMethod dummyMethod = new SootMethod(name(), parameterTypes(), returnType(), Modifier.PUBLIC);
+				cl.addMethod(dummyMethod);
+				return dummyMethod;
+			}
+
 			if (Scene.v().allowsPhantomRefs() && (cl.isPhantom() || Options.v().ignore_resolution_errors())) {
 				SootMethod m = new SootMethod(name, parameterTypes, returnType, isStatic() ? Modifier.STATIC : 0);
 				m.setPhantom(true);

--- a/src/soot/SootMethodRefImpl.java
+++ b/src/soot/SootMethodRefImpl.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import fj.P;
 import soot.javaToJimple.LocalGenerator;
 import soot.jimple.AssignStmt;
 import soot.jimple.InvokeStmt;
@@ -141,6 +142,16 @@ class SootMethodRefImpl implements SootMethodRef {
 		return tryResolve(null);
 	}
 
+	public boolean isSignaturePolymorphic() {
+		if(!isStatic() && declaringClass.getName().equals("java.lang.invoke.MethodHandle")) {
+			if(name().equals("invoke") || name.equals("invokeExact")) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private SootMethod checkStatic(SootMethod ret) {
 		if (ret.isStatic() != isStatic()) {
 			if (Options.v().wrong_staticness() != Options.wrong_staticness_ignore
@@ -152,6 +163,11 @@ class SootMethodRefImpl implements SootMethodRef {
 	}
 
 	private SootMethod tryResolve(StringBuffer trace) {
+
+		if(isSignaturePolymorphic()) {
+			return new SootMethod(name(), parameterTypes(), returnType(), Modifier.PUBLIC);
+		}
+
 		if (declaringClass.getName().equals("java.dyn.InvokeDynamic")) {
 			throw new IllegalStateException("Cannot resolve invokedynamic method references at compile time!");
 		}

--- a/src/soot/baf/BafASMBackend.java
+++ b/src/soot/baf/BafASMBackend.java
@@ -23,6 +23,7 @@ import soot.CharType;
 import soot.DoubleType;
 import soot.FloatType;
 import soot.IntType;
+import soot.JastAddJ.Opt;
 import soot.Local;
 import soot.LongType;
 import soot.NullType;
@@ -39,6 +40,7 @@ import soot.TypeSwitch;
 import soot.Unit;
 import soot.UnitBox;
 import soot.Value;
+import soot.baf.internal.BPushInst;
 import soot.baf.internal.BafLocal;
 import soot.jimple.CaughtExceptionRef;
 import soot.jimple.ClassConstant;
@@ -118,6 +120,11 @@ public class BafASMBackend extends AbstractASMBackend {
 		}
 
 		for (Unit u : body.getUnits()) {
+			if (u instanceof PushInst) {
+				if(((PushInst) u).getConstant().getType().getEscapedName().equals("java.lang.invoke.MethodHandle")) {
+					return Options.java_version_1_7;
+				}
+			}
 			if (u instanceof DynamicInvokeInst) {
 				return Options.java_version_1_7;
 			}
@@ -441,8 +448,8 @@ public class BafASMBackend extends AbstractASMBackend {
 					} else {
 						tag = Opcodes.H_INVOKEVIRTUAL;
 					}
-					Handle handle = new Handle(tag, ref.declaringClass().getName(), ref.name(), ref.getSignature(),
-							ref.declaringClass().isInnerClass());
+					Handle handle = new Handle(tag, slashify(ref.declaringClass().getName()), ref.name(), toTypeDesc(ref),
+							ref.declaringClass().isInterface());
 
 					mv.visitLdcInsn(handle);
 				} else {

--- a/src/soot/jimple/internal/AbstractInvokeExpr.java
+++ b/src/soot/jimple/internal/AbstractInvokeExpr.java
@@ -64,6 +64,7 @@ abstract public class AbstractInvokeExpr implements InvokeExpr
 
     public SootMethod getMethod()
     {
+
         return methodRef.resolve();
     }
 

--- a/tests/soot/jimple/MethodHandleTest.java
+++ b/tests/soot/jimple/MethodHandleTest.java
@@ -50,7 +50,6 @@ public class MethodHandleTest {
 
 
   @Test
-  @Ignore
   public void testInvoke() throws IOException {
 
     // First generate a classfile with a MethodHnadle


### PR DESCRIPTION
This corrects the output of MethodHandle constants implemented in the previous pull request (#637) and adds support for MethodHandle.invoke() and MethodHandle.invokeExact(), which are signature polymorphic.