### PR TITLE
BugFix: Issues with throwable and phantom classes

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
@@ -190,15 +190,21 @@ public class AugEvalFunction implements IEvalFunction {
 
       for (RefType t : TrapManager.getExceptionTypesOf(stmt, jb)) {
         if (r == null) {
-          r = t;
-        } else if (t.getSootClass().isPhantom() || r.getSootClass().isPhantom()) {
-          r = throwableType;
+          if(t.getSootClass().isPhantom()) {
+            r = throwableType;
+          } else {
+            r = t;
+          }
         } else {
-          /*
-           * In theory, we could have multiple exception types pointing here. The JLS requires the exception parameter be a
-           * *subclass* of Throwable, so we do not need to worry about multiple inheritance.
-           */
-          r = BytecodeHierarchy.lcsc(r, t, throwableType);
+          if (t.getSootClass().isPhantom()) {
+            r = throwableType;
+          } else {
+            /*
+             * In theory, we could have multiple exception types pointing here. The JLS requires the exception parameter be a
+             * *subclass* of Throwable, so we do not need to worry about multiple inheritance.
+             */
+            r = BytecodeHierarchy.lcsc(r, t, throwableType);
+          }
         }
       }
 

--- a/src/main/java/soot/jimple/toolkits/typing/fast/BytecodeHierarchy.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/BytecodeHierarchy.java
@@ -1,5 +1,7 @@
 package soot.jimple.toolkits.typing.fast;
 
+import java.util.ArrayDeque;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -242,24 +244,33 @@ public class BytecodeHierarchy implements IHierarchy {
     }
   }
 
+  /* Returns a list of the super classes of a given type in which the anchor
+   * will always be the first element even when the types class is phantom.
+   * Note anchor should always be type Throwable as this is the root of all
+   * exception types.
+   */
   private static Deque<RefType> superclassPath(RefType t, RefType anchor) {
-    Deque<RefType> r = new LinkedList<RefType>();
+    Deque<RefType> r = new ArrayDeque<RefType>();
     r.addFirst(t);
-    if (t.getSootClass().isPhantom() && anchor != null) {
-      r.addFirst(anchor);
+    
+    if(TypeResolver.typesEqual(t, anchor)) {
       return r;
     }
-
+    
     SootClass sc = t.getSootClass();
-    while (sc.hasSuperclass()) {
+    while(sc.hasSuperclass()) {
       sc = sc.getSuperclass();
-      r.addFirst(sc.getType());
-      if (sc.isPhantom() && anchor != null) {
-        r.addFirst(anchor);
+      RefType cur = sc.getType();
+      r.addFirst(cur);
+      if(TypeResolver.typesEqual(cur, anchor)) {
         break;
       }
     }
-
+    
+    if(!TypeResolver.typesEqual(r.getFirst(), anchor)) {
+      r.addFirst(anchor);
+    }
+    
     return r;
   }
 


### PR DESCRIPTION
- The previous fix for handling Throwable not being the base class
  for phantom exception classes had some holes in it. This fixes
  those.
- Exception super class hierarchy does not really need to check
  if things are phantom, it just needs to make sure the first
  element is always Throwable and that Throwable only occurs once.
  Ensuring this is sufficant to cover phantom Exceptions and exceptions
  with a well formed super class hierarchy (since they will already have
  Throwable as their root minus Object).