### PR TITLE
Introduced class loading strategy for plugins

### DIFF
--- a/src/main/java/soot/plugins/internal/ClassLoadingStrategy.java
+++ b/src/main/java/soot/plugins/internal/ClassLoadingStrategy.java
@@ -1,0 +1,36 @@
+/* Soot - a J*va Optimization Framework
+ * 
+ * Copyright (C) 2018 Bernhard J. Berger
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+package soot.plugins.internal;
+
+/**
+ * Interface for different class loading strategies.
+ *
+ * @author Bernhard J. Berger
+ */
+public interface ClassLoadingStrategy {
+
+	/**
+	 * Creates an instance of the given class name.
+	 *
+	 * @param className Name of the class.
+	 * @return The newly created instance.
+	 */
+	public Object create(final String className) throws ClassNotFoundException, InstantiationException;
+}

--- a/src/main/java/soot/plugins/internal/ReflectionClassLoadingStrategy.java
+++ b/src/main/java/soot/plugins/internal/ReflectionClassLoadingStrategy.java
@@ -1,0 +1,39 @@
+/* Soot - a J*va Optimization Framework
+ * 
+ * Copyright (C) 2018 Bernhard J. Berger
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+package soot.plugins.internal;
+
+/**
+ * Class loading strategy that uses traditional reflection for instantiation.
+ *
+ * @author Bernhard J. Berger
+ */
+public class ReflectionClassLoadingStrategy implements ClassLoadingStrategy {
+
+	@Override
+	public Object create(final String className) throws ClassNotFoundException, InstantiationException {
+		final Class<?> clazz = Class.forName(className);
+
+		try {
+			return clazz.newInstance();
+		} catch (final IllegalAccessException e) {
+			throw new InstantiationException("Failed to create instance of " + className + " due to access restrictions.");
+		}
+	}
+}


### PR DESCRIPTION
Soot uses reflection to create instances of plugins.  This approach does not work in all execution environments, e.g. OSGi. In OSGi one cannot load an arbitrary class by name as long as it is not a explicit dependency. 

The changes in this pull request introduce a class loading strategy for plugin instantiation. The default implementation still employs Java reflection and does not change the current behavior. Nevertheless, it is possible to write new strategies coping with special execution environments and register them using ```PluginLoader.setClassLoadingStrategy```.