### PR TITLE
dynamic method invocations now handled as phantom classes

### DIFF
--- a/src/main/java/soot/SootMethodRefImpl.java
+++ b/src/main/java/soot/SootMethodRefImpl.java
@@ -167,10 +167,6 @@ public class SootMethodRefImpl implements SootMethodRef {
   }
 
   private SootMethod tryResolve(StringBuffer trace) {
-    if (declaringClass.getName().equals("java.dyn.InvokeDynamic")) {
-      throw new IllegalStateException("Cannot resolve invokedynamic method references at compile time!");
-    }
-
     SootClass cl = declaringClass;
     while (cl != null) {
       if (trace != null) {
@@ -229,7 +225,12 @@ public class SootMethodRefImpl implements SootMethodRef {
     // we simply create the methods on the fly; the method body will throw
     // an appropriate
     // error just in case the code *is* actually reached at runtime
-    if (Options.v().allow_phantom_refs() && !declaringClass.isInterface()) {
+    boolean treatAsPhantomClass = Options.v().allow_phantom_refs() && !declaringClass.isInterface();
+
+    //declaring class of dynamic invocations not known at compile time, treat as phantom class regardless if phantom classes are enabled
+    treatAsPhantomClass = treatAsPhantomClass || declaringClass.getName().equals(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME);
+
+    if (treatAsPhantomClass) {
       return createUnresolvedErrorMethod(declaringClass);
     }
 


### PR DESCRIPTION
References issue #976 
When resolving methods of dynamic method invocations, a `soot.SootMethodRefImpl$ClassResolutionFailedException` was thrown, since the declaring class of such invocations is unknown at compile time. However, this leads to unwanted bevahior when e.g. validating a method containing lambdas (which use dynamic method invocations), as well as writing a `SootClass` to a .class file (which also validates its methods), because an exception is thrown.
According to https://github.com/Sable/soot/wiki/Java%27s-Invokedynamic the dummy declaring class `soot.dummy.InvokeDynamic` of dynamic method invocations must be treated as a phantom class, regardless if phantom classes are enabled. This is now implemented.
Additionally, I've removed the `IllegalStateException` at the beginning of `tryResolve(StringBuffer trace)`, because it seems to address the same issue but wrongly (when compared to the wiki article). First, the class name the declaring class is compared to is hardcoded and wrong (`java.dyn.InvokeDynamic` instead of `soot.dummy.InvokeDynamic`) and second, it throws an exception instead of treating the class as a phantom class.