### PR TITLE
Fixing soot.jbco.jimpleTransformations.MethodRenamer

### DIFF
--- a/src/main/generated/singletons/soot/Singletons.java
+++ b/src/main/generated/singletons/soot/Singletons.java
@@ -23,7 +23,7 @@
 package soot;
 
 /** A class to group together all the global variables in Soot. */
-@javax.annotation.Generated(value = "Saxonica v3.0", date = "2018-03-20T19:12:30.663+01:00", comments = "from singletons.xml")
+@javax.annotation.Generated(value = "Saxonica v3.0", date = "2018-03-23T12:42:25.891+03:00", comments = "from singletons.xml")
 public class Singletons {
 
     public final class Global {
@@ -2382,5 +2382,19 @@ public class Singletons {
     }
     protected void release_soot_jbco_jimpleTransformations_ClassRenamer() {
     	instance_soot_jbco_jimpleTransformations_ClassRenamer = null;
+    }
+
+    private soot.jbco.jimpleTransformations.MethodRenamer instance_soot_jbco_jimpleTransformations_MethodRenamer;
+    public soot.jbco.jimpleTransformations.MethodRenamer soot_jbco_jimpleTransformations_MethodRenamer() {
+        if (instance_soot_jbco_jimpleTransformations_MethodRenamer == null) {
+	       	synchronized (this) {
+		        if (instance_soot_jbco_jimpleTransformations_MethodRenamer == null)
+	        		instance_soot_jbco_jimpleTransformations_MethodRenamer = new soot.jbco.jimpleTransformations.MethodRenamer(g);
+	       	}
+       	}
+        return instance_soot_jbco_jimpleTransformations_MethodRenamer;
+    }
+    protected void release_soot_jbco_jimpleTransformations_MethodRenamer() {
+    	instance_soot_jbco_jimpleTransformations_MethodRenamer = null;
     }
 }

--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -18,33 +18,10 @@
  */
 
 package soot;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.jar.JarEntry;
-import java.util.jar.JarOutputStream;
-import java.util.zip.GZIPOutputStream;
-import java.util.zip.ZipEntry;
-// [AM]
-//import soot.javaToJimple.toolkits.*;
 
 import heros.solver.CountingThreadPoolExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import soot.baf.Baf;
 import soot.baf.BafASMBackend;
 import soot.baf.BafBody;
@@ -138,6 +115,27 @@ import soot.util.JasminOutputStream;
 import soot.util.PhaseDumper;
 import soot.xml.TagCollector;
 import soot.xml.XMLPrinter;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
 
 /** Manages the Packs containing the various phases and their options. */
 public class PackManager {
@@ -898,15 +896,14 @@ public class PackManager {
 	private void runBodyPacks(SootClass c) {
 		final int format = Options.v().output_format();
 		if (format == Options.output_format_dava) {
-			logger.debug("Decompiling ");
+			logger.debug("Decompiling {}...", c.getName());
 
 			// January 13th, 2006 SootMethodAddedByDava is set to false for
 			// SuperFirstStmtHandler
 			G.v().SootMethodAddedByDava = false;
 		} else {
-			logger.debug("Transforming ");
+			logger.debug("Transforming {}...", c.getName());
 		}
-		logger.debug(""+c.getName() + "... ");
 
 		boolean produceBaf = false, produceGrimp = false, produceDava = false, produceJimple = true,
 				produceShimple = false;

--- a/src/main/java/soot/SootMethod.java
+++ b/src/main/java/soot/SootMethod.java
@@ -355,7 +355,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
 			throw new RuntimeException("cannot get active body for phantom class: " + getSignature());
 
 		// ignore empty body exceptions if we are just computing coffi metrics
-		if (!soot.jbco.Main.metrics && !hasActiveBody())
+		if (!soot.jbco.Main.metrics)
 			throw new RuntimeException("no active body present for method " + getSignature());
 
 		return activeBody;

--- a/src/main/java/soot/jbco/Main.java
+++ b/src/main/java/soot/jbco/Main.java
@@ -365,7 +365,7 @@ public class Main {
     if (name.equals("wjtp.jbco_fr"))
       return new FieldRenamer();
     if (name.equals("wjtp.jbco_mr"))
-      return new MethodRenamer();
+      return MethodRenamer.v();
     if (name.equals("jtp.jbco_adss"))
       return new AddSwitches();
     if (name.equals("jtp.jbco_jl"))

--- a/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
@@ -163,7 +163,7 @@ public class BuildIntermediateAppClasses extends SceneTransformer implements IJb
                     int modifiers = originalSuperclassMethod.getModifiers() & ~Modifier.ABSTRACT & ~Modifier.NATIVE;
                     SootMethod newMethod;
                     { // build new junk method to call original method
-                        String newMethodName = MethodRenamer.getNewName();
+                        String newMethodName = MethodRenamer.v().getNewName();
                         newMethod = Scene.v().makeSootMethod(newMethodName, paramTypes, returnType,
                                 modifiers, exceptions);
                         mediatingClass.addMethod(newMethod);

--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -45,7 +45,6 @@ import soot.jbco.util.BodyBuilder;
 import soot.jbco.util.HierarchyUtils;
 import soot.jbco.util.Rand;
 import soot.jimple.InvokeExpr;
-import soot.options.Options;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -198,8 +197,6 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
 
     @Override
     protected void internalTransform(String phaseName, Map<String, String> options) {
-        Options.v().set_verbose(true);
-
         if (isVerbose()) {
             logger.info("Transforming method names...");
         }
@@ -351,8 +348,6 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
                 }
             }
         }
-
-        Options.v().set_verbose(false);
 
         Scene.v().releaseActiveHierarchy();
         Scene.v().setFastHierarchy(new FastHierarchy());

--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -19,141 +19,295 @@
 
 package soot.jbco.jimpleTransformations;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import soot.ArrayType;
 import soot.Body;
 import soot.FastHierarchy;
 import soot.G;
-import soot.Hierarchy;
+import soot.RefType;
 import soot.Scene;
 import soot.SceneTransformer;
+import soot.Singletons;
 import soot.SootClass;
 import soot.SootField;
 import soot.SootMethod;
 import soot.SootMethodRef;
+import soot.Type;
 import soot.Unit;
 import soot.Value;
 import soot.ValueBox;
+import soot.VoidType;
 import soot.jbco.IJbcoTransform;
+import soot.jbco.name.JunkNameGenerator;
+import soot.jbco.name.NameGenerator;
 import soot.jbco.util.BodyBuilder;
 import soot.jbco.util.HierarchyUtils;
 import soot.jbco.util.Rand;
 import soot.jimple.InvokeExpr;
+import soot.options.Options;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 /**
- * @author Michael Batchelder
+ * Creates new method names using names of fields or generates randomly. New names are <strong>unique</strong>
+ * through the whole application.
  * <p>
- * Created on 24-Jan-2006
+ * Some methods cannot be renamed:
+ * <ul>
+ * <li>{@code main} methods</li>
+ * <li>constructors</li>
+ * <li>static initializers</li>
+ * </ul>
+ * (these methods are filtered by names)
+ * <ul>
+ * <li>ones that override/implement library methods</li>
+ * </ul>
+ * <p>
+ * To find methods from last group the next approach is used. All superclasses and interfaces that processing class
+ * extends / implements are collected. The children of that items are taken and united together along with processing
+ * class. The same action is performed for every item of the obtained result until the full "tree" is not created.
+ * Then from this tree, the classes that do not have methods with <similar>similar</similar> to searching signature,
+ * are removed. The left items that have {@link SootClass#isLibraryClass()} {@code true} are searching ones.
+ * <p>
+ * This complex approach is used to detect <i>indirect</i> inheritance. Consider next example:
+ * <pre>
+ *                            ,--------.
+ *                            |A       |
+ *                            |--------|
+ *                            |--------|
+ *                            |method()|
+ *                            `--------'
+ *                              /    \
+ *                             /      \
+ * ,-----------------------------.  ,--------.       ,--------. ,--------------------------------.
+ * |D                            |  |B       |       |E       | | Note: E is a library interface |
+ * |-----------------------------|  |--------|       |--------| `--------------------------------'
+ * |-----------------------------|  |--------|       |--------|
+ * |method()                     |  |method()|       |method()|
+ * |method(java.lang.String, int)|  `--------'       `--------'
+ * `-----------------------------'           \      /
+ *                                  ,------------------------.
+ *                                  |C                       |
+ *                                  |------------------------|
+ *                                  |------------------------|
+ *                                  |method()                |
+ *                                  |method(java.lang.String)|
+ *                                  |method(long, int)       |
+ *                                  `------------------------'
+ * </pre>
+ * Thus when {@code D#method()} is processed, it must not be renamed as there is class {@code C} that implements
+ * library one ({@code E#method()}).
+ * <p>
+ * After applying this transformer the next result is expected:
+ * <ul>
+ * <li>{@code #method()} is not renamed in any application classes as it overrides one from library</li>
+ * <li>{@code #method(java.lang.String)}, {@code #method(long, int)} and {@code #method(java.lang.String, int)} are
+ * renamed and have the <strong>same</strong> name. Such renaming behaviour allows having <i>renaming map</i> for
+ * every class with old method name as a key and new method name as a value</li>
+ * </ul>
+ *
+ * @author Michael Batchelder, Pavel Nesterovich
+ * @since 24-Jan-2006
  */
 public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
 
-    public static String name = "wjtp.jbco_mr";
-    public static String dependancies[] = new String[]{"wjtp.jbco_mr"};
+    private static final Logger logger = LoggerFactory.getLogger(MethodRenamer.class);
 
-    public static Map<String, String> oldToNewMethodNames = new HashMap<>();
+    public static final String name = "wjtp.jbco_mr";
+    public static final String dependencies[] = new String[]{MethodRenamer.name};
 
-    private static final char stringChars[][] = {{'S', '5', '$'}, {'l', '1', 'I'}, {'_'}};
-    private static Hierarchy hierarchy;
+    private static final String MAIN_METHOD_SUB_SIGNATURE = SootMethod.getSubSignature(
+            "main", singletonList(ArrayType.v(RefType.v("java.lang.String"), 1)), VoidType.v());
 
+    private static final Function<SootClass, Map<String, String>> RENAMING_MAP_CREATOR = key -> new HashMap<>();
+
+    private final Map<SootClass, Map<String, String>> classToRenamingMap = new HashMap<>();
+
+    private final NameGenerator nameGenerator;
+
+    /**
+     * Singleton constructor.
+     *
+     * @param global the singletons container. Must not be {@code null}
+     * @throws NullPointerException when {@code global} argument is {@code null}
+     */
+    public MethodRenamer(Singletons.Global global) {
+        if (global == null) {
+            throw new NullPointerException("Cannot instantiate MethodRenamer with null Singletons.Global");
+        }
+
+        nameGenerator = new JunkNameGenerator();
+    }
+
+    /**
+     * Singleton getter.
+     *
+     * @return returns instance of {@link MethodRenamer}
+     */
+    public static MethodRenamer v() {
+        return G.v().soot_jbco_jimpleTransformations_MethodRenamer();
+    }
+
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String[] getDependencies() {
-        return dependancies;
+        return Arrays.copyOf(dependencies, dependencies.length);
     }
 
+    @Override
     public void outputSummary() {
+        final Integer newNames = classToRenamingMap.values().stream().map(Map::values)
+                .flatMap(Collection::stream).collect(collectingAndThen(toSet(), Set::size));
+        logger.info("{} methods were renamed.", newNames);
     }
 
+    /**
+     * Gets renaming map for specific class.
+     *
+     * @param className the name of class to get renaming map for
+     * @return the map where the key is old method name, the value - new method name. Never {@code null}
+     */
+    public Map<String, String> getRenamingMap(String className) {
+        return classToRenamingMap.entrySet().stream()
+                .filter(entry -> entry.getKey().getName().equals(className))
+                .flatMap(entry -> entry.getValue().entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
     protected void internalTransform(String phaseName, Map<String, String> options) {
-        if (output) {
-            out.println("Transforming Method Names...");
+        Options.v().set_verbose(true);
+
+        if (isVerbose()) {
+            logger.info("Transforming method names...");
         }
 
         BodyBuilder.retrieveAllBodies();
         BodyBuilder.retrieveAllNames();
 
-        Scene scene = G.v().soot_Scene();
-        scene.releaseActiveHierarchy();
-        hierarchy = scene.getActiveHierarchy();
+        Scene.v().releaseActiveHierarchy();
 
-        // iterate through application classes, rename methods with junk
-        for (SootClass sc : scene.getApplicationClasses()) {
-            List<String> fieldNames = sc.getFields().stream().map(SootField::getName).collect(toList());
-            List<SootMethod> methods = new ArrayList<>(sc.getMethods());
+        // iterate through application classes and create new junk names
+        // but DO NOT RENAME METHODS YET as it might break searching of declaring classes
+        for (SootClass applicationClass : Scene.v().getApplicationClasses()) {
+            final List<String> fieldNames = applicationClass.getFields().stream().map(SootField::getName)
+                    .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+            final List<String> leftFieldNames = new ArrayList<>(fieldNames);
 
+            // create local copy to avoid ConcurrentModificationException -- methods are being updated
+            final List<SootMethod> methods = new ArrayList<>(applicationClass.getMethods());
             for (SootMethod method : methods) {
-                String subSig = method.getSubSignature();
 
-                if (!allowsRename(sc, method)) {
+                if (!isRenamingAllowed(method)) {
                     continue;
                 }
 
-                boolean rename = true;
-                //use getSuperclassesOfIncluding instead of getSuperclassesOf to avoid problems when sc is an interface
-                for (SootClass c : hierarchy.getSuperclassesOfIncluding(sc.getSuperclass())) {
-                    if (c.declaresMethod(subSig)
-                            && hierarchy.isVisible(sc, c.getMethod(subSig))
-                            && c.isLibraryClass()) {
-                        if (output) {
-                            out.println("\t" + c.getName() + "'s method "
-                                    + subSig + " is overridden in "
-                                    + sc.getName());
+                final Set<SootClass> declaringClasses = getDeclaringClasses(applicationClass, method);
+                if (declaringClasses.isEmpty()) {
+                    throw new IllegalStateException("Cannot find classes that declare " + method.getSignature() + ".");
+                }
+
+                final Optional<SootClass> libraryClass = declaringClasses.stream()
+                        .filter(SootClass::isLibraryClass).findAny();
+                if (libraryClass.isPresent()) {
+                    if (isVerbose()) {
+                        logger.info("Skipping renaming {} method as it overrides library one from {}.",
+                                method.getSignature(), libraryClass.get().getName());
+                    }
+
+                    continue;
+                }
+
+                // we unite declaringClasses with parents of application class (excluding library ones)
+                // to be sure that every class in this hierarchy has the only new name
+                // for all methods (in this hierarchy) with the same old name and different parameters
+                final Set<SootClass> union = uniteWithApplicationParents(applicationClass, declaringClasses);
+
+                String newName = getNewName(union, method.getName());
+                if (newName == null) {
+                    if (leftFieldNames.isEmpty()) {
+                        newName = getNewName();
+                    } else {
+                        final int randomIndex = Rand.getInt(leftFieldNames.size());
+                        final String randomFieldName = leftFieldNames.remove(randomIndex);
+
+                        // check both value and existing methods, if class already contains method and field with
+                        // same name then we likely will fall in trouble when renaming this method before previous
+                        if (isNotUnique(randomFieldName) || fieldNames.contains(randomFieldName)) {
+                            newName = getNewName();
+                        } else {
+                            newName = randomFieldName;
                         }
-                        rename = false;
-                        break;
                     }
                 }
 
-                if (rename) {
-                    // TODO: This is flawed since it all methods of a similar
-                    // name will get same name
-                    String newName = oldToNewMethodNames.get(method.getName());
-                    if (newName == null) {
-                        if (!fieldNames.isEmpty()) {
-                            int rand = Rand.getInt(fieldNames.size());
-                            final String randomFieldName = fieldNames.remove(rand);
-                            //check both value and existing methods, if class already contains method and field with
-                            // same name then we likely will fall in trouble when renaming this method before previous
-                            if (oldToNewMethodNames.containsValue(randomFieldName)
-                                    || sc.getMethods().stream().anyMatch(m -> randomFieldName.equals(m.getName()))) {
-                                newName = getNewName();
-                            } else {
-                                newName = randomFieldName;
-                            }
-                        } else {
-                            newName = getNewName();
-                        }
-                        oldToNewMethodNames.put(method.getName(), newName);
+                // It is important to share renaming between different class trees as they might be intersecting.
+                // For example, pretend we have class tree (A,B) with renaming ["aa"=>"bb", "cc"=>"dd"].
+                // When we receive tree (B,C) with method "aa" and realize that (B,C) ∩ (A,B),
+                // we not just skip generating new name but share mapping ["aa"=>"bb"] of tree (A,B)
+                // with tree (B,C). As a result we will have (B,C) with mapping ["aa"=>"bb"].
+                // We share this to handle case when the methods are renamed and it is impossible to get
+                // this indirect connection between classes (with A and C in example above), we will still be able
+                // to rename methods (and their calls) correctly
+                for (SootClass declaringClass : union) {
+                    classToRenamingMap
+                            .computeIfAbsent(declaringClass, RENAMING_MAP_CREATOR)
+                            .put(method.getName(), newName);
+                }
+            }
+        }
+
+        // rename methods AFTER creating mapping
+        for (SootClass applicationClass : Scene.v().getApplicationClasses()) {
+            final List<SootMethod> methods = new ArrayList<>(applicationClass.getMethods());
+            for (SootMethod method : methods) {
+                final String newName = getNewName(Collections.singleton(applicationClass), method.getName());
+                if (newName != null) {
+                    if (isVerbose()) {
+                        logger.info("Method \"{}\" is being renamed to \"{}\".", method.getSignature(), newName);
                     }
-                    if (output) {
-                        out.println("\tChanged " + method.getSignature() + " to " + newName);
-                    }
+
                     method.setName(newName);
                 }
             }
         }
 
         // iterate through application classes, update references of renamed methods
-        for (SootClass c : scene.getApplicationClasses()) {
-            final List<SootMethod> methods = new ArrayList<>(c.getMethods());
-            for (SootMethod m : methods) {
-                if (!m.isConcrete() || m.getDeclaringClass().isLibraryClass()) {
+        for (SootClass applicationClass : Scene.v().getApplicationClasses()) {
+            final List<SootMethod> methods = new ArrayList<>(applicationClass.getMethods());
+            for (SootMethod method : methods) {
+
+                if (!method.isConcrete() || method.getDeclaringClass().isLibraryClass()) {
                     continue;
                 }
-                Body body;
-                try {
-                    body = m.getActiveBody();
-                } catch (Exception exc) {
-                    // no active body present
+
+                final Body body = getActiveBodySafely(method);
+                if (body == null) {
                     continue;
                 }
+
                 for (Unit unit : body.getUnits()) {
                     for (ValueBox valueBox : unit.getUseBoxes()) {
                         Value v = valueBox.getValue();
@@ -161,117 +315,235 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
                             continue;
                         }
 
-                        InvokeExpr invokeExpr = (InvokeExpr) v;
-                        SootMethodRef methodRef = invokeExpr.getMethodRef();
+                        final InvokeExpr invokeExpr = (InvokeExpr) v;
+                        final SootMethodRef methodRef = invokeExpr.getMethodRef();
 
-                        // if the method won't be resolved in declaring class by subsignature of method ref,
-                        // then we know it was renamed and update that method ref with new name
-                        if (isAbleToResolve(methodRef)) {
+                        final Set<SootClass> parents = getParents(methodRef.declaringClass());
+
+                        // 1. we check if method overrides one from library directly
+                        // Note: we cannot use getDeclaringClasses(applicationClass, method) as method can be renamed
+                        final Optional<SootClass> declaringLibraryClass = findDeclaringLibraryClass(parents, methodRef);
+                        if (declaringLibraryClass.isPresent()) {
+                            if (isVerbose()) {
+                                logger.info("Skipping replacing method call \"{}\" in \"{}\" as it is overrides one "
+                                                + " from library {}.", methodRef.getSignature(), method.getSignature(),
+                                        declaringLibraryClass.get().getName());
+                            }
                             continue;
                         }
 
-                        String newName = oldToNewMethodNames.get(methodRef.name());
+                        final String newName = getNewName(parents, methodRef.name());
+                        // 2. we indirectly check that method is not overrides one from library indirectly:
+                        // we will get new name only if no one from class tree do not overrides library method
                         if (newName == null) {
                             continue;
                         }
 
-                        methodRef = scene.makeMethodRef(methodRef.declaringClass(), newName,
-                                methodRef.parameterTypes(), methodRef.returnType(),
-                                methodRef.isStatic());
-                        invokeExpr.setMethodRef(methodRef);
+                        final SootMethodRef newMethodRef = Scene.v().makeMethodRef(methodRef.declaringClass(), newName,
+                                methodRef.parameterTypes(), methodRef.returnType(), methodRef.isStatic());
+                        invokeExpr.setMethodRef(newMethodRef);
+
+                        if (isVerbose()) {
+                            logger.info("Method call \"{}\" is being replaced with \"{}\" in {}.",
+                                    methodRef.getSignature(), newMethodRef.getSignature(), method.getSignature());
+                        }
                     }
                 }
             }
         }
 
-        scene.releaseActiveHierarchy();
-        scene.getActiveHierarchy();
-        scene.setFastHierarchy(new FastHierarchy());
+        Options.v().set_verbose(false);
+
+        Scene.v().releaseActiveHierarchy();
+        Scene.v().setFastHierarchy(new FastHierarchy());
+
+        if (isVerbose()) {
+            logger.info("Transforming method names is completed.");
+        }
     }
 
-    /*
-     * @return String newly generated junk name that DOES NOT exist yet
+    /**
+     * Creates new <strong>unique</strong> method name.
+     *
+     * @return newly generated junk name that DOES NOT exist yet
      */
-    public static String getNewName() {
+    public String getNewName() {
         int size = 5;
         int tries = 0;
-        int index = Rand.getInt(stringChars.length);
-        int length = stringChars[index].length;
 
-        String result;
-        char cNewName[] = new char[size];
-        do {
-            if (tries == size) {
-                cNewName = new char[++size];
+        String newName = nameGenerator.generateName(size);
+
+        while (isNotUnique(newName) || BodyBuilder.nameList.contains(newName)) {
+            if (tries++ > size) {
+                size++;
                 tries = 0;
             }
 
-            do {
-                cNewName[0] = stringChars[index][Rand.getInt(length)];
-            } while (!Character.isJavaIdentifierStart(cNewName[0]));
+            newName = nameGenerator.generateName(size);
+        }
 
-            // generate random string
-            for (int i = 1; i < cNewName.length; i++) {
-                int rand = Rand.getInt(length);
-                cNewName[i] = stringChars[index][rand];
-            }
+        BodyBuilder.nameList.add(newName);
 
-            result = String.copyValueOf(cNewName);
-            tries++;
-        } while (oldToNewMethodNames.containsValue(result) || BodyBuilder.nameList.contains(result));
-
-        BodyBuilder.nameList.add(result);
-
-        return result;
+        return newName;
     }
 
-    private static boolean allowsRename(SootClass sc, SootMethod method) {
+    private boolean isRenamingAllowed(SootMethod method) {
         if (soot.jbco.Main.getWeight(MethodRenamer.name, method.getName()) == 0) {
             return false;
         }
 
-        String subSig = method.getSubSignature();
-        if ("void main(java.lang.String[])".equals(subSig) && method.isPublic() && method.isStatic()) {
-            return false; // skip the main method - it needs to be named 'main'
-        } else if (subSig.contains(SootMethod.constructorName) || subSig.contains(SootMethod.staticInitializerName)) {
-            return false; // skip constructors for now
-        } else {
-            return !(isOverriddenLibraryInterfaceMethod(sc, method)
-                    || isOverriddenLibrarySuperclassMethod(sc, method)
-                    || isOverriddenLibraryMethodWithinAllChildren(sc, method));
+        final String subSignature = method.getSubSignature();
+        if (MAIN_METHOD_SUB_SIGNATURE.equals(subSignature) && method.isPublic() && method.isStatic()) {
+            if (isVerbose()) {
+                logger.info("Skipping renaming \"{}\" method as it is main one.", subSignature);
+            }
+            return false; // skip the main method
         }
+
+        if (method.getName().equals(SootMethod.constructorName)
+                || method.getName().equals(SootMethod.staticInitializerName)) {
+            if (isVerbose()) {
+                logger.info("Skipping renaming \"{}\" method as it is constructor or static initializer.",
+                        subSignature);
+            }
+            return false; // skip constructors/initializers
+        }
+
+        return true;
     }
 
-    private static boolean isAbleToResolve(SootMethodRef methodRef) {
-        SootClass declaringClass = methodRef.declaringClass();
-        return declaringClass.getMethodUnsafe(methodRef.getSubSignature()) != null
-                || hierarchy.getSuperclassesOfIncluding(declaringClass.getSuperclass()).stream()
-                .filter(c -> c.declaresMethod(methodRef.getSubSignature()))
-                .anyMatch(c -> hierarchy.isVisible(declaringClass, c.getMethod(methodRef.getSubSignature())))
-                || HierarchyUtils.getAllInterfacesOf(declaringClass).stream()
-                .anyMatch(c -> c.declaresMethod(methodRef.name(), methodRef.parameterTypes(), methodRef.returnType()));
+    private boolean isNotUnique(String methodName) {
+        return classToRenamingMap.values()
+                .stream().map(Map::values).flatMap(Collection::stream).anyMatch(methodName::equals);
     }
 
-    private static boolean isOverriddenLibrarySuperclassMethod(SootClass sc, SootMethod method) {
-        String subSignature = method.getSubSignature();
-        //use getSuperclassesOfIncluding instead of getSuperclassesOf to avoid problems when 'sc' parameter is interface
-        return hierarchy.getSuperclassesOfIncluding(sc.getSuperclass()).stream()
+    private Set<SootClass> uniteWithApplicationParents(SootClass applicationClass, Collection<SootClass> classes) {
+        final Set<SootClass> parents = getApplicationParents(applicationClass);
+
+        final Set<SootClass> result = new HashSet<>(parents.size() + classes.size());
+        result.addAll(parents);
+        result.addAll(classes);
+
+        return result;
+    }
+
+    private Optional<SootClass> findDeclaringLibraryClass(Collection<SootClass> classes, SootMethodRef methodRef) {
+        return classes.stream()
                 .filter(SootClass::isLibraryClass)
-                .filter(c -> c.declaresMethod(subSignature))
-                .anyMatch(c -> hierarchy.isVisible(sc, c.getMethod(subSignature)));
+                .filter(sootClass -> isDeclared(sootClass, methodRef.name(), methodRef.parameterTypes()))
+                .findAny();
     }
 
-    private static boolean isOverriddenLibraryInterfaceMethod(SootClass sc, SootMethod method) {
-        return HierarchyUtils.getAllInterfacesOf(sc).stream()
-                .filter(SootClass::isLibraryClass)
-                .anyMatch(c -> c.declaresMethod(method.getName(), method.getParameterTypes(), method.getReturnType()));
+    private Set<SootClass> getDeclaringClasses(SootClass applicationClass, SootMethod method) {
+        return getTree(applicationClass).stream()
+                .filter(sootClass -> isDeclared(sootClass, method.getName(), method.getParameterTypes()))
+                .collect(toSet());
     }
 
-    private static boolean isOverriddenLibraryMethodWithinAllChildren(SootClass sc, SootMethod method) {
-        final List<SootClass> subClasses = sc.isInterface()
-                ? hierarchy.getImplementersOf(sc) : hierarchy.getSubclassesOf(sc);
-        return subClasses.stream().anyMatch(
-                c -> isOverriddenLibraryInterfaceMethod(c, method) || isOverriddenLibrarySuperclassMethod(c, method));
+    private Set<SootClass> getTree(SootClass applicationClass) {
+        final Set<SootClass> children = getChildrenOfIncluding(getParentsOfIncluding(applicationClass));
+
+        int count = 0;
+        do {
+            count = children.size();
+            children.addAll(getChildrenOfIncluding(getParentsOfIncluding(children)));
+        } while (count < children.size());
+
+        return children;
+    }
+
+    private Set<SootClass> getParents(SootClass applicationClass) {
+        final Set<SootClass> parents = new HashSet<>(getParentsOfIncluding(applicationClass));
+
+        int count = 0;
+        do {
+            count = parents.size();
+            parents.addAll(getParentsOfIncluding(parents));
+        } while (count < parents.size());
+
+        return parents;
+    }
+
+    private Set<SootClass> getApplicationParents(SootClass applicationClass) {
+        return getParents(applicationClass).stream().filter(parent -> !parent.isLibraryClass()).collect(toSet());
+    }
+
+    private List<SootClass> getParentsOfIncluding(SootClass applicationClass) {
+        // result contains of interfaces that implements passed applicationClass
+        final List<SootClass> result = HierarchyUtils.getAllInterfacesOf(applicationClass);
+
+        // and superclasses (superinterfaces) of passed applicationClass
+        result.addAll(applicationClass.isInterface()
+                ? Scene.v().getActiveHierarchy().getSuperinterfacesOfIncluding(applicationClass)
+                : Scene.v().getActiveHierarchy().getSuperclassesOfIncluding(applicationClass)
+        );
+
+        return result;
+    }
+
+    private Set<SootClass> getChildrenOfIncluding(Collection<SootClass> classes) {
+        return Stream.concat(
+                classes.stream()
+                        .filter(c -> !c.getName().equals("java.lang.Object"))
+                        .map(c -> c.isInterface()
+                                ? Scene.v().getActiveHierarchy().getImplementersOf(c)
+                                : Scene.v().getActiveHierarchy().getSubclassesOf(c)
+                        ).flatMap(Collection::stream),
+                classes.stream()
+        ).collect(toSet());
+    }
+
+    private Set<SootClass> getParentsOfIncluding(Collection<SootClass> classes) {
+        return classes.stream().map(sootClass -> sootClass.isInterface()
+                ? Scene.v().getActiveHierarchy().getSuperinterfacesOfIncluding(sootClass)
+                : Scene.v().getActiveHierarchy().getSuperclassesOfIncluding(sootClass))
+                .flatMap(Collection::stream).collect(toSet());
+    }
+
+    private String getNewName(Collection<SootClass> classes, String name) {
+        final Set<String> names = classToRenamingMap.entrySet().stream()
+                .filter(entry -> classes.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .map(Map::entrySet)
+                .flatMap(Collection::stream)
+                .filter(entry -> entry.getKey().equals(name))
+                .map(Map.Entry::getValue)
+                .collect(toSet());
+
+        if (names.size() > 1) {
+            logger.warn("Found {} names for method \"{}\": {}.", names.size(), name, String.join(", ", names));
+        }
+
+        return names.isEmpty() ? null : names.iterator().next();
+    }
+
+    /**
+     * Checks that method is declared in class. We assume that method is declared in class if class
+     * contains method with the same name and the same number of arguments. The exact types are not compared.
+     *
+     * @param sootClass      the class to search in
+     * @param methodName     the searching method name
+     * @param parameterTypes the searching method parameters
+     * @return {@code true} if passed class contains similar method; {@code false} otherwise
+     */
+    private boolean isDeclared(SootClass sootClass, String methodName, List<Type> parameterTypes) {
+        for (SootMethod declared : sootClass.getMethods()) {
+            if (declared.getName().equals(methodName) && declared.getParameterCount() == parameterTypes.size()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Body getActiveBodySafely(SootMethod method) {
+        try {
+            return method.getActiveBody();
+        } catch (Exception exception) {
+            logger.warn("Getting Body from SootMethod {} caused exception that was suppressed.", exception);
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/soot/jbco/name/JunkNameGenerator.java
+++ b/src/main/java/soot/jbco/name/JunkNameGenerator.java
@@ -1,0 +1,41 @@
+package soot.jbco.name;
+
+import soot.jbco.util.Rand;
+
+/**
+ * Implementation that generates names consisting of hard recognizable symbols.
+ *
+ * @author p.nesterovich
+ * @since 21.03.18
+ */
+public class JunkNameGenerator implements NameGenerator {
+
+    private static final char stringChars[][] = {
+            {'S', '5', '$'},
+            {'l', '1', 'I'},
+            {'_'}
+    };
+
+    @Override
+    public String generateName(final int size) {
+        if (size > NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException("Cannot generate junk name: too long for JVM.");
+        }
+
+        final int index = Rand.getInt(stringChars.length);
+        final int length = stringChars[index].length;
+
+        char newName[] = new char[size];
+        do {
+            newName[0] = stringChars[index][Rand.getInt(length)];
+        } while (!Character.isJavaIdentifierStart(newName[0]));
+
+        // generate random string
+        for (int i = 1; i < newName.length; i++) {
+            int rand = Rand.getInt(length);
+            newName[i] = stringChars[index][rand];
+        }
+        return String.valueOf(newName);
+    }
+
+}

--- a/src/main/java/soot/jbco/name/NameGenerator.java
+++ b/src/main/java/soot/jbco/name/NameGenerator.java
@@ -1,0 +1,27 @@
+package soot.jbco.name;
+
+/**
+ * Generates names that are compatible with Java identifiers.
+ *
+ * @author p.nesterovich
+ * @since 21.03.18
+ */
+public interface NameGenerator {
+
+    /**
+     * According to JVM specification, the name is limited to 65535 characters by the 16-bit unsigned length item of
+     * the CONSTANT_Utf8_info structure. As the limit is on the number of bytes and UTF-8 encodes some characters using
+     * two or three bytes, we assume that in worst case number or characters is 65535 / 3
+     */
+    int NAME_MAX_LENGTH = 65_535 / 3;
+
+    /**
+     * Generates random name of required length that can be used as Java identifier.
+     *
+     * @param size the expected size
+     * @return the name of expected length
+     * @throws IllegalArgumentException when passed size is more than {@link NameGenerator#NAME_MAX_LENGTH}
+     */
+    String generateName(int size);
+
+}

--- a/src/main/xml/singletons/singletons.xml
+++ b/src/main/xml/singletons/singletons.xml
@@ -168,4 +168,5 @@
   <class>soot.jimple.spark.internal.CompleteAccessibility</class>
   <class>soot.jimple.toolkits.reflection.ConstantInvokeMethodBaseTransformer</class>
   <class>soot.jbco.jimpleTransformations.ClassRenamer</class>
+  <class>soot.jbco.jimpleTransformations.MethodRenamer</class>
 </singletons>


### PR DESCRIPTION
Fixing `soot.jbco.jimpleTransformations.MethodRenamer` to handle "indirect" inheritance. Consider the next class hierarchy:
![diagram-one](https://user-images.githubusercontent.com/895548/37826997-b3af57ea-2ea6-11e8-893d-2a85bb11f8ea.png)
Method `method()` cannot be renamed in class `C` because it implements library one. As we leave this method name as is, none of superclasses of class `C` cannot change this name too. As we do not rename `A#method()` we must not change its name in any implementation of `A` including `D`. So this case boils down to indirect connection between `D#method()` and `E#method`: "indirect" inheritance. Although updated version of `MethodRenamer` recognizes this connection and skips renaming of such methods, it still processes rest methods with same name but different number of parameters. Thus, `D#method(java.lang.String, int)`, `C#method(java.lang.String)` and `C#method(long, int)` will be renamed, but will have _the same_ name. The restriction to have the same new method name for the methods with the same name but different parameters, was introduced to support _renaming map_: the result of call `soot.jbco.jimpleTransformations.MethodRenamer#getRenamingMap(String className)` for any class must return map with old-to-new method names. The structure of map does not allow us to store different new method names for one method (I mean we will not know exactly the new method name if we receive a collection, not a single value). Note, that this rule applies to every single _tree_ of classes. Thus, a method with name `method` in other class hierarchy not related to this one, will have other name.

Also I extracted generation names logic into separate class; updated javadoc and formatted printing logs