### PR TITLE
solve the bug in Tarjan's algorithm of Geom Points-to Analysis

### DIFF
--- a/src/main/java/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
+++ b/src/main/java/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
@@ -609,12 +609,14 @@ public class GeomPointsTo extends PAG {
 
     while (p != null) {
       t = p.t;
-      if (vis_cg[t] == 0) {
+      
+      if (vis_cg[t] == 0){
         callGraphDFS(t);
+        low_cg[s] = Math.min(low_cg[s], low_cg[t]);
+      }else{
+        low_cg[s] = Math.min(low_cg[s], vis_cg[t]);
       }
-      if (low_cg[t] < low_cg[s]) {
-        low_cg[s] = low_cg[t];
-      }
+      
       p = p.next;
     }
 


### PR DESCRIPTION
Solve a bug in the function 

  private void callGraphDFS(int s)

in the file

  GeomPointsTo.java

which use Tarjan's algorithm to contract the SCCs.

The problem of this bug is that it may cause Soot to report an empty points-to set for some of the pointers when using Geom Points-to Analysis. In fact, this is a typical bug when implementing Tarjan's algorithm.