### PR TITLE
Remove this-assignment from body when method is corrected to static

### DIFF
--- a/src/main/java/soot/Body.java
+++ b/src/main/java/soot/Body.java
@@ -289,15 +289,20 @@ public abstract class Body extends AbstractHost implements Serializable {
     return trapChain;
   }
 
-  /** Return LHS of the first identity stmt assigning from \@this. **/
-  public Local getThisLocal() {
-    for (Unit s : getUnits()) {
-      if (s instanceof IdentityStmt && ((IdentityStmt) s).getRightOp() instanceof ThisRef) {
-        return (Local) (((IdentityStmt) s).getLeftOp());
+  /** Return unit containing the \@this-assignment **/
+  public Unit getThisUnit() {
+    for (Unit u : getUnits()) {
+      if (u instanceof IdentityStmt && ((IdentityStmt) u).getRightOp() instanceof ThisRef) {
+        return u;
       }
     }
 
-    throw new RuntimeException("couldn't find identityref!" + " in " + getMethod());
+    throw new RuntimeException("couldn't find this-assignment!" + " in " + getMethod());
+  }
+
+  /** Return LHS of the first identity stmt assigning from \@this. **/
+  public Local getThisLocal() {
+    return (Local) (((IdentityStmt) getThisUnit()).getLeftOp());
   }
 
   /** Return LHS of the first identity stmt assigning from \@parameter i. **/

--- a/src/main/java/soot/jimple/toolkits/scalar/MethodStaticnessCorrector.java
+++ b/src/main/java/soot/jimple/toolkits/scalar/MethodStaticnessCorrector.java
@@ -70,6 +70,9 @@ public class MethodStaticnessCorrector extends AbstractStaticnessCorrector {
               SootMethod target = Scene.v().grabMethod(iexpr.getMethodRef().getSignature());
               if (target != null && !target.isStatic()) {
                 if (canBeMadeStatic(target)) {
+                  // Remove the this-assignment to prevent
+                  // 'this-assignment in a static method!' exception
+                  target.getActiveBody().getUnits().remove(target.getActiveBody().getThisUnit());
                   target.setModifiers(target.getModifiers() | Modifier.STATIC);
                 }
               }


### PR DESCRIPTION
When analyzing the 'com.magzter.platin' apk (to transform it to .class files or a new apk) I had the following error:
```
@this-assignment in a static method!
    at soot.jimple.validation.IdentityStatementsValidator.validate(IdentityStatementsValidator.java:70)
    at soot.jimple.JimpleBody.validate(JimpleBody.java:118)
    at soot.jimple.JimpleBody.validate(JimpleBody.java:98)
    at soot.baf.BafBody.<init>(BafBody.java:82)
    at soot.baf.Baf.newBody(Baf.java:549)
    at soot.PackManager.convertJimpleBodyToBaf(PackManager.java:1093)
    at soot.PackManager.runBodyPacks(PackManager.java:1048)
    at soot.PackManager.runBodyPacks(PackManager.java:667)
    ... 5 more
```
It seems that an originally non static method (that contains a this-assignment in its body) which is
then corrected to static method (by the MethodStaticnessCorrector class) keeps its this-assignment.
So when validation is performed, the newly static method has a this-assignment.

The PR should fix the issue by removing the this-assignment when changing the method to a static
one.

Also, since the changes are done from the transformation of an other method, I'm not sure that it's
thread safe. The tests with this apk passed but I can't affirm anything about thread safety since I
don't know understand the whole process.

Finally, I have a question: how to log a warning when suppressing the this-assignment? This deletion
modify the semantic of the code parsed (the class becomes static during the analysis) so I think it would be relevant to notice the user when doing so.
