### PR TITLE
Fixing LibraryMethodWrapperBuilder

### DIFF
--- a/src/main/java/soot/jbco/IJbcoTransform.java
+++ b/src/main/java/soot/jbco/IJbcoTransform.java
@@ -19,20 +19,61 @@
 
 package soot.jbco;
 
-import java.io.PrintStream;
 import soot.G;
 
+import java.io.PrintStream;
+
 /**
- * @author Michael Batchelder 
- * 
- * Created on 19-Jun-2006 
+ * @author Michael Batchelder
+ * <p>
+ * Created on 19-Jun-2006
  */
 public interface IJbcoTransform {
 
-  public PrintStream out = soot.G.v().out;
-  public boolean output = G.v().soot_options_Options().verbose() || soot.jbco.Main.jbcoVerbose;
-  public boolean debug = soot.jbco.Main.jbcoDebug;
-  public void outputSummary();
-  public String[] getDependancies();
-  public String getName();
+    @Deprecated
+    PrintStream out = soot.G.v().out;
+    @Deprecated
+    boolean output = G.v().soot_options_Options().verbose() || soot.jbco.Main.jbcoVerbose;
+    @Deprecated
+    boolean debug = soot.jbco.Main.jbcoDebug;
+
+    /**
+     * Gets the code name of {@link IJbcoTransform jbco transformer} implementation.
+     *
+     * @return the code name of {@link IJbcoTransform jbco transformer}
+     */
+    String getName();
+
+    /**
+     * Gets array of {@link IJbcoTransform jbco transformer} code names on which current transformer depends on.
+     *
+     * @return array of code names
+     */
+    String[] getDependencies();
+
+    /**
+     * Prints summary of the produced changes.
+     */
+    void outputSummary();
+
+    /**
+     * Checks if {@link IJbcoTransform jbco transformer} can log extra information.
+     *
+     * @return {@code true} when {@link IJbcoTransform jbco transformer} can log extra information;
+     * {@code false} otherwise
+     */
+    default boolean isVerbose() {
+        return G.v().soot_options_Options().verbose() || soot.jbco.Main.jbcoVerbose;
+    }
+
+    /**
+     * Checks if {@link IJbcoTransform jbco transformer} can log debug information.
+     *
+     * @return {@code true} when {@link IJbcoTransform jbco transformer} can log debug information;
+     * {@code false} otherwise
+     */
+    default boolean isDebugEnabled() {
+        return soot.jbco.Main.jbcoDebug;
+    }
+
 }

--- a/src/main/java/soot/jbco/bafTransformations/AddJSRs.java
+++ b/src/main/java/soot/jbco/bafTransformations/AddJSRs.java
@@ -19,11 +19,30 @@
 
 package soot.jbco.bafTransformations;
 
-import java.util.*;
-import soot.*;
-import soot.baf.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import soot.Body;
+import soot.BodyTransformer;
+import soot.PatchingChain;
+import soot.RefType;
+import soot.Trap;
+import soot.Unit;
+import soot.baf.Baf;
+import soot.baf.GotoInst;
+import soot.baf.JSRInst;
+import soot.baf.LookupSwitchInst;
+import soot.baf.PopInst;
+import soot.baf.TableSwitchInst;
+import soot.baf.TargetArgInst;
 import soot.jbco.IJbcoTransform;
-import soot.jbco.util.*;
+import soot.jbco.util.BodyBuilder;
+import soot.jbco.util.Rand;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Michael Batchelder
@@ -34,11 +53,13 @@ import soot.jbco.util.*;
  */
 public class AddJSRs extends BodyTransformer implements IJbcoTransform {
 
+  private static final Logger logger = LoggerFactory.getLogger(AddJSRs.class);
+
   int jsrcount = 0;
 
   public static String dependancies[] = new String[] { "jtp.jbco_jl", "bb.jbco_cb2ji", "bb.jbco_ful", "bb.lp" };
   
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   
@@ -49,7 +70,7 @@ public class AddJSRs extends BodyTransformer implements IJbcoTransform {
   }
 
   public void outputSummary() {
-    out.println("If/Gotos replaced with JSRs: " + jsrcount);
+    logger.info("{} If/Gotos replaced with JSRs.", jsrcount);
   }
 
   protected void internalTransform(Body b, String phaseName, Map<String,String> options) {

--- a/src/main/java/soot/jbco/bafTransformations/BAFCounter.java
+++ b/src/main/java/soot/jbco/bafTransformations/BAFCounter.java
@@ -34,7 +34,7 @@ public class BAFCounter extends BodyTransformer implements IJbcoTransform {
 	static int count = 0;
 	public static String dependancies[] = new String[] { "bb.jbco_counter" };
 
-	public String[] getDependancies() {
+	public String[] getDependencies() {
 		return dependancies;
 	}
 

--- a/src/main/java/soot/jbco/bafTransformations/BAFPrintout.java
+++ b/src/main/java/soot/jbco/bafTransformations/BAFPrintout.java
@@ -39,7 +39,7 @@ public class BAFPrintout extends BodyTransformer implements IJbcoTransform {
   public static String name = "bb.printout";
   
   public void outputSummary() {}
-  public String[] getDependancies() {return new String[0];}
+  public String[] getDependencies() {return new String[0];}
   public String getName() { 
     return name;
   }

--- a/src/main/java/soot/jbco/bafTransformations/BafLineNumberer.java
+++ b/src/main/java/soot/jbco/bafTransformations/BafLineNumberer.java
@@ -30,7 +30,7 @@ public class BafLineNumberer extends BodyTransformer implements IJbcoTransform {
   public static String name = "bb.jbco_bln";
 
   public void outputSummary() {}
-  public String[] getDependancies() { return new String[]{name};}
+  public String[] getDependencies() { return new String[]{name};}
   public String getName() { return name;}
   protected void internalTransform(Body b, String phaseName, Map<String,String> options) {
     int idx = 0;

--- a/src/main/java/soot/jbco/bafTransformations/ConstructorConfuser.java
+++ b/src/main/java/soot/jbco/bafTransformations/ConstructorConfuser.java
@@ -35,7 +35,7 @@ public class ConstructorConfuser extends BodyTransformer implements
   
   public static String dependancies[] = new String[] { "bb.jbco_dcc", "bb.jbco_ful", "bb.lp" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/FindDuplicateSequences.java
+++ b/src/main/java/soot/jbco/bafTransformations/FindDuplicateSequences.java
@@ -39,7 +39,7 @@ public class FindDuplicateSequences extends BodyTransformer implements IJbcoTran
   
   public static String dependancies[] = new String[] {"bb.jbco_j2bl", "bb.jbco_rds", "bb.jbco_ful", "bb.lp" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/FixUndefinedLocals.java
+++ b/src/main/java/soot/jbco/bafTransformations/FixUndefinedLocals.java
@@ -43,7 +43,7 @@ public class FixUndefinedLocals extends BodyTransformer implements IJbcoTransfor
   
   public static String dependancies[] = new String[] {"bb.jbco_j2bl", "bb.jbco_ful", "bb.lp" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/IfNullToTryCatch.java
+++ b/src/main/java/soot/jbco/bafTransformations/IfNullToTryCatch.java
@@ -38,7 +38,7 @@ public class IfNullToTryCatch extends BodyTransformer implements IJbcoTransform 
   
   public static String dependancies[] = new String[] {"bb.jbco_riitcb","bb.jbco_ful","bb.lp"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/IndirectIfJumpsToCaughtGotos.java
+++ b/src/main/java/soot/jbco/bafTransformations/IndirectIfJumpsToCaughtGotos.java
@@ -39,7 +39,7 @@ public class IndirectIfJumpsToCaughtGotos extends BodyTransformer implements IJb
   
   public static String dependancies[] = new String[] {"bb.jbco_iii", "bb.jbco_ful", "bb.lp"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/Jimple2BafLocalBuilder.java
+++ b/src/main/java/soot/jbco/bafTransformations/Jimple2BafLocalBuilder.java
@@ -38,7 +38,7 @@ public class Jimple2BafLocalBuilder extends BodyTransformer implements IJbcoTran
 
   public static String dependancies[] = new String[] {"jtp.jbco_jl","bb.jbco_j2bl","bb.lp"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/LocalsToBitField.java
+++ b/src/main/java/soot/jbco/bafTransformations/LocalsToBitField.java
@@ -35,7 +35,7 @@ public class LocalsToBitField extends BodyTransformer  implements IJbcoTransform
   
   public static String dependancies[] = new String[]{"jtp.jbco_jl","bb.jbco_plvb", "bb.jbco_ful", "bb.lp"}; 
   
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/MoveLoadsAboveIfs.java
+++ b/src/main/java/soot/jbco/bafTransformations/MoveLoadsAboveIfs.java
@@ -39,7 +39,7 @@ public class MoveLoadsAboveIfs extends BodyTransformer  implements IJbcoTransfor
   
   public static String dependancies[] = new String[] {"bb.jbco_rlaii", "bb.jbco_ful", "bb.lp"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/RemoveRedundantPushStores.java
+++ b/src/main/java/soot/jbco/bafTransformations/RemoveRedundantPushStores.java
@@ -17,7 +17,7 @@ public class RemoveRedundantPushStores extends BodyTransformer implements IJbcoT
   
   public static String dependancies[] = new String[] {"bb.jbco_rrps"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/TryCatchCombiner.java
+++ b/src/main/java/soot/jbco/bafTransformations/TryCatchCombiner.java
@@ -35,7 +35,7 @@ public class TryCatchCombiner extends BodyTransformer implements IJbcoTransform 
   
   public static String dependancies[] = new String[] {"bb.jbco_j2bl", "bb.jbco_ctbcb", "bb.jbco_ful", "bb.lp" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/bafTransformations/UpdateConstantsToFields.java
+++ b/src/main/java/soot/jbco/bafTransformations/UpdateConstantsToFields.java
@@ -36,7 +36,7 @@ public class UpdateConstantsToFields extends BodyTransformer  implements IJbcoTr
 
   public static String dependancies[] = new String[] {"wjtp.jbco_cc","bb.jbco_ecvf", "bb.jbco_ful", "bb.lp"};
   
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   public static String name = "bb.jbco_ecvf";

--- a/src/main/java/soot/jbco/bafTransformations/WrapSwitchesInTrys.java
+++ b/src/main/java/soot/jbco/bafTransformations/WrapSwitchesInTrys.java
@@ -37,7 +37,7 @@ public class WrapSwitchesInTrys extends BodyTransformer implements IJbcoTransfor
   
   public static String dependancies[] = new String[] {"bb.jbco_ptss", "bb.jbco_ful", "bb.lp" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/jimpleTransformations/AddSwitches.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/AddSwitches.java
@@ -46,7 +46,7 @@ public class AddSwitches extends BodyTransformer implements IJbcoTransform {
 
   public static String dependancies[] = new String[] { "wjtp.jbco_fr", "jtp.jbco_adss", "bb.jbco_ful"};
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/ArithmeticTransformer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/ArithmeticTransformer.java
@@ -70,7 +70,7 @@ public class ArithmeticTransformer extends BodyTransformer implements IJbcoTrans
     public static String dependancies[] = new String[]{"jtp.jbco_cae2bo"};
     public static String name = "jtp.jbco_cae2bo";
 
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
@@ -79,7 +79,7 @@ public class BuildIntermediateAppClasses extends SceneTransformer implements IJb
 
     public static String dependancies[] = new String[]{"wjtp.jbco_bapibm"};
 
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/ClassRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/ClassRenamer.java
@@ -113,7 +113,7 @@ public class ClassRenamer extends SceneTransformer implements IJbcoTransform {
     }
 
     @Override
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/CollectConstants.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/CollectConstants.java
@@ -73,7 +73,7 @@ public class CollectConstants extends SceneTransformer implements IJbcoTransform
 
     public static String dependancies[] = new String[]{"wjtp.jbco_cc"};
 
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/CollectJimpleLocals.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/CollectJimpleLocals.java
@@ -37,7 +37,7 @@ public class CollectJimpleLocals extends BodyTransformer implements
 
 	public static String dependancies[] = new String[] { "jtp.jbco_jl" };
 
-	public String[] getDependancies() {
+	public String[] getDependencies() {
 		return dependancies;
 	}
 

--- a/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
@@ -67,7 +67,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
 
     public static String dependancies[] = new String[]{"wjtp.jbco_fr"};
 
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jbco/jimpleTransformations/GotoInstrumenter.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/GotoInstrumenter.java
@@ -38,7 +38,7 @@ public class GotoInstrumenter extends BodyTransformer implements IJbcoTransform 
 
   public static String dependancies[] = new String[] { "jtp.jbco_gia" };
 
-  public String[] getDependancies() {
+  public String[] getDependencies() {
     return dependancies;
   }
   

--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -64,7 +64,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
         return name;
     }
 
-    public String[] getDependancies() {
+    public String[] getDependencies() {
         return dependancies;
     }
 

--- a/src/main/java/soot/jimple/InvokeExpr.java
+++ b/src/main/java/soot/jimple/InvokeExpr.java
@@ -19,29 +19,54 @@
  */
 
 /*
- * Modified by the Sable Research Group and others 1997-1999.  
+ * Modified by the Sable Research Group and others 1997-1999.
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
  */
 
-
-
-
-
 package soot.jimple;
 
-import soot.*;
-import java.util.*;
+import soot.SootMethod;
+import soot.SootMethodRef;
+import soot.Value;
+import soot.ValueBox;
 
-public interface InvokeExpr extends Expr
-{
-    public void setMethodRef(SootMethodRef smr);
-    public SootMethodRef getMethodRef();
-    public SootMethod getMethod();
-    public List<Value> getArgs();
-    public Value getArg(int index);
-    public int getArgCount();
-    public void setArg(int index, Value arg);
-    public ValueBox getArgBox(int index);
-    public Type getType();
+import java.util.List;
+
+/**
+ * Represents method invocation expression.
+ *
+ * @see VirtualInvokeExpr invokevirtual
+ * @see InterfaceInvokeExpr invokeinterface
+ * @see SpecialInvokeExpr invokespecial
+ * @see StaticInvokeExpr invokestatic
+ * @see DynamicInvokeExpr invokedynamic
+ */
+public interface InvokeExpr extends Expr {
+
+    void setMethodRef(SootMethodRef smr);
+
+    SootMethodRef getMethodRef();
+
+    /**
+     * Resolves {@link SootMethodRef} to {@link SootMethod}.
+     *
+     * @return {@link SootMethod} instance, or {@code null} when reference cannot be resolved and
+     * {@link soot.options.Options#ignore_resolution_errors} is {@code true}
+     * @throws soot.SootMethodRefImpl.ClassResolutionFailedException when reference cannot be resolved and  {@link
+     *                                                               soot.options.Options#ignore_resolution_errors}
+     *                                                               is {@code false}
+     */
+    SootMethod getMethod();
+
+    List<Value> getArgs();
+
+    Value getArg(int index);
+
+    int getArgCount();
+
+    void setArg(int index, Value arg);
+
+    ValueBox getArgBox(int index);
+
 }


### PR DESCRIPTION
Fixed `soot.jbco.jimpleTransformations.LibraryMethodWrappersBuilder` that could produce incomplete methods.
Let's pretend we have the following code:
```java
public class CustomWatcher implements android.text.TextWatcher {
    // code
    @Override
    public void afterTextChanged(android.text.Editable editable) {
        if (editable.toString().equals("something")) {
            return;
        }
        // code
    }
}
```
Expression `editable.toString()` is `invokeinterface`. Method `soot.jimple.InvokeExpr#getMethod` returns `Object#toString()` that is absolutely correct because jar was compiled with `android-api.jar` (not the implementation). So in this case expression `editable.toString()` is not `invokeinterface` anymore, but `invokevirtual`. But `LibraryMethodWrappersBuilder` treated it as `invokeinterface` that led to runtime exception. As exception was ignored the transformer left new generated method incomplete.
Another problem in this case is incorrect treating with API methods: if we allow `LibraryMethodWrappersBuilder` replace `invokeinterface` with `invokevirtual` that will lead to replacing `android.text.Editable#toString()` with `Object#toString()` that is wrong.
So my solution is checking if we "lose" interface (and find class instead) and skip this transformation

---
Also I added `@Deprecated` annotation to `soot.jbco.IJbcoTransform#out` (will be replace with logger), `soot.jbco.IJbcoTransform#output` (added `soot.jbco.IJbcoTransform#isVerbose` method that gets state at runtime) and `soot.jbco.IJbcoTransform#debug`  (added `soot.jbco.IJbcoTransform#isDebugEnabled` method that gets state at runtime)