### PR TITLE
Fixes Constructor.newInstance handling

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -846,7 +846,7 @@ public final class OnFlyCallGraphBuilder {
             }
             break;
           case "java.lang.reflect.Constructor":
-            if (methodRef.getSubSignature().getString().equals("java.lang.Object newInstance(java.lang.Object[]))")) {
+            if (methodRef.getSubSignature().getString().equals("java.lang.Object newInstance(java.lang.Object[])")) {
               reflectionModel.contructorNewInstance(source, s);
             }
             break;


### PR DESCRIPTION
The subsignature in the on-the-fly call graph builder had an
extra ending ')', which caused it to skip handling all calls to
Constructor.newInstance.