### PR TITLE
Handle initial field value when creating a new SootField instance fro…

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1868,6 +1868,10 @@ public class Scene // extends AbstractHost
     return new SootMethod(name, parameterTypes, returnType, modifiers, thrownExceptions);
   }
 
+  public SootField makeSootField(String name, Type type, int modifiers, String initialValue) {
+    return new SootField(name, type, modifiers, initialValue);
+  }
+
   public SootField makeSootField(String name, Type type, int modifiers) {
     return new SootField(name, type, modifiers);
   }

--- a/src/main/java/soot/SootField.java
+++ b/src/main/java/soot/SootField.java
@@ -42,6 +42,16 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
   protected boolean isDeclared = false;
   protected SootClass declaringClass;
   protected boolean isPhantom = false;
+  String initialValueString; // Dalvik-only
+
+  /** Constructs a Soot field with the given name, type, modifiers and initial value. */
+  public SootField(String name, Type type, int modifiers, String initialValueString)
+  {
+    this.name = name;
+    this.type = type;
+    this.modifiers = modifiers;
+    this.initialValueString = initialValueString;
+  }
 
   /** Constructs a Soot field with the given name, type and modifiers. */
   public SootField(String name, Type type, int modifiers) {

--- a/src/main/java/soot/dexpler/DexField.java
+++ b/src/main/java/soot/dexpler/DexField.java
@@ -98,7 +98,9 @@ public class DexField {
     String name = f.getName();
     Type type = DexType.toSoot(f.getType());
     int flags = f.getAccessFlags();
-    SootField sf = Scene.v().makeSootField(name, type, flags);
+    EncodedValue e = f.getInitialValue();
+    String initialValue = ((e == null) ? null : e.toString());
+    SootField sf = Scene.v().makeSootField(name, type, flags, initialValue);
     if (Modifier.isFinal(flags)) {
       DexField.addConstantTag(sf, f);
     }


### PR DESCRIPTION
A minor modification to the way Soot handles DexFields and their conversion to SootFields. I added a field of String type to model the initial value for Android fields, since I see it right now it is not preserved.I'm also wondering whether this change can help with issue #937 in case it is accepted.

Best regards,
Tony