### PR TITLE
use absolute resource path

### DIFF
--- a/src/main/generated/sablecc/soot/jimple/parser/lexer/Lexer.java
+++ b/src/main/generated/sablecc/soot/jimple/parser/lexer/Lexer.java
@@ -2202,7 +2202,7 @@ public class Lexer
         {
             DataInputStream s = new DataInputStream(
                 new BufferedInputStream(
-                Lexer.class.getResourceAsStream("lexer.dat")));
+                Lexer.class.getResourceAsStream("/lexer.dat")));
 
             // read gotoTable
             int length = s.readInt();

--- a/src/main/generated/sablecc/soot/jimple/parser/parser/Parser.java
+++ b/src/main/generated/sablecc/soot/jimple/parser/parser/Parser.java
@@ -7524,7 +7524,7 @@ public class Parser
         {
             DataInputStream s = new DataInputStream(
                 new BufferedInputStream(
-                Parser.class.getResourceAsStream("parser.dat")));
+                Parser.class.getResourceAsStream("/parser.dat")));
 
             // read actionTable
             int length = s.readInt();


### PR DESCRIPTION
Reading jimple source files was broken around  Nov 6, 2017 see  1bde6596bbb0699ba09221303c9a52f0f09f6636 and 063e0da1b3412cfc2577db4139176dd1f80d4728

A test case for a `Main.jimple` file is a call like:
```
java -jar sootclasses-trunk-jar-with-dependencies.jar -src-prec J -cp .:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar Main
```

The current error looks like:

```
Soot started on Mon Feb 26 14:15:17 CET 2018
Exception in thread "main" java.lang.ExceptionInInitializerError
	at soot.jimple.parser.JimpleAST.<init>(JimpleAST.java:53)
	at soot.JimpleClassSource.resolve(JimpleClassSource.java:50)
	at soot.SootResolver.bringToHierarchyUnchecked(SootResolver.java:236)
	at soot.SootResolver.bringToHierarchy(SootResolver.java:208)
	at soot.SootResolver.bringToSignatures(SootResolver.java:269)
	at soot.SootResolver.processResolveWorklist(SootResolver.java:170)
	at soot.SootResolver.resolveClass(SootResolver.java:133)
	at soot.Scene.loadClass(Scene.java:860)
	at soot.Scene.loadClassAndSupport(Scene.java:846)
	at soot.Scene.loadNecessaryClass(Scene.java:1576)
	at soot.Scene.loadNecessaryClasses(Scene.java:1589)
	at soot.Main.run(Main.java:250)
	at soot.Main.main(Main.java:147)
Caused by: java.lang.RuntimeException: The file "parser.dat" is either missing or corrupted.
	at soot.jimple.parser.parser.Parser.<clinit>(Parser.java:7588)
	... 13 more
```
