### PR TITLE
BugFix: Null pointer exception in UseChecker

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/UseChecker.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/UseChecker.java
@@ -258,6 +258,9 @@ public class UseChecker extends AbstractStmtSwitch {
         at = (ArrayType) this.tg.get(base);
       } else {
         Type bt = this.tg.get(base);
+        // At the very least, the the type for this array should be whatever its
+        // base type is
+        et = bt;
 
         // If we have a type of java.lang.Object and access it like an object,
         // this could lead to any kind of object, so we have to look at the uses.


### PR DESCRIPTION
In cases like the following:

unknown $u11, $u8#22
$u11 := @parameter0: java.lang.Object;
$u8#19 = $u11 instanceof java.lang.Object[];
if $u8#19 == 0 goto label12;
$u8#22 = $u11[0];
if $u8#22 == null goto label06;

UseChecker would identify $u11 as an Object type but would fail to identify
$u8#22 as a Object[] type because its only use was in the if check against
null. This resulted in a NullPointerException as the variable that was
supposed to contain the base type of the array reference was never set.

However, it is already known that $u11 is of type Object. Thus by setting the
base type of the array ref to the already resolved type of local $u11 at the
beginning, we resolve the NullPointerException and still allow for the type
to be changed if more information is discovered through use analysis.