### PR TITLE
Fixing potential NPE in AbstractMultiMap

### DIFF
--- a/src/soot/util/AbstractMultiMap.java
+++ b/src/soot/util/AbstractMultiMap.java
@@ -40,11 +40,14 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V>, Serializ
 		
 		@Override
 		public void remove() {
+			if (valueIterator == null)
+			  //Removing an element twice or removing no valid elemnt does not make sense
+			  return;
 			valueIterator.remove();
 
 			if (get(currentKey).isEmpty()) {
 				keyIterator.remove();
-				keyIterator = null;
+				valueIterator = null;
 				currentKey = null;
 			}
 		}

--- a/src/soot/util/AbstractMultiMap.java
+++ b/src/soot/util/AbstractMultiMap.java
@@ -41,7 +41,7 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V>, Serializ
 		@Override
 		public void remove() {
 			if (valueIterator == null)
-			  //Removing an element twice or removing no valid elemnt does not make sense
+			  //Removing an element twice or removing no valid element does not make sense
 			  return;
 			valueIterator.remove();
 


### PR DESCRIPTION
Fixing NPE in AbstractMultiMap, which may occur when a value is deleted via the iterator and no value is left for the corresponding key.