### PR TITLE
Bug fix: No break after tableswitch

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -1772,6 +1772,7 @@ final class AsmMethodSource implements MethodSource {
           convertTableSwitchInsn(swtch);
           LabelNode dflt = swtch.dflt;
           addEdges(insn, dflt, swtch.labels);
+          break;
         } else if (type == TYPE_INSN) {
           convertTypeInsn((TypeInsnNode) insn);
         } else if (type == VAR_INSN) {


### PR DESCRIPTION
There should be a break after processing TABLESWITCH, like other control instructions. Otherwise, the hand-constructed example below will not successfully translate. It will crash when translating POP, because the stack height after TABLESWITCH is 0, while it is 1 when jumping from IFEQ.

The complete test class file is attached at the bottom, which is executable.

  // access flags 0x8
  static foo(II)V
   L0
    LINENUMBER 7 L0
    ILOAD 0
    ILOAD 1
    IFEQ L1
    TABLESWITCH
      1: L2
      2: L2
      default: L2
   L1
   FRAME SAME1 I
    POP
   L2
   FRAME SAME
    RETURN
    MAXSTACK = 2
    MAXLOCALS = 2

[Tableswitch.zip](https://github.com/Sable/soot/files/2474257/Tableswitch.zip)