### PR TITLE
Make slf4j implementation dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,7 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.5</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Testing dependencies -->


### PR DESCRIPTION
Currently, anyone who has Soot as a dependency will have `slf4j-simple` as transitive dependency. Anyone who wishes to bind a different logger (e.g. `slf4j-nop`) will encounter the warning that "Class path contains multiple SLF4J bindings." According to the [SLF4J FAQ](https://www.slf4j.org/codes.html#multiple_bindings), the solution is to *not* make the binding itself a dependency, but only the API.

Therefore, this PR makes the simple binder an [optional dependency](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html), which means that it is a required dependency when compiling Soot, but will not be a dependency of projects that use Soot. This will allow users of Soot to use their own logger binder.

I think this will fix #757.
