### PR TITLE
Fix for an outer class without name in Android app com.mgi.moneygram

### DIFF
--- a/src/main/java/soot/dexpler/DexClassLoader.java
+++ b/src/main/java/soot/dexpler/DexClassLoader.java
@@ -141,10 +141,9 @@ public class DexClassLoader {
 
           // Get the outer class name
           String outer = DexInnerClassParser.getOuterClassNameFromTag(ict);
-          if (outer == null) {
+          if (outer == null || outer.length() == 0) {
             // If we don't have any clue what the outer class is, we
-            // just remove
-            // the reference entirely
+            // just remove the reference entirely
             innerTagIt.remove();
             continue;
           }


### PR DESCRIPTION
Fix for an outer class without name in Android app com.mgi.moneygram_4.0.1 (4000100):
[inner=L$b, outer=, name=Factory,flags=1545]
[inner=L$a, outer=, name=AndroidViewModelFactory,flags=9]
[inner=L$c, outer=, name=NewInstanceFactory,flags=9]

Otherwise Soot runs into a java.lang.StringIndexOutOfBoundsException:
String index out of range: 0