### PR TITLE
Make the LoopFinder easier to call and clean it up

### DIFF
--- a/src/main/java/soot/jimple/toolkits/annotation/logic/LoopFinder.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/logic/LoopFinder.java
@@ -22,14 +22,14 @@ package soot.jimple.toolkits.annotation.logic;
  * #L%
  */
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
+import java.util.Set;
 
 import soot.Body;
 import soot.BodyTransformer;
@@ -41,93 +41,92 @@ import soot.toolkits.graph.UnitGraph;
 
 public class LoopFinder extends BodyTransformer {
 
-  private UnitGraph g;
-
-  private HashMap<Stmt, List<Stmt>> loops;
-
-  public Collection<Loop> loops() {
-    Collection<Loop> result = new HashSet<Loop>();
-    for (Map.Entry<Stmt, List<Stmt>> entry : loops.entrySet()) {
-      result.add(new Loop(entry.getKey(), entry.getValue(), g));
-    }
-    return result;
+  private Set<Loop> loops;
+  
+  public LoopFinder() {
+    loops = null;
   }
-
-  protected void internalTransform(Body b, String phaseName, Map<String, String> options) {
-    g = new ExceptionalUnitGraph(b);
-    MHGDominatorsFinder<Unit> a = new MHGDominatorsFinder<>(g);
-
-    loops = new HashMap<Stmt, List<Stmt>>();
-
-    Iterator<Unit> stmtsIt = b.getUnits().iterator();
-    while (stmtsIt.hasNext()) {
-      Stmt s = (Stmt) stmtsIt.next();
-
-      List<Unit> succs = g.getSuccsOf(s);
-      Collection<Unit> dominaters = (Collection<Unit>) a.getDominators(s);
-
-      ArrayList<Stmt> headers = new ArrayList<Stmt>();
-
-      Iterator<Unit> succsIt = succs.iterator();
-      while (succsIt.hasNext()) {
-        Stmt succ = (Stmt) succsIt.next();
+  
+  protected void internalTransform (Body b, String phaseName, Map<String,String> options) {
+    getLoops(b);
+  }
+  
+  public Set<Loop> getLoops(Body b) {
+    if (loops != null) {
+      return loops;
+    }
+    return getLoops(new ExceptionalUnitGraph(b));
+  }
+  
+  public Set<Loop> getLoops(UnitGraph g) {
+    if (loops != null) {
+      return loops;
+    }
+  
+    MHGDominatorsFinder<Unit> a = new MHGDominatorsFinder<Unit>(g);
+    Map<Stmt, List<Stmt>> loops = new HashMap<Stmt, List<Stmt>>();
+    
+    for(Unit u : g.getBody().getUnits()) {
+      List<Unit> succs = g.getSuccsOf(u);
+      List<Unit> dominaters = a.getDominators(u);
+      List<Stmt> headers = new ArrayList<Stmt>();
+      
+      for(Unit succ : succs) {
         if (dominaters.contains(succ)) {
-          // header succeeds and dominates s, we have a loop
-          headers.add(succ);
+          //header succeeds and dominates s, we have a loop
+          headers.add((Stmt)succ);
         }
       }
-
-      Iterator<Stmt> headersIt = headers.iterator();
-      while (headersIt.hasNext()) {
-        Stmt header = headersIt.next();
-        List<Stmt> loopBody = getLoopBodyFor(header, s);
-
-        // for now just print out loops as sets of stmts
-        // System.out.println("FOUND LOOP: Header: "+header+" Body: "+loopBody);
+      
+      for(Unit header : headers) {
+        List<Stmt> loopBody = getLoopBodyFor(header, u, g);
         if (loops.containsKey(header)) {
           // merge bodies
           List<Stmt> lb1 = loops.get(header);
-          loops.put(header, union(lb1, loopBody));
+          loops.put((Stmt)header, union(lb1, loopBody));
         } else {
-          loops.put(header, loopBody);
+          loops.put((Stmt)header, loopBody);
         }
       }
     }
-
+    
+    Set<Loop> ret = new HashSet<Loop>();
+    for (Map.Entry<Stmt,List<Stmt>> entry : loops.entrySet()) {
+      ret.add(new Loop(entry.getKey(),entry.getValue(),g));
+    }
+    
+    this.loops = ret;
+    return ret;
   }
-
-  private List<Stmt> getLoopBodyFor(Stmt header, Stmt node) {
-
-    ArrayList<Stmt> loopBody = new ArrayList<Stmt>();
-    Stack<Unit> stack = new Stack<Unit>();
-
-    loopBody.add(header);
+  
+  private List<Stmt> getLoopBodyFor(Unit header, Unit node, UnitGraph g) {
+    List<Stmt> loopBody = new ArrayList<Stmt>();
+    Deque<Unit> stack = new ArrayDeque<Unit>();
+    
+    loopBody.add((Stmt)header);
     stack.push(node);
-
+    
     while (!stack.isEmpty()) {
-      Stmt next = (Stmt) stack.pop();
+      Stmt next = (Stmt)stack.pop();
       if (!loopBody.contains(next)) {
         // add next to loop body
         loopBody.add(0, next);
         // put all preds of next on stack
-        Iterator<Unit> it = g.getPredsOf(next).iterator();
-        while (it.hasNext()) {
-          stack.push(it.next());
+        for(Unit u : g.getPredsOf(next)) {
+          stack.push(u);
         }
       }
     }
-
-    assert (node == header && loopBody.size() == 1) || loopBody.get(loopBody.size() - 2) == node;
-    assert loopBody.get(loopBody.size() - 1) == header;
-
+    
+    assert (node==header && loopBody.size()==1) || loopBody.get(loopBody.size()-2)==node;
+    assert loopBody.get(loopBody.size()-1)==header;
+    
     return loopBody;
   }
-
+  
   private List<Stmt> union(List<Stmt> l1, List<Stmt> l2) {
-    Iterator<Stmt> it = l2.iterator();
-    while (it.hasNext()) {
-      Stmt next = it.next();
-      if (!l1.contains(next)) {
+    for(Stmt next : l2) {
+      if (!l1.contains(next)){
         l1.add(next);
       }
     }

--- a/src/main/java/soot/jimple/toolkits/annotation/logic/LoopInvariantFinder.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/logic/LoopInvariantFinder.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,10 +72,7 @@ public class LoopInvariantFinder extends BodyTransformer {
     UnitGraph g = sld.getGraph();
     NaiveSideEffectTester nset = new NaiveSideEffectTester();
 
-    LoopFinder lf = new LoopFinder();
-    lf.internalTransform(b, phaseName, options);
-
-    Collection<Loop> loops = lf.loops();
+    Collection<Loop> loops = new LoopFinder().getLoops(b);
     constants = new ArrayList();
 
     // no loop invariants if no loops

--- a/src/main/java/soot/toolkits/graph/LoopNestTree.java
+++ b/src/main/java/soot/toolkits/graph/LoopNestTree.java
@@ -85,11 +85,7 @@ public class LoopNestTree extends TreeSet<Loop> {
   }
 
   private static Collection<Loop> computeLoops(Body b) {
-    LoopFinder loopFinder = new LoopFinder();
-    loopFinder.transform(b);
-
-    Collection<Loop> loops = loopFinder.loops();
-    return loops;
+    return new LoopFinder().getLoops(b);
   }
 
   public boolean hasNestedLoops() {


### PR DESCRIPTION
- Reformatted extremly old code in the LoopFinder so that it uses more
  up-to-date java standards.
- Made it much easier to call the LoopFinder without having to go through
  the transofmation procedure since this was not really being used by the
  LoopFinder. It is still possible to call it that way though.
- Replaced a few calls in other parts of the code to account for the
  change in the way to get the loops.