### PR TITLE
Fixing a (possible) ConcurrentModificationException

### DIFF
--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -1282,7 +1282,7 @@ public class PackManager {
       // note: the following is a snapshot iterator;
       // this is necessary because it can happen that phantom methods
       // are added during resolution
-      Iterator<SootMethod> methodIt = cl.getMethods().iterator();
+      Iterator<SootMethod> methodIt = new ArrayList<SootMethod>(cl.getMethods()).iterator();
       while (methodIt.hasNext()) {
         final SootMethod m = methodIt.next();
         if (m.isConcrete()) {


### PR DESCRIPTION
I noticed a concurrency error in the retrieveAllBody method of the PackManager class. I was doing
weird things with its code but it can also be easily reproduced by adding a `Thread.sleep()` call right after the creation of the thread that will execute `retriveActiveBody()`.
With the class: AbstractClientConnAdapter (taken from the apk com.app_dalkeith.layout, sha256: 007E8F1EE6ABAE56E444920051F48E4F9B3A5AFE9CBA6D8DD000A675C7177DEC), sleeping 5 milliseconds:

```java
1286       while (methodIt.hasNext()) {
1287         final SootMethod m = methodIt.next();
1288         if (m.isConcrete()) {
1289           executor.execute(new Runnable() {
1290
1291             @Override
1292             public void run() {
1293               m.retrieveActiveBody();
1294             }
1295
1296           });
1297           try {
1298             Thread.sleep(5);
1299           } catch (InterruptedException e) {
1300             // TODO Auto-generated catch block
1301             e.printStackTrace();
1302           }
1303         }
1304       }

```
results in a:
```
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
    at java.util.ArrayList$Itr.next(ArrayList.java:859)
    at soot.PackManager.retrieveAllBodies(PackManager.java:1288)
    at soot.PackManager.runPacksNormally(PackManager.java:497)
    at soot.PackManager.runPacks(PackManager.java:419)
    at soot.Main.run(Main.java:269)
    at soot.Main.main(Main.java:141)
```
However this occurs only if both '-ire' and '-allow-phantom-refs' are used. Eg:
```
java  -cp sootclasses-trunk-jar-with-dependencies.jar soot.Main -f class -ire -allow-phantom-refs
-src-prec apk -process-dir input/
```
(with AbstractClientConnAdapter.dex in input). The dex file can be found in <https://github.com/Sowke/faulty-apk/tree/master/concurrent_error>. Actually with a 5 ms sleep this error happens with a lot of apk, they can be downloaded from the same repo as AbstractClientConnAdapter.dex.

The reason I found is that the array `methodList` that is looped over to create the threads may be appended with a new method in `tryResolve(StringBuffer trace)` from the class SootMethodRefImpl (if
both the options are set).
It doesn't happen with a regular apk because looping over the methodList is way quicker than reaching the call to the method that may change it. But if something slows down the main thread the modification of the methodList may occurred before the end of the while loop. Hence, creating a ConcurrentModificationException.

Moreover, there is a comment before creating the iterator that will be used to loop over the methodList which states:
```java
// note: the following is a snapshot iterator;
// this is necessary because it can happen that phantom methods
// are added during resolution
```
but then only a common iterator is created.

This PR simply proposes to create an iterator over a copy of the methodList.
