### PR TITLE
Use global soot options when creating an ExceptionalUnitGraph

### DIFF
--- a/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
@@ -127,7 +127,7 @@ public abstract class AbstractJimpleBasedICFG implements BiDiInterproceduralCFG<
   }
 
   protected DirectedGraph<Unit> makeGraph(Body body) {
-    return enableExceptions ? new ExceptionalUnitGraph(body, UnitThrowAnalysis.v(), true) : new BriefUnitGraph(body);
+    return enableExceptions ? new ExceptionalUnitGraph(body) : new BriefUnitGraph(body);
   }
 
   @Override


### PR DESCRIPTION
All JimpleBasedICFG were forced to use the UnitThrowAnalysis and and omit
exceptional unit edges when constructing an ExceptionalUnitGraph. There
are global settings for these options, so it makes more sense to use the
global settings than to have them hardcoded. Esepeically since this
exception to the global settings is not stated anywhere.