### PR TITLE
Bug fix: ClassFormatException not found

### DIFF
--- a/src/test/java/soot/asm/backend/ConstantPoolTest.java
+++ b/src/test/java/soot/asm/backend/ConstantPoolTest.java
@@ -40,8 +40,6 @@ import org.objectweb.asm.util.TraceClassVisitor;
 import soot.G;
 import soot.Main;
 
-import com.sun.org.apache.bcel.internal.classfile.ClassFormatException;
-
 /**
  * Test for fields that contain constant values
  *
@@ -244,8 +242,6 @@ public class ConstantPoolTest extends AbstractASMBackendTest {
 		} catch (MalformedURLException e) {
 			logger.error(e.getMessage(), e);
 		} catch (ClassNotFoundException e) {
-			logger.error(e.getMessage(), e);
-		} catch (ClassFormatException e) {
 			logger.error(e.getMessage(), e);
 		}
 


### PR DESCRIPTION
Not able to compile this test file using Oracle JDK 10 and 11 on macOS 10.13:

Error:Error:line (43)java: package com.sun.org.apache.bcel.internal.classfile does not exist
Error:Error:line (248)java: cannot find symbol
symbol:   class ClassFormatException
location: class soot.asm.backend.ConstantPoolTest

Turned out no method in that try-catch block will throw a ClassFormatException, thus it will be safe not to catch that exception.