### PR TITLE
Fixed Sable/soot#930

### DIFF
--- a/src/main/java/soot/jbco/Main.java
+++ b/src/main/java/soot/jbco/Main.java
@@ -172,7 +172,7 @@ public class Main {
         Object o = null;
         arg = arg.substring(4);
 
-        int tweight = 0;
+        int tweight = 9;
         char cweight = arg.charAt(0);
         if (cweight >= '0' && cweight <= '9') {
           try {
@@ -209,6 +209,7 @@ public class Main {
           o = arg;
         }
 
+        transformsToAdd.add(trans);
         Map<Object, Integer> htmp = transformsToMethodsToWeights.get(trans);
         if (htmp == null) {
           htmp = new HashMap<Object, Integer>();
@@ -470,6 +471,8 @@ public class Main {
         if (o instanceof java.util.regex.Pattern) {
           if (((java.util.regex.Pattern) o).matcher(method).matches()) {
             intg = (Integer) htmp.get(o);
+          } else {
+            intg = 0;
           }
         } else if (o instanceof String && method.equals(o)) {
           intg = (Integer) htmp.get(o);

--- a/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
@@ -118,7 +118,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
         }
         // rename all the fields in the class
         for (SootField f : sc.getFields()) {
-          int weight = soot.jbco.Main.getWeight(phaseName, f.getName());
+          int weight = soot.jbco.Main.getWeight(phaseName, f.getSignature());
           if (weight > 0) {
             renameField(className, f);
           }

--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -379,7 +379,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
   }
 
   private boolean isRenamingAllowed(SootMethod method) {
-    if (soot.jbco.Main.getWeight(MethodRenamer.name, method.getName()) == 0) {
+    if (soot.jbco.Main.getWeight(MethodRenamer.name, method.getSignature()) == 0) {
       return false;
     }
 


### PR DESCRIPTION
After some time I found my way through the code and could fix #930. I am asking myself if this every worked before? There's is a bunch of dead code lying around and several undocumented flags/command options. I use `-it:` for regex selected method names.

<sub>I am sorry, but this 12 year old code base of JBCO is a tremendous mess</sub>