### PR TITLE
Fixes types for init

### DIFF
--- a/src/main/java/soot/jimple/spark/solver/OnFlyCallGraph.java
+++ b/src/main/java/soot/jimple/spark/solver/OnFlyCallGraph.java
@@ -159,7 +159,7 @@ public class OnFlyCallGraph {
         public void visit(Node n) {
           if (n instanceof AllocNode) {
             AllocNode an = ((AllocNode) n);
-            ofcgb.addInvokeArgDotField(receiver, an.dot(ArrayElement.v()));
+            ofcgb.addInvokeArgDotField(receiver, pag.makeAllocDotField(an, ArrayElement.v()));
             assert an.getNewExpr() instanceof NewArrayExpr;
             NewArrayExpr nae = (NewArrayExpr) an.getNewExpr();
             if (!(nae.getSize() instanceof IntConstant)) {


### PR DESCRIPTION
The OFCGB is supposed to "subscribe" to updates of array contents
when that array flows to an invoke call. However, we were creating
the AllocAndDotField class by calling dot() on the alloc node,
which returns null if the field hasn't been explicitly alloced through
the PAG. This fixes the subscription mechanism to use pag's
makeAllocDotField.