### PR TITLE
MethodValidator

### DIFF
--- a/src/main/java/soot/jimple/JimpleBody.java
+++ b/src/main/java/soot/jimple/JimpleBody.java
@@ -40,6 +40,7 @@ import soot.jimple.validation.IdentityStatementsValidator;
 import soot.jimple.validation.IdentityValidator;
 import soot.jimple.validation.InvokeArgumentValidator;
 import soot.jimple.validation.JimpleTrapValidator;
+import soot.jimple.validation.MethodValidator;
 import soot.jimple.validation.NewValidator;
 import soot.jimple.validation.ReturnStatementsValidator;
 import soot.jimple.validation.TypesValidator;
@@ -61,7 +62,7 @@ public class JimpleBody extends StmtBody {
 		if (validators == null) {
 			validators = new BodyValidator[] { IdentityStatementsValidator.v(), TypesValidator.v(),
 					ReturnStatementsValidator.v(), InvokeArgumentValidator.v(), FieldRefValidator.v(), NewValidator.v(),
-					JimpleTrapValidator.v(), IdentityValidator.v()
+					JimpleTrapValidator.v(), IdentityValidator.v(), MethodValidator.v()
 					// InvokeValidator.v()
 			};
 		}

--- a/src/main/java/soot/jimple/validation/FieldRefValidator.java
+++ b/src/main/java/soot/jimple/validation/FieldRefValidator.java
@@ -24,11 +24,11 @@ public enum FieldRefValidator implements BodyValidator {
 	}
 
 
-	@Override
 	/**
 	 * Checks the consistency of field references.
 	 */
-	public void validate(Body body, List<ValidationException> exception) {
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
 		SootMethod method = body.getMethod();
 		if (method.isAbstract())
 			return;
@@ -47,13 +47,13 @@ public enum FieldRefValidator implements BodyValidator {
 				try {
 					SootField field = v.getField();
 					if (field == null)
-						exception.add(new UnitValidationException(unit, body, "Resolved field is null: " + fr.toString()));
+						exceptions.add(new UnitValidationException(unit, body, "Resolved field is null: " + fr.toString()));
 
 					if (!field.isStatic() && !field.isPhantom()) {
-						exception.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
+						exceptions.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
 					}
 				} catch (ResolutionFailedException e) {
-					exception.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
+					exceptions.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
 				}
 			} else if (fr instanceof InstanceFieldRef) {
 				InstanceFieldRef v = (InstanceFieldRef) fr;
@@ -61,13 +61,13 @@ public enum FieldRefValidator implements BodyValidator {
 				try {
 					SootField field = v.getField();
 					if (field == null)
-						exception.add(new UnitValidationException(unit, body, "Resolved field is null: " + fr.toString()));
+						exceptions.add(new UnitValidationException(unit, body, "Resolved field is null: " + fr.toString()));
 					
 					if (field.isStatic() && !field.isPhantom()) {
-						exception.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
+						exceptions.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
 					}
 				} catch (ResolutionFailedException e) {
-					exception.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
+					exceptions.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
 				}
 			} else {
 				throw new RuntimeException("unknown field ref");

--- a/src/main/java/soot/jimple/validation/IdentityStatementsValidator.java
+++ b/src/main/java/soot/jimple/validation/IdentityStatementsValidator.java
@@ -3,6 +3,7 @@ package soot.jimple.validation;
 import java.util.List;
 
 import soot.Body;
+import soot.Modifier;
 import soot.SootMethod;
 import soot.Unit;
 import soot.jimple.IdentityStmt;
@@ -20,7 +21,6 @@ public enum IdentityStatementsValidator implements BodyValidator {
 	}
 
 
-	@Override
 	/**
      * Checks the following invariants on this Jimple body:
      * <ol>
@@ -30,10 +30,12 @@ public enum IdentityStatementsValidator implements BodyValidator {
      *      if they occur at all
      * </ol>
      */
-	public void validate(Body body, List<ValidationException> exception) {
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
 		SootMethod method = body.getMethod();
-		if (method.isAbstract())
-			return;
+		if (method.isAbstract()) {
+		    return;
+        }
 		
 		Chain<Unit> units=body.getUnits().getNonPatchingChain();
 
@@ -45,15 +47,15 @@ public enum IdentityStatementsValidator implements BodyValidator {
 				IdentityStmt identityStmt = (IdentityStmt) unit;
 				if(identityStmt.getRightOp() instanceof ThisRef) {					
 					if(method.isStatic()) {
-						exception.add(new ValidationException(identityStmt, "@this-assignment in a static method!"));
+						exceptions.add(new ValidationException(identityStmt, "@this-assignment in a static method!"));
 					}					
 					if(!firstStatement) {
-						exception.add(new ValidationException(identityStmt, "@this-assignment statement should precede all other statements"
+						exceptions.add(new ValidationException(identityStmt, "@this-assignment statement should precede all other statements"
 						        +"\n method: "+ method));
 					}
 				} else if(identityStmt.getRightOp() instanceof ParameterRef) {
 					if(foundNonThisOrParamIdentityStatement) {
-						exception.add(new ValidationException(identityStmt, "@param-assignment statements should precede all non-identity statements"
+						exceptions.add(new ValidationException(identityStmt, "@param-assignment statements should precede all non-identity statements"
 						        +"\n method: "+ method));
 					}
 				} else {

--- a/src/main/java/soot/jimple/validation/IdentityValidator.java
+++ b/src/main/java/soot/jimple/validation/IdentityValidator.java
@@ -41,11 +41,11 @@ public enum IdentityValidator implements BodyValidator {
 		return INSTANCE;
 	}
 
-	@Override
 	/**
 	 * Checks whether each ParameterRef and ThisRef is used exactly once.
 	 */
-	public void validate(Body body, List<ValidationException> exception) {
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
 		boolean hasThisLocal = false;
 		int paramCount = body.getMethod().getParameterCount();
 		boolean[] parameterRefs = new boolean[paramCount];
@@ -61,27 +61,27 @@ public enum IdentityValidator implements BodyValidator {
 					if (ref.getIndex() < 0 || ref.getIndex() >= paramCount)
 					{
 						if (paramCount == 0)
-							exception.add(new ValidationException(id, "This method has no parameters, so no parameter reference is allowed"));
+							exceptions.add(new ValidationException(id, "This method has no parameters, so no parameter reference is allowed"));
 						else
-							exception.add(new ValidationException(id, String.format("Parameter reference index must be between 0 and %d (inclusive)", paramCount - 1)));
+							exceptions.add(new ValidationException(id, String.format("Parameter reference index must be between 0 and %d (inclusive)", paramCount - 1)));
 						return;
 					}
 					if (parameterRefs[ref.getIndex()]) {
-						exception.add(new ValidationException(id, String.format("Only one local for parameter %d is allowed", ref.getIndex())));
+						exceptions.add(new ValidationException(id, String.format("Only one local for parameter %d is allowed", ref.getIndex())));
 					}
 					parameterRefs[ref.getIndex()] = true;
 				}
 			}
 		}
 		
-		if (!(body.getMethod().isStatic() || body.getMethod().isStaticInitializer()) && !hasThisLocal) {
-			exception.add(new ValidationException(body, String.format("The method %s is not static, but does not have a this local", body.getMethod().getSignature())));
+		if (!body.getMethod().isStatic() && !hasThisLocal) {
+			exceptions.add(new ValidationException(body, String.format("The method %s is not static, but does not have a this local", body.getMethod().getSignature())));
 		}
 		
 		for (int i = 0; i < paramCount; i++) {
 			if (!parameterRefs[i])
 			{
-				exception.add(new ValidationException(body, String.format("There is no parameter local for parameter number %d", i)));
+				exceptions.add(new ValidationException(body, String.format("There is no parameter local for parameter number %d", i)));
 			}
 		}
 	}

--- a/src/main/java/soot/jimple/validation/JimpleTrapValidator.java
+++ b/src/main/java/soot/jimple/validation/JimpleTrapValidator.java
@@ -45,22 +45,22 @@ public enum JimpleTrapValidator implements BodyValidator {
 		return INSTANCE;
 	}
 
-	@Override
 	/**
 	 * Checks whether all Caught-Exception-References are associated to traps.
 	 */
-	public void validate(Body body, List<ValidationException> exception) {
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
 		Set<Unit> caughtUnits = new HashSet<Unit>();
 		for (Trap trap : body.getTraps()) {
 			caughtUnits.add(trap.getHandlerUnit());
 			
 			if (!(trap.getHandlerUnit() instanceof IdentityStmt))
-				exception.add(new ValidationException(trap, "Trap handler does not start with caught "
+				exceptions.add(new ValidationException(trap, "Trap handler does not start with caught "
 						+ "exception reference"));
 			else {
 				IdentityStmt is = (IdentityStmt) trap.getHandlerUnit();
 				if (!(is.getRightOp() instanceof CaughtExceptionRef))
-					exception.add(new ValidationException(trap, "Trap handler does not start with caught "
+					exceptions.add(new ValidationException(trap, "Trap handler does not start with caught "
 							+ "exception reference"));
 			}
 		}
@@ -70,7 +70,7 @@ public enum JimpleTrapValidator implements BodyValidator {
 				if (id.getRightOp() instanceof CaughtExceptionRef) {
 					if (!caughtUnits.contains(id)) 
 					{
-						exception
+						exceptions
 						.add(new ValidationException(
 								id,
 								"Could not find a corresponding trap using this statement as handler",

--- a/src/main/java/soot/jimple/validation/MethodValidator.java
+++ b/src/main/java/soot/jimple/validation/MethodValidator.java
@@ -1,0 +1,41 @@
+package soot.jimple.validation;
+
+import soot.Body;
+import soot.SootMethod;
+import soot.validation.BodyValidator;
+import soot.validation.ValidationException;
+
+import java.util.List;
+
+public enum MethodValidator implements BodyValidator {
+    INSTANCE;
+
+    public static MethodValidator v() {
+        return INSTANCE;
+    }
+
+    /**
+     * Checks the following invariants on this Jimple body:
+     * <ol>
+     * <li> static initializer should have 'static' modifier
+     * </ol>
+     */
+    @Override
+    public void validate(Body body, List<ValidationException> exceptions) {
+        SootMethod method = body.getMethod();
+        if (method.isAbstract()) {
+            return;
+        }
+        if (method.isStaticInitializer() && !method.isStatic()) {
+            exceptions.add(new ValidationException(method, SootMethod.staticInitializerName
+                    + " should be static! Static initializer without 'static'('0x8') modifier"
+                    + " will cause problem when running on android platform: "
+                    + "\"<clinit> is not flagged correctly wrt/ static\"!"));
+        }
+    }
+
+    @Override
+    public boolean isBasicValidator() {
+        return true;
+    }
+}

--- a/src/main/java/soot/jimple/validation/NewValidator.java
+++ b/src/main/java/soot/jimple/validation/NewValidator.java
@@ -61,11 +61,11 @@ public enum NewValidator implements BodyValidator {
 		return INSTANCE;
 	}
 
-	@Override
 	/**
 	 * Checks whether after each new-instruction a constructor call follows.
 	 */
-	public void validate(Body body, List<ValidationException> exception) {
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
 		UnitGraph g = new BriefUnitGraph(body);
 		for (Unit u : body.getUnits()) {
 			if (u instanceof AssignStmt) {
@@ -74,7 +74,7 @@ public enum NewValidator implements BodyValidator {
 				// First seek for a JNewExpr.
 				if (assign.getRightOp() instanceof NewExpr) {
 					if (!(assign.getLeftOp().getType() instanceof RefType)) {
-						exception.add(new ValidationException(u,
+						exceptions.add(new ValidationException(u,
 								"A new-expression must be used on reference type locals",
 								String.format(
 										"Body of method %s contains a new-expression, which is assigned to a non-reference local",
@@ -86,7 +86,7 @@ public enum NewValidator implements BodyValidator {
 					LinkedHashSet<Local> locals = new LinkedHashSet<Local>();
 					locals.add((Local) assign.getLeftOp());
 
-					checkForInitializerOnPath(g, assign, exception);
+					checkForInitializerOnPath(g, assign, exceptions);
 				}
 			}
 		}

--- a/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
+++ b/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
@@ -20,7 +20,6 @@ public enum ReturnStatementsValidator implements BodyValidator {
 	}
 
 
-	@Override
 	/**
      * Checks the following invariants on this Jimple body:
      * <ol>
@@ -30,10 +29,9 @@ public enum ReturnStatementsValidator implements BodyValidator {
      *      if they occur at all
      * </ol>
      */
-	public void validate(Body body, List<ValidationException> exception) {
-	    /**
-	     * Checks that this Jimple body actually contains a return statement
-	     */
+    @Override
+	public void validate(Body body, List<ValidationException> exceptions) {
+        //Checks that this Jimple body actually contains a return statement
 		for (Unit u : body.getUnits())
 			if ((u instanceof ReturnStmt) || (u instanceof ReturnVoidStmt)
 					|| (u instanceof RetStmt)
@@ -53,7 +51,7 @@ public enum ReturnStatementsValidator implements BodyValidator {
         if (last instanceof GotoStmt || last instanceof ThrowStmt)
             return;
 
-        exception.add(new ValidationException(body.getMethod(), "The method does not contain a return statement", "Body of method " + body.getMethod().getSignature()
+        exceptions.add(new ValidationException(body.getMethod(), "The method does not contain a return statement", "Body of method " + body.getMethod().getSignature()
 				+ " does not contain a return statement"));
     }
 

--- a/src/main/java/soot/jimple/validation/TypesValidator.java
+++ b/src/main/java/soot/jimple/validation/TypesValidator.java
@@ -23,25 +23,25 @@ public enum TypesValidator implements BodyValidator {
 
 
 	@Override
-	public void validate(Body body, List<ValidationException> exception) {
+	public void validate(Body body, List<ValidationException> exceptions) {
 		SootMethod method = body.getMethod();
 		
-		if(method!=null) {
-			if(!method.getReturnType().isAllowedInFinalCode()) {
-				exception.add(new ValidationException(method, "Return type not allowed in final code: " + method.getReturnType(), "return type not allowed in final code:"+method.getReturnType()
+		if (method != null) {
+			if (!method.getReturnType().isAllowedInFinalCode()) {
+				exceptions.add(new ValidationException(method, "Return type not allowed in final code: " + method.getReturnType(), "return type not allowed in final code:"+method.getReturnType()
 				        +"\n method: "+ method));
 			}
-			for(Type t: method.getParameterTypes()) {
-				if(!t.isAllowedInFinalCode()) {
-					exception.add(new ValidationException(method, "Parameter type not allowed in final code: " + t, "parameter type not allowed in final code:"+t
+			for (Type t: method.getParameterTypes()) {
+				if (!t.isAllowedInFinalCode()) {
+					exceptions.add(new ValidationException(method, "Parameter type not allowed in final code: " + t, "parameter type not allowed in final code:"+t
 					        +"\n method: "+ method));
 				}
 			}
 		}
-		for(Local l: body.getLocals()) {
+		for (Local l: body.getLocals()) {
 			Type t = l.getType();
-			if(!t.isAllowedInFinalCode()) {
-				exception.add(new ValidationException(l, "Local type not allowed in final code: " + t, "(" + method + ") local type not allowed in final code: " + t +" local: "+l));
+			if (!t.isAllowedInFinalCode()) {
+				exceptions.add(new ValidationException(l, "Local type not allowed in final code: " + t, "(" + method + ") local type not allowed in final code: " + t +" local: "+l));
 			}
 		}
     }


### PR DESCRIPTION
I have added validator to check that static initializers have 'static' modifier (if not exception with message "<clinit> is not flagged correctly wrt/ static" will be thrown in android runtime, see d46683feb30ec21ca913219da365e6b0df058dff commit)
and removed change added in 382971d0cb32f9ecf2c6d363e1626821d03ca05e commit to IdentityValidator , as we don't need it now since MethodValidator ensures that all static initializers have 'static' modifier (thus check for static is sufficient)