### PR TITLE
Minor bug fixes to dava output

### DIFF
--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -561,6 +561,7 @@ public class PackManager {
     }
     if (Options.v().output_format() == Options.output_format_dava) {
       postProcessDAVA();
+      outputDava();
     } else if (Options.v().output_format() == Options.output_format_dex
         || Options.v().output_format() == Options.output_format_force_dex) {
       writeDexOutput();
@@ -819,8 +820,6 @@ public class PackManager {
     if (transformations) {
       InterProceduralAnalyses.applyInterProceduralAnalyses();
     }
-
-    outputDava();
   }
 
   private void outputDava() {

--- a/src/main/java/soot/dava/toolkits/base/AST/transformations/RemoveEmptyBodyDefaultConstructor.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/transformations/RemoveEmptyBodyDefaultConstructor.java
@@ -85,6 +85,11 @@ public class RemoveEmptyBodyDefaultConstructor {
       debug("No active body found for the default constructor");
       return;
     }
+    
+    if (!constructor.isPublic()) {
+      debug("Default constructor is not public.");
+      return;
+    }
 
     Body body = constructor.getActiveBody();
     Chain units = ((DavaBody) body).getUnits();


### PR DESCRIPTION
- Move "outputDAVA" method outside of "postProcessDAVA" to make
  debugging easier.
- Make sure non-public empty constructors are not removed as
  these are no longer default constructors.