### PR TITLE
fix jbco MethodRenamer, FieldRenamer and CollectConstants

### DIFF
--- a/src/soot/jbco/jimpleTransformations/CollectConstants.java
+++ b/src/soot/jbco/jimpleTransformations/CollectConstants.java
@@ -97,7 +97,7 @@ public class CollectConstants extends SceneTransformer implements IJbcoTransform
 
 		for (SootClass cl : appClasses) {
 			for (SootMethod m : cl.getMethods()) {
-				if (!m.hasActiveBody() || m.getName().indexOf("<clinit>") >= 0)
+				if (!m.hasActiveBody() || m.getName().contains(SootMethod.staticInitializerName))
 					continue;
 
 				for (ValueBox useBox : m.getActiveBody().getUseBoxes()) {
@@ -181,16 +181,17 @@ public class CollectConstants extends SceneTransformer implements IJbcoTransform
 				return;
 		}
 
-		Body b = null;
+		Body b;
 		boolean newInit = false;
-		if (!clas.declaresMethodByName("<clinit>")) {
-			SootMethod m = Scene.v().makeSootMethod("<clinit>", Collections.<Type>emptyList(), VoidType.v());
+		if (!clas.declaresMethodByName(SootMethod.staticInitializerName)) {
+			SootMethod m = Scene.v().makeSootMethod(SootMethod.staticInitializerName,
+                    Collections.<Type>emptyList(), VoidType.v(), Modifier.STATIC);
 			clas.addMethod(m);
 			b = Jimple.v().newBody(m);
 			m.setActiveBody(b);
 			newInit = true;
 		} else {
-			SootMethod m = clas.getMethodByName("<clinit>");
+			SootMethod m = clas.getMethodByName(SootMethod.staticInitializerName);
 			if (!m.hasActiveBody()) {
 				b = Jimple.v().newBody(m);
 				m.setActiveBody(b);

--- a/src/soot/jbco/jimpleTransformations/FieldRenamer.java
+++ b/src/soot/jbco/jimpleTransformations/FieldRenamer.java
@@ -53,7 +53,7 @@ import soot.jimple.Jimple;
 
 /**
  * @author Michael Batchelder
- * 
+ *
  *         Created on 26-Jan-2006
  */
 public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
@@ -207,16 +207,17 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
 		if (!value && f.getType() instanceof IntegerType && Rand.getInt() % 2 > 0)
 			return;
 
-		Body b = null;
+		Body b;
 		boolean newInit = false;
-		if (!c.declaresMethodByName("<clinit>")) {
-			SootMethod m = Scene.v().makeSootMethod("<clinit>", Collections.<Type>emptyList(), VoidType.v());
+		if (!c.declaresMethodByName(SootMethod.staticInitializerName)) {
+			SootMethod m = Scene.v().makeSootMethod(SootMethod.staticInitializerName,
+                    Collections.<Type>emptyList(), VoidType.v(), Modifier.STATIC);
 			c.addMethod(m);
 			b = Jimple.v().newBody(m);
 			m.setActiveBody(b);
 			newInit = true;
 		} else {
-			SootMethod m = c.getMethodByName("<clinit>");
+			SootMethod m = c.getMethodByName(SootMethod.staticInitializerName);
 			b = m.getActiveBody();
 		}
 

--- a/src/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -77,8 +77,8 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
 		if (output)
 			out.println("Transforming Method Names...");
 
-		soot.jbco.util.BodyBuilder.retrieveAllBodies();
-		soot.jbco.util.BodyBuilder.retrieveAllNames();
+		BodyBuilder.retrieveAllBodies();
+		BodyBuilder.retrieveAllNames();
 
 		Scene scene = G.v().soot_Scene();
 		scene.releaseActiveHierarchy();
@@ -159,24 +159,22 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
 							continue;
 
 						InvokeExpr ie = (InvokeExpr) v;
+                        SootMethodRef methodRef = ie.getMethodRef();
 
-						try {
-							// if the method won't resolve, then we know it's
-							// not a lib method
-							ie.getMethod();
-							continue;
-						} catch (Exception e) {
-						}
+                        // if the method won't be resolved in declaring class by subsignature of method ref,
+                        // then we know it was renamed and update that method ref with new name
+                        if (methodRef.declaringClass().getMethodUnsafe(methodRef.getSubSignature()) != null) {
+                            continue;
+                        }
 
-						SootMethodRef r = ie.getMethodRef();
-						String newName = oldToNewMethodNames.get(r.name());
+						String newName = oldToNewMethodNames.get(methodRef.name());
 						if (newName == null)
 							continue;
 
-						r = scene.makeMethodRef(r.declaringClass(), newName,
-								r.parameterTypes(), r.returnType(),
-								r.isStatic());
-						ie.setMethodRef(r);
+						methodRef = scene.makeMethodRef(methodRef.declaringClass(), newName,
+								methodRef.parameterTypes(), methodRef.returnType(),
+								methodRef.isStatic());
+						ie.setMethodRef(methodRef);
 					}
 				}
 			}


### PR DESCRIPTION
Fix `MethodRenamer` "Unresolved compilation error" in renamed method's bodies.
Refactoring `SootMethod#setName` and `SootClass` (remove `subSigToMethods` field and use `methodList` instead, no more "keep in sync" work between those two fields, e.g. to rename method just rename it, not remove-rename-add).