### PR TITLE
fix NPE in soot.dexpler.DexBody.jimplify(Body b, SootMethod m)

### DIFF
--- a/src/main/java/soot/dexpler/DexBody.java
+++ b/src/main/java/soot/dexpler/DexBody.java
@@ -528,6 +528,9 @@ public class DexBody {
         instruction.setLineNumber(prevLineNumber);
       }
     }
+    if (dangling != null) {
+      dangling.finalize(this, null);
+    }
     for (DeferableInstruction instruction : deferredInstructions) {
       instruction.deferredJimplify(this);
     }


### PR DESCRIPTION
Detailed:
If the last instruction of body is InvodeStaticInstruction, the last dangling instruction's finalize will not be called. This leads to a NullPointerException in the following fixLineNumbers() method. This situation is not very common but still exists, e.g. some invokes android.util.Log.i() at the end of the method body.

And further more, maybe we could use some **code formatter such as clang-format to make our codes more readable**?
Anyway, please merge this into mainline to fix this bug.