### PR TITLE
Fixed some issues with LibraryMethodWrapperBuilder, MethodRenamer

### DIFF
--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -236,7 +236,9 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
         } else if (subSig.contains(SootMethod.constructorName) || subSig.contains(SootMethod.staticInitializerName)) {
             return false; // skip constructors for now
         } else {
-            return !(isOverriddenLibraryInterfaceMethod(sc, method) || isOverriddenLibrarySuperclassMethod(sc, method));
+            return !(isOverriddenLibraryInterfaceMethod(sc, method)
+                    || isOverriddenLibrarySuperclassMethod(sc, method)
+                    || isOverriddenLibraryMethodWithinAllChildren(sc, method));
         }
     }
 
@@ -263,6 +265,13 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
         return HierarchyUtils.getAllInterfacesOf(sc).stream()
                 .filter(SootClass::isLibraryClass)
                 .anyMatch(c -> c.declaresMethod(method.getName(), method.getParameterTypes(), method.getReturnType()));
+    }
+
+    private static boolean isOverriddenLibraryMethodWithinAllChildren(SootClass sc, SootMethod method) {
+        final List<SootClass> subClasses = sc.isInterface()
+                ? hierarchy.getImplementersOf(sc) : hierarchy.getSubclassesOf(sc);
+        return subClasses.stream().anyMatch(
+                c -> isOverriddenLibraryInterfaceMethod(c, method) || isOverriddenLibrarySuperclassMethod(c, method));
     }
 
 }

--- a/src/main/java/soot/jbco/util/HierarchyUtils.java
+++ b/src/main/java/soot/jbco/util/HierarchyUtils.java
@@ -1,6 +1,5 @@
 package soot.jbco.util;
 
-import soot.ClassMember;
 import soot.Hierarchy;
 import soot.Scene;
 import soot.SootClass;
@@ -38,27 +37,6 @@ public final class HierarchyUtils {
                 .map(HierarchyUtils::getAllInterfacesOf)
                 .flatMap(Collection::stream));
         return Stream.concat(superClassInterfaces, directInterfaces).collect(toList());
-    }
-
-    /**
-     * Returns true if the class member is visible from code in the provided class.
-     * Phantom superclasses and interfaces are ignored.
-     *
-     * @param from   any class from which class member visibility/availability should be checked
-     * @param member any class member
-     * @return returns {@code true} if the {@code member } is visible from code in the provided class {@code from}.
-     */
-    public static boolean isVisible(SootClass from, ClassMember member) {
-        from.checkLevel(SootClass.HIERARCHY);
-        member.getDeclaringClass().checkLevel(SootClass.HIERARCHY);
-
-        Hierarchy hierarchy = Scene.v().getActiveHierarchy();
-        if (member.isProtected()) {
-            List<SootClass> superclasses = hierarchy.getSuperclassesOfIncluding(from);
-            return superclasses.contains(member.getDeclaringClass())
-                    || from.getJavaPackageName().equals(member.getDeclaringClass().getJavaPackageName());
-        }
-        return hierarchy.isVisible(from, member);
     }
 
 }


### PR DESCRIPTION
We cannot extract calls to 'super' to the static methods, as it is not permitted on the language level to call 'super' on objects from the outside.
So without this fix we get such (not working) wrappers:
```
public static void run(Object arg, Object libObj) {
    super.doSomething(arg); //ignoring libObj
}
```
the fix is to skip `specialinvoke` instructions