### PR TITLE
Fixed "remove" method of ArraySparseSet iterator.

### DIFF
--- a/src/main/java/soot/toolkits/scalar/ArraySparseSet.java
+++ b/src/main/java/soot/toolkits/scalar/ArraySparseSet.java
@@ -273,22 +273,25 @@ public class ArraySparseSet<T> extends AbstractFlowSet<T> {
   public Iterator<T> iterator() {
     return new Iterator<T>() {
 
-      int lastIdx = 0;
+      int nextIdx = 0;
 
       @Override
       public boolean hasNext() {
-        return lastIdx < numElements;
+        return nextIdx < numElements;
       }
 
       @Override
       public T next() {
-        return elements[lastIdx++];
+        return elements[nextIdx++];
       }
 
       @Override
       public void remove() {
-        ArraySparseSet.this.remove(lastIdx);
-        lastIdx--;
+        if (nextIdx == 0) {
+          throw new IllegalStateException("'next' has not been called yet.");
+        }
+        ArraySparseSet.this.remove(nextIdx - 1);
+        nextIdx--;
       }
 
     };

--- a/src/test/java/soot/toolkits/scalar/ArraySparseSetTest.java
+++ b/src/test/java/soot/toolkits/scalar/ArraySparseSetTest.java
@@ -23,6 +23,7 @@ package soot.toolkits.scalar;
  */
 
 import java.util.Arrays;
+import java.util.Iterator;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,6 +58,41 @@ public class ArraySparseSetTest {
 		
 		Assert.assertEquals(ars1, aps);
 		Assert.assertEquals(ars1.hashCode(), aps.hashCode());
+	}
+
+	@Test
+	public void testIterator() {
+		ArraySparseSet<String> ars1 = new ArraySparseSet<String>();
+		ars1.add("a");
+		ars1.add("b");
+		ars1.add("c");
+
+		// remove element c
+		Iterator<String> it = ars1.iterator();
+		while (it.hasNext()) {
+			String element = it.next();
+			if (element.equals("c"))
+				it.remove();
+		}
+
+		// check size
+		Assert.assertEquals(2, ars1.size());
+
+		// check remaining elements
+		boolean aFound = false;
+		boolean bFound = false;
+		for (String element : ars1) {
+			if (element.equals("a")) {
+				Assert.assertFalse(aFound);
+				aFound = true;
+			}
+			if (element.equals("b")) {
+				Assert.assertFalse(bFound);
+				bFound = true;
+			}
+		}
+		Assert.assertTrue(aFound);
+		Assert.assertTrue(bFound);
 	}
 	
 }


### PR DESCRIPTION
The "remove" method of the ArraySparseSet iterator did not work correctly because it used a wrong index. This has been fixed now. A test for this method has been added.