### PR TITLE
Fixing GotoInstumenter

### DIFF
--- a/src/main/java/soot/jbco/jimpleTransformations/GotoInstrumenter.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/GotoInstrumenter.java
@@ -19,186 +19,226 @@
 
 package soot.jbco.jimpleTransformations;
 
-import soot.*;
-import soot.util.*;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import soot.Body;
+import soot.BodyTransformer;
+import soot.Local;
+import soot.PatchingChain;
+import soot.RefType;
+import soot.Scene;
+import soot.SootMethod;
+import soot.Trap;
+import soot.Unit;
+import soot.UnitBox;
 import soot.jbco.IJbcoTransform;
 import soot.jbco.util.Rand;
-import soot.jimple.*;
-import java.util.*;
+import soot.jimple.GotoStmt;
+import soot.jimple.IdentityStmt;
+import soot.jimple.Jimple;
+import soot.jimple.Stmt;
+import soot.util.Chain;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
- * @author Michael Batchelder 
- * 
- * Created on 15-Feb-2006 
+ * Changes the sequence of statements in which they appear in methods, preserving the sequence they are executed using
+ * {@code goto} commands and {@code labels}. Also if possible adds {@code try-catch} block in random position.
+ *
+ * @author Michael Batchelder
+ * @since 15-Feb-2006
  */
 public class GotoInstrumenter extends BodyTransformer implements IJbcoTransform {
 
-  private int trapsAdded = 0;
-  private int gotosInstrumented = 0;
+    private static final Logger logger = LoggerFactory.getLogger(GotoInstrumenter.class);
 
-  public static String dependancies[] = new String[] { "jtp.jbco_gia" };
+    public static final String name = "jtp.jbco_gia";
+    public static final String dependencies[] = new String[]{GotoInstrumenter.name};
 
-  public String[] getDependencies() {
-    return dependancies;
-  }
-  
-  public static String name = "jtp.jbco_gia";
-  
-  public String getName() {
-    return name;
-  }
-  
-  public void outputSummary() {
-    out.println("Gotos Instrumented "+gotosInstrumented);
-    out.println("Traps Added "+trapsAdded);
-  }
+    private int trapsAdded = 0;
+    private int gotosInstrumented = 0;
 
-  static boolean verbose = G.v().soot_options_Options().verbose();
-  
-  protected void internalTransform(Body b, String phaseName, Map<String,String> options) 
-  { 
-    if (b.getMethod().getName().indexOf("<init>")>=0) return;
-    
-    int weight = soot.jbco.Main.getWeight(phaseName, b.getMethod().getSignature());
-    if (weight == 0) return;
-    
-    PatchingChain<Unit> units = b.getUnits();
-    int size = units.size();
-    Unit first = null;
-    Iterator<Unit> uit = units.iterator();
-    while (uit.hasNext()) {
-      Unit o = uit.next();
-      if (o instanceof IdentityStmt) {
-        first=o;
-        size--;
-      } else
-        break;
-    }
-    
-    if (size < 8) return;
-    
-    if (first == null)
-      first = (Unit)units.getFirst();
-    
-    Chain<Trap> traps = b.getTraps();
-    int i = 0, rand = 0;
-    while (i++ < 10)
-    {
-      rand = Rand.getInt(size);
-      if (rand<1) 
-        rand = 1;
-      else if (rand == size - 1)
-        rand = size - 2;
-     
-      if (isExceptionCaughtAt(units, rand + (units.size() - size), traps.iterator()))
-        continue;
-      break;
-    }
-    
-    // if 10 tries, we give up
-    if (i>=10) return;
-    
-    
-    i = 0;
-    
-    if (output) {
-    	out.println("Applying Gotos to "+b.getMethod().getName());
-    }
- 
-    
-    /*Iterator it = units.iterator();
-    while(it.hasNext()) {
-      Unit x = (Unit)it.next();
-      System.out.println(i+++":  "+x.toString() + "  : "+isExceptionCaughtAt(units, x,traps.iterator()));
-    }*/
-  
-    // move random-size chunk at beginning to end
-    first = (Unit)units.getSuccOf(first);
-    Unit u = first;
-    do {
-      Object toU[] = u.getBoxesPointingToThis().toArray();
-      for (Object element : toU)
-		u.removeBoxPointingToThis((UnitBox)element);
-      
-      // unit box targets stay with a unit even if the unit is removed.
-      Unit u2 = (Unit)units.getSuccOf(u);
-      units.remove(u);
-      units.add(u);
-      
-      for (Object element : toU)
-		u.addBoxPointingToThis((UnitBox)element);
-      
-      u = u2;
-    } while (++i < rand);
+    private static final UnitBox[] EMPTY_UNIT_BOX_ARRAY = new UnitBox[0];
 
-    Unit oldFirst = first;
-    // add goto as FIRST unit to point to new chunk location    
-    if (first instanceof GotoStmt) {
-      oldFirst = ((GotoStmt)first).getTargetBox().getUnit();
-      first = Jimple.v().newGotoStmt(((GotoStmt)first).getTargetBox().getUnit());
-    } else
-      first = Jimple.v().newGotoStmt(first);
-    units.insertBeforeNoRedirect(first,u);
+    private static final int MAX_TRIES_TO_GET_REORDER_COUNT = 10;
 
-    // add goto as LAST unit to point to new position of second chunk
-    if (((Unit)units.getLast()).fallsThrough()) {
-      Stmt gtS = null;
-      if (u instanceof GotoStmt)
-        gtS = Jimple.v().newGotoStmt(((GotoStmt)u).getTargetBox().getUnit());
-      else
-        gtS = Jimple.v().newGotoStmt(u);
-    
-      units.add(gtS);
+    @Override
+    public String getName() {
+        return name;
     }
-    
-    RefType throwable = G.v().soot_Scene().getRefType("java.lang.Throwable");
-    CaughtExceptionRef cexc = Jimple.v().newCaughtExceptionRef();
-    Local excLocal = Jimple.v().newLocal("jbco_gi_caughtExceptionLocal", throwable);
-    b.getLocals().add(excLocal);
-    
-    Unit handler = Jimple.v().newIdentityStmt(excLocal,cexc);
-    units.add(handler);
-    units.add(Jimple.v().newThrowStmt(excLocal));
-    
-    Unit trapEnd = (Unit)units.getSuccOf(oldFirst);
-    try {
-	    while (trapEnd instanceof IdentityStmt)
-	      trapEnd = (Unit)units.getSuccOf(trapEnd);
-	    trapEnd = (Unit)units.getSuccOf(trapEnd);
-	    b.getTraps().add(Jimple.v().newTrap(throwable.getSootClass(), (Unit)units.getPredOf(oldFirst), trapEnd, handler));
-	    trapsAdded++;
-    } catch (Exception exc) {}
-    gotosInstrumented++;
-  }
-  
-  private boolean isExceptionCaughtAt(Chain<Unit> units, int idx, Iterator<Trap> trapsIt)
-  {
-    Object u = null;
-    Iterator<Unit> it = units.iterator();
-    while (it.hasNext())
-    {
-      if (idx--==0) {
-        u = it.next();
-        break;
-      }
-      it.next();
+
+    @Override
+    public String[] getDependencies() {
+        return Arrays.copyOf(dependencies, dependencies.length);
     }
-    
-    if (u == null)
-    	return false;
-  
-    //System.out.println("\r\tselected unit is "+u);
-    while (trapsIt.hasNext())
-    {
-      Trap t = (Trap)trapsIt.next();
-      it = units.iterator(t.getBeginUnit(),units.getPredOf(t.getEndUnit()));
-      while (it.hasNext())
-        if (u.equals(it.next()))
-          return true;
-      if (t.getEndUnit().equals(u))
-        return true;
+
+    @Override
+    public void outputSummary() {
+        logger.info("Instrumented {} GOTOs, added {} traps.", gotosInstrumented, trapsAdded);
     }
-    
-    return false;
-  }
+
+    @Override
+    protected void internalTransform(Body body, String phaseName, Map<String, String> options) {
+        if (SootMethod.constructorName.equals(body.getMethod().getName())
+                || SootMethod.staticInitializerName.equals(body.getMethod().getName())) {
+            if (isVerbose()) {
+                logger.info("Skipping {} method GOTO instrumentation as it is constructor/initializer.",
+                        body.getMethod().getSignature());
+            }
+            return;
+        }
+
+        if (soot.jbco.Main.getWeight(phaseName, body.getMethod().getSignature()) == 0) return;
+
+        final PatchingChain<Unit> units = body.getUnits();
+
+        int precedingFirstNotIdentityIndex = 0;
+        Unit precedingFirstNotIdentity = null;
+        for (Unit unit : units) {
+            if (unit instanceof IdentityStmt) {
+                precedingFirstNotIdentity = unit;
+                precedingFirstNotIdentityIndex++;
+                continue;
+            }
+
+            break;
+        }
+
+        final int unitsLeft = units.size() - precedingFirstNotIdentityIndex;
+        if (unitsLeft < 8) {
+            if (isVerbose()) {
+                logger.info("Skipping {} method GOTO instrumentation as it is too small.",
+                        body.getMethod().getSignature());
+            }
+            return;
+        }
+
+        int tries = 0;
+        int unitsQuantityToReorder = 0;
+        while (tries < MAX_TRIES_TO_GET_REORDER_COUNT) {
+            // value must be in (0; unitsLeft - 1]
+            // - greater than 0 to avoid modifying the precedingFirstNotIdentity
+            // - less than unitsLeft - 1 to avoid getting out of bounds
+            unitsQuantityToReorder = Rand.getInt(unitsLeft - 2) + 1;
+
+            tries++;
+
+            final Unit selectedUnit = Iterables.get(units, precedingFirstNotIdentityIndex + unitsQuantityToReorder);
+            if (isExceptionCaught(selectedUnit, units, body.getTraps()))
+                continue;
+
+            break;
+        }
+
+        // if 10 tries, we give up
+        if (tries >= MAX_TRIES_TO_GET_REORDER_COUNT) return;
+
+        if (isVerbose()) {
+            logger.info("Adding GOTOs to \"{}\".", body.getMethod().getName());
+        }
+
+        final Unit first = precedingFirstNotIdentity == null ? units.getFirst() : precedingFirstNotIdentity;
+        final Unit firstReorderingUnit = units.getSuccOf(first);
+
+        // move random-size chunk at beginning to end
+        Unit reorderingUnit = firstReorderingUnit;
+        for (int reorder = 0; reorder < unitsQuantityToReorder; reorder++) {
+            // create separate array to avoid coming modifications
+            final UnitBox pointingToReorderingUnit[] = reorderingUnit.getBoxesPointingToThis()
+                    .toArray(EMPTY_UNIT_BOX_ARRAY);
+            for (UnitBox element : pointingToReorderingUnit) {
+                reorderingUnit.removeBoxPointingToThis(element);
+            }
+
+            // unit box targets stay with a unit even if the unit is removed.
+            final Unit nextReorderingUnit = units.getSuccOf(reorderingUnit);
+            units.remove(reorderingUnit);
+            units.add(reorderingUnit);
+
+            for (UnitBox element : pointingToReorderingUnit) {
+                reorderingUnit.addBoxPointingToThis(element);
+            }
+
+            reorderingUnit = nextReorderingUnit;
+        }
+
+        // add goto as FIRST unit to point to new chunk location
+        final Unit firstReorderingNotGotoStmt = first instanceof GotoStmt
+                ? ((GotoStmt) first).getTargetBox().getUnit() : firstReorderingUnit;
+        final GotoStmt gotoFirstReorderingNotGotoStmt = Jimple.v().newGotoStmt(firstReorderingNotGotoStmt);
+        units.insertBeforeNoRedirect(gotoFirstReorderingNotGotoStmt, reorderingUnit);
+
+        // add goto as LAST unit to point to new position of second chunk
+        if (units.getLast().fallsThrough()) {
+            final Stmt gotoStmt = (reorderingUnit instanceof GotoStmt)
+                    ? Jimple.v().newGotoStmt(((GotoStmt) reorderingUnit).getTargetBox().getUnit())
+                    : Jimple.v().newGotoStmt(reorderingUnit);
+
+            units.add(gotoStmt);
+        }
+
+        gotosInstrumented++;
+
+        Unit secondReorderedUnit = units.getSuccOf(firstReorderingNotGotoStmt);
+        if (secondReorderedUnit == null
+                || (secondReorderedUnit.equals(units.getLast()) && secondReorderedUnit instanceof IdentityStmt)) {
+
+            if (firstReorderingNotGotoStmt instanceof IdentityStmt) {
+                if (isVerbose()) {
+                    logger.info("Skipping adding try-catch block at \"{}\".", body.getMethod().getSignature());
+                }
+                return;
+            }
+
+            secondReorderedUnit = firstReorderingNotGotoStmt;
+        }
+
+        final RefType throwable = Scene.v().getRefType("java.lang.Throwable");
+        final Local caughtExceptionLocal = Jimple.v().newLocal("jbco_gi_caughtExceptionLocal", throwable);
+        body.getLocals().add(caughtExceptionLocal);
+
+        final Unit caughtExceptionHandler = Jimple.v().newIdentityStmt(
+                caughtExceptionLocal, Jimple.v().newCaughtExceptionRef());
+        units.add(caughtExceptionHandler);
+        units.add(Jimple.v().newThrowStmt(caughtExceptionLocal));
+
+        final Iterator<Unit> reorderedUnitsIterator = units.iterator(
+                secondReorderedUnit, units.getPredOf(caughtExceptionHandler));
+        Unit trapEndUnit = reorderedUnitsIterator.next();
+        while (trapEndUnit instanceof IdentityStmt && reorderedUnitsIterator.hasNext()) {
+            trapEndUnit = reorderedUnitsIterator.next();
+        }
+        trapEndUnit = units.getSuccOf(trapEndUnit);
+
+        body.getTraps().add(
+                Jimple.v().newTrap(
+                        throwable.getSootClass(),
+                        units.getPredOf(firstReorderingNotGotoStmt),
+                        trapEndUnit,
+                        caughtExceptionHandler
+                ));
+
+        trapsAdded++;
+    }
+
+    private static boolean isExceptionCaught(Unit unit, Chain<Unit> units, Chain<Trap> traps) {
+        for (Trap trap : traps) {
+            final Unit end = trap.getEndUnit();
+            if (end.equals(unit)) {
+                return true;
+            }
+
+            final Iterator<Unit> unitsInTryIterator = units.iterator(trap.getBeginUnit(), units.getPredOf(end));
+            if (Iterators.contains(unitsInTryIterator, unit)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/src/main/java/soot/jbco/name/AbstractNameGenerator.java
+++ b/src/main/java/soot/jbco/name/AbstractNameGenerator.java
@@ -1,0 +1,39 @@
+package soot.jbco.name;
+
+import soot.jbco.util.Rand;
+
+/**
+ * Abstract class that implements {@link NameGenerator#generateName(int)}.
+ *
+ * @author p.nesterovich
+ * @since 21.03.18
+ */
+public abstract class AbstractNameGenerator implements NameGenerator {
+
+    @Override
+    public String generateName(final int size) {
+        if (size > NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException("Cannot generate junk name: too long for JVM.");
+        }
+
+        final char[][] chars = getChars();
+
+        final int index = Rand.getInt(chars.length);
+        final int length = chars[index].length;
+
+        char newName[] = new char[size];
+        do {
+            newName[0] = chars[index][Rand.getInt(length)];
+        } while (!Character.isJavaIdentifierStart(newName[0]));
+
+        // generate random string
+        for (int i = 1; i < newName.length; i++) {
+            int rand = Rand.getInt(length);
+            newName[i] = chars[index][rand];
+        }
+        return String.valueOf(newName);
+    }
+
+    protected abstract char[][] getChars();
+
+}

--- a/src/main/java/soot/jbco/name/HorrorNameGenerator.java
+++ b/src/main/java/soot/jbco/name/HorrorNameGenerator.java
@@ -1,0 +1,29 @@
+package soot.jbco.name;
+
+/**
+ * Implementation that generates names consisting of hard recognizable symbols.
+ *
+ * @author p.nesterovich
+ * @since 21.03.18
+ */
+public class HorrorNameGenerator extends AbstractNameGenerator implements NameGenerator {
+
+    private static final char stringChars[][] = {
+            {'S', '5', '$'}, // latin s, five, dollar sign
+            {'l', '1', 'I', 'Ι'}, // l, one, I, greek iota
+            {'0', 'O', 'О', 'Ο', 'Օ'}, // zero, english O, russian O, greek omicron, armenian Օ
+            {'o', 'о', 'ο'}, // english o, russian o and greek omicron
+            {'T', 'Т', 'Τ'}, // english T, russian T, greek tau
+            {'H', 'Н', 'Η'}, // english, russian, greek
+            {'E', 'Е', 'Ε'}, // english, russian, greek
+            {'P', 'Р', 'Ρ'}, // english, russian, greek
+            {'B', 'В', 'Β'}, // english, russian, greek
+            {'_'}
+    };
+
+    @Override
+    protected char[][] getChars() {
+        return stringChars;
+    }
+
+}

--- a/src/main/java/soot/jbco/name/JunkNameGenerator.java
+++ b/src/main/java/soot/jbco/name/JunkNameGenerator.java
@@ -1,14 +1,12 @@
 package soot.jbco.name;
 
-import soot.jbco.util.Rand;
-
 /**
  * Implementation that generates names consisting of hard recognizable symbols.
  *
  * @author p.nesterovich
  * @since 21.03.18
  */
-public class JunkNameGenerator implements NameGenerator {
+public class JunkNameGenerator extends AbstractNameGenerator implements NameGenerator {
 
     private static final char stringChars[][] = {
             {'S', '5', '$'},
@@ -17,25 +15,8 @@ public class JunkNameGenerator implements NameGenerator {
     };
 
     @Override
-    public String generateName(final int size) {
-        if (size > NAME_MAX_LENGTH) {
-            throw new IllegalArgumentException("Cannot generate junk name: too long for JVM.");
-        }
-
-        final int index = Rand.getInt(stringChars.length);
-        final int length = stringChars[index].length;
-
-        char newName[] = new char[size];
-        do {
-            newName[0] = stringChars[index][Rand.getInt(length)];
-        } while (!Character.isJavaIdentifierStart(newName[0]));
-
-        // generate random string
-        for (int i = 1; i < newName.length; i++) {
-            int rand = Rand.getInt(length);
-            newName[i] = stringChars[index][rand];
-        }
-        return String.valueOf(newName);
+    protected char[][] getChars() {
+        return stringChars;
     }
 
 }


### PR DESCRIPTION
There were cases when `GotoInstumenter` might create `Trap` with `null` end unit. That made generated code wrong (and actually it fails on validation).
This case appeared when we move only one statement to the end of method body. When we create try-catch block that covers this statement, we cannot find the end statement (because of random process).

Also I created `HorrorNameGenerator` that uses _similar_ letters from different alphabets.