### PR TITLE
New: SootMethodInterface as a common interface for SootMethod and SootMethodRef

### DIFF
--- a/src/main/java/soot/SootMethod.java
+++ b/src/main/java/soot/SootMethod.java
@@ -30,6 +30,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import soot.dava.DavaBody;
 import soot.dava.toolkits.base.renamer.RemoveFullyQualifiedName;
 import soot.jimple.toolkits.callgraph.VirtualCalls;
@@ -40,18 +43,21 @@ import soot.util.Numberable;
 import soot.util.NumberedString;
 
 /**
- * Soot representation of a Java method. Can be declared to belong to a SootClass. Does not contain the actual code, which
- * belongs to a Body. The getActiveBody() method points to the currently-active body.
+ * Soot representation of a Java method. Can be declared to belong to a {@link SootClass}. Does not contain the actual code,
+ * which belongs to a {@link Body}. The {@link #getActiveBody()} method points to the currently-active body.
  */
-public class SootMethod extends AbstractHost implements ClassMember, Numberable, MethodOrMethodContext {
+public class SootMethod extends AbstractHost implements ClassMember, Numberable, MethodOrMethodContext, SootMethodInterface {
+
+  private static final Logger logger = LoggerFactory.getLogger(SootMethod.class);
+
   public static final String constructorName = "<init>";
   public static final String staticInitializerName = "<clinit>";
-  public static boolean DEBUG = false;
+
   /** Name of the current method. */
   protected String name;
 
   /**
-   * An array of parameter types taken by this <code>SootMethod</code> object, in declaration order.
+   * An array of parameter types taken by this {@link SootMethod} object, in declaration order.
    */
   protected Type[] parameterTypes;
 
@@ -59,7 +65,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   protected Type returnType;
 
   /**
-   * True when some <code>SootClass</code> object declares this <code>SootMethod</code> object.
+   * True when some {@link SootClass} object declares this {@link SootMethod} object.
    */
   protected boolean isDeclared;
 
@@ -67,7 +73,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   protected SootClass declaringClass;
 
   /**
-   * Modifiers associated with this SootMethod (e.g. private, protected, etc.)
+   * Modifiers associated with this {@link SootMethod} (e.g. private, protected, etc.)
    */
   protected int modifiers;
 
@@ -82,26 +88,26 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
 
   /** Tells this method how to find out where its body lives. */
   protected volatile MethodSource ms;
-  
+
   protected volatile String sig;
   protected volatile String subSig;
 
   /**
-   * Constructs a SootMethod with the given name, parameter types and return type.
+   * Constructs a {@link SootMethod} with the given name, parameter types and return type.
    */
   public SootMethod(String name, List<Type> parameterTypes, Type returnType) {
     this(name, parameterTypes, returnType, 0, Collections.<SootClass>emptyList());
   }
 
   /**
-   * Constructs a SootMethod with the given name, parameter types, return type and modifiers.
+   * Constructs a {@link SootMethod} with the given name, parameter types, return type and modifiers.
    */
   public SootMethod(String name, List<Type> parameterTypes, Type returnType, int modifiers) {
     this(name, parameterTypes, returnType, modifiers, Collections.<SootClass>emptyList());
   }
 
   /**
-   * Constructs a SootMethod with the given name, parameter types, return type, and list of thrown exceptions.
+   * Constructs a {@link SootMethod} with the given name, parameter types, return type, and list of thrown exceptions.
    */
   public SootMethod(String name, List<Type> parameterTypes, Type returnType, int modifiers,
       List<SootClass> thrownExceptions) {
@@ -120,7 +126,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     }
     subsignature = Scene.v().getSubSigNumberer().findOrAdd(getSubSignature());
   }
-  
+
   /**
    * Returns a hash code for this method consistent with structural equality.
    */
@@ -132,7 +138,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   public String getName() {
     return name;
   }
-  
+
   /** Sets the name of this method. */
   public synchronized void setName(String name) {
     boolean wasDeclared = isDeclared;
@@ -154,7 +160,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     // There is nothing to stop this field from being null except when it actually gets in
     // other classes such as SootMethodRef (when it tries to resolve the method). However, if
     // the method is not declared, it should not be trying to resolve it anyways. So I see no
-    // problem with having it able to be null. 
+    // problem with having it able to be null.
     if (declClass != null) {
       Scene.v().getMethodNumberer().add(this);
     }
@@ -164,7 +170,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     sig = null;
   }
 
-  /** Returns the class which declares the current <code>SootMethod</code>. */
+  /** Returns the class which declares the current {@link SootMethod}. */
   @Override
   public SootClass getDeclaringClass() {
     if (!isDeclared) {
@@ -179,23 +185,20 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   }
 
   /**
-   * Returns true when some <code>SootClass</code> object declares this <code>SootMethod</code> object.
+   * Returns true when some {@link SootClass} object declares this {@link SootMethod} object.
    */
   @Override
   public boolean isDeclared() {
     return isDeclared;
   }
 
-  /** Returns true when this <code>SootMethod</code> object is phantom. */
+  /** Returns true when this {@link SootMethod} object is phantom. */
   @Override
   public boolean isPhantom() {
     return isPhantom;
   }
 
-  /**
-   * Returns true if this method is not phantom, abstract or native, i.e. this method can have a body.
-   */
-
+  /** Returns true if this method is not phantom, abstract or native, i.e. this method can have a body. */
   public boolean isConcrete() {
     return !isPhantom() && !isAbstract() && !isNative();
   }
@@ -290,16 +293,16 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     }
   }
 
-  /** Returns the MethodSource of the current SootMethod. */
+  /** Returns the {@link MethodSource} of the current {@link SootMethod}. */
   public MethodSource getSource() {
     return ms;
   }
-  
-  /** Sets the MethodSource of the current SootMethod. */
+
+  /** Sets the {@link MethodSource} of the current {@link SootMethod}. */
   public synchronized void setSource(MethodSource ms) {
     this.ms = ms;
   }
-  
+
   /**
    * Retrieves the active body for this method.
    */
@@ -312,7 +315,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     if (activeBody != null) {
       return activeBody;
     }
-    
+
     // Synchronize because we are operating on two fields that may be updated
     // separately otherwise.
     synchronized (this) {
@@ -321,14 +324,14 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
       if (activeBody != null) {
         return activeBody;
       }
-      
+
       if (declaringClass != null) {
         declaringClass.checkLevel(SootClass.BODIES);
       }
       if ((declaringClass != null && declaringClass.isPhantomClass()) || isPhantom()) {
         throw new RuntimeException("cannot get active body for phantom method: " + getSignature());
       }
-      
+
       // ignore empty body exceptions if we are just computing coffi metrics
       if (!soot.jbco.Main.metrics) {
         throw new RuntimeException("no active body present for method " + getSignature());
@@ -359,12 +362,12 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
 
     this.activeBody = body;
   }
-  
+
   /**
    * Returns the active body if present, else constructs an active body and returns that.
    *
    * If you called Scene.v().loadClassAndSupport() for a class yourself, it will not be an application class, so you cannot
-   * get retrieve its active body. Please call setApplicationClass() on the relevant class.
+   * get retrieve its active body. Please call {@link SootClass#setApplicationClass()} on the relevant class.
    */
   public Body retrieveActiveBody() {
     // Retrieve the active body so thread changes do not affect the
@@ -374,7 +377,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     if (activeBody != null) {
       return activeBody;
     }
-    
+
     // Synchronize because we are operating on multiple fields that may be updated
     // separately otherwise.
     synchronized (this) {
@@ -383,22 +386,22 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
       if (activeBody != null) {
         return activeBody;
       }
-      
+
       if (declaringClass != null) {
         declaringClass.checkLevel(SootClass.BODIES);
       }
       if ((declaringClass != null && declaringClass.isPhantomClass()) || isPhantom()) {
         throw new RuntimeException("cannot get resident body for phantom method : " + this);
       }
-      
+
       if (ms == null) {
         throw new RuntimeException("No method source set for method " + this);
       }
-      
+
       // Method sources are not expected to be thread safe
       activeBody = ms.getBody(this, "jb");
       setActiveBody(activeBody);
-      
+
       // If configured, we drop the method source to save memory
       if (Options.v().drop_bodies_after_load()) {
         ms = null;
@@ -430,9 +433,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
    * Adds the given exception to the list of exceptions thrown by this method.
    */
   public void addException(SootClass e) {
-    if (DEBUG) {
-      System.out.println("Adding exception " + e);
-    }
+    logger.trace("Adding exception {}", e);
 
     if (exceptions == null) {
       exceptions = new ArrayList<SootClass>();
@@ -447,9 +448,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
    * Removes the given exception from the list of exceptions thrown by this method.
    */
   public void removeException(SootClass e) {
-    if (DEBUG) {
-      System.out.println("Removing exception " + e);
-    }
+    logger.trace("Removing exception {}", e);
 
     if (exceptions == null) {
       throw new RuntimeException("does not throw exception " + e.getName());
@@ -643,9 +642,9 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     }
     return sig;
   }
-  
+
   public static String getSignature(SootClass cl, String name, List<Type> params, Type returnType) {
-    return getSignature(cl,getSubSignatureImpl(name, params, returnType));
+    return getSignature(cl, getSubSignatureImpl(name, params, returnType));
   }
 
   public static String getSignature(SootClass cl, String subSignature) {

--- a/src/main/java/soot/SootMethodInterface.java
+++ b/src/main/java/soot/SootMethodInterface.java
@@ -1,0 +1,36 @@
+package soot;
+
+import java.util.List;
+
+import soot.util.NumberedString;
+
+/**
+ * The common interface of {@link SootMethod} (resolved method) and {@link SootMethodRef} (unresolved method). Therefore it
+ * allows to access the properties independently whether the method is a resolved one or not.
+ */
+public interface SootMethodInterface {
+
+  /**
+   *  @return The class which declares the current {@link SootMethod}/{@link SootMethodRef}  
+   */
+  public SootClass getDeclaringClass();
+
+  /**
+   * @return Name of the method
+   */
+  public String getName();
+
+  public List<Type> getParameterTypes();
+
+  public Type getParameterType(int i);
+
+  public Type getReturnType();
+
+  public boolean isStatic();
+
+  /**
+   * @return The Soot signature of this method. Used to refer to methods unambiguously.
+   */
+  public String getSignature();
+
+}

--- a/src/main/java/soot/SootMethodRef.java
+++ b/src/main/java/soot/SootMethodRef.java
@@ -24,6 +24,8 @@ package soot;
 
 import java.util.List;
 
+import soot.SootMethodRefImpl.ClassResolutionFailedException;
+import soot.options.Options;
 import soot.util.NumberedString;
 
 /**
@@ -31,15 +33,27 @@ import soot.util.NumberedString;
  * actually exist; the actual target of the reference is determined according to the resolution procedure in the Java Virtual
  * Machine Specification, 2nd ed, section 5.4.3.3.
  */
+public interface SootMethodRef extends SootMethodInterface {
 
-public interface SootMethodRef {
-  public SootClass declaringClass();
+  /**
+   * Use {@link #getDeclaringClass()} instead
+   */
+  public @Deprecated SootClass declaringClass();
 
-  public String name();
+  /**
+   * Use {@link #getName()} instead
+   */
+  public @Deprecated String name();
 
-  public List<Type> parameterTypes();
+  /**
+   * Use {@link #getParameterTypes()} instead
+   */
+  public @Deprecated List<Type> parameterTypes();
 
-  public Type returnType();
+  /**
+   * Use {@link #getReturnType()} instead
+   */
+  public @Deprecated Type returnType();
 
   public boolean isStatic();
 
@@ -47,26 +61,31 @@ public interface SootMethodRef {
 
   public String getSignature();
 
-  public Type parameterType(int i);
+  /**
+   * Use {@link #getParameterType(int)} instead
+   */
+  public @Deprecated Type parameterType(int i);
 
   /**
    * Resolves this method call, i.e., finds the method to which this reference points. This method does not handle virtual
    * dispatch, it just gives the immediate target, which can also be an abstract method.
    *
    * @return The immediate target if this method reference
+   * @throws ClassResolutionFailedException
+   *           (can be suppressed by {@link Options#set_ignore_resolution_errors(boolean)})
    */
   public SootMethod resolve();
 
   /**
    * Tries to resolve this method call, i.e., tries to finds the method to which this reference points. This method does not
    * handle virtual dispatch, it just gives the immediate target, which can also be an abstract method. This method is
-   * different from resolve() in the following ways:
+   * different from {@link #resolve()} in the following ways:
    *
    * (1) This method does not fail when the target method does not exist and phantom references are not allowed. In that
-   * case, it returns null. (2) While resolve() creates fake methods that throw exceptions when a target method does not
-   * exist and phantom references are allowed, this method returns null.
+   * case, it returns <code>null</code>. (2) While {@link #resolve()} creates fake methods that throw exceptions when a
+   * target method does not exist and phantom references are allowed, this method returns <code>null</code>.
    *
-   * @return The immediate target if this method reference if available, null otherwise
+   * @return The immediate target if this method reference if available, <code>null</code> otherwise
    */
   public SootMethod tryResolve();
 

--- a/src/main/java/soot/SootMethodRefImpl.java
+++ b/src/main/java/soot/SootMethodRefImpl.java
@@ -86,21 +86,39 @@ public class SootMethodRefImpl implements SootMethodRef {
 
   @Override
   public SootClass declaringClass() {
+    return getDeclaringClass();
+  }
+
+  public SootClass getDeclaringClass() {
     return declaringClass;
   }
 
   @Override
   public String name() {
+    return getName();
+  }
+
+  @Override
+  public String getName() {
     return name;
   }
 
   @Override
   public List<Type> parameterTypes() {
+    return getParameterTypes();
+  }
+
+  public List<Type> getParameterTypes() {
     return parameterTypes == null ? Collections.<Type>emptyList() : parameterTypes;
   }
 
   @Override
   public Type returnType() {
+    return getReturnType();
+  }
+
+  @Override
+  public Type getReturnType() {
     return returnType;
   }
 
@@ -124,6 +142,11 @@ public class SootMethodRefImpl implements SootMethodRef {
 
   @Override
   public Type parameterType(int i) {
+    return getParameterType(i);
+  }
+
+  @Override
+  public Type getParameterType(int i) {
     return parameterTypes.get(i);
   }
 
@@ -159,8 +182,8 @@ public class SootMethodRefImpl implements SootMethodRef {
 
   private SootMethod checkStatic(SootMethod ret) {
     if ((Options.v().wrong_staticness() == Options.wrong_staticness_fail
-          || Options.v().wrong_staticness() == Options.wrong_staticness_fixstrict)
-          && ret.isStatic() != isStatic() && !ret.isPhantom()) {
+        || Options.v().wrong_staticness() == Options.wrong_staticness_fixstrict) && ret.isStatic() != isStatic()
+        && !ret.isPhantom()) {
       throw new ResolutionFailedException("Resolved " + this + " to " + ret + " which has wrong static-ness");
     }
     return ret;
@@ -226,7 +249,7 @@ public class SootMethodRefImpl implements SootMethodRef {
     // an appropriate error just in case the code *is* actually reached at runtime
     boolean treatAsPhantomClass = Options.v().allow_phantom_refs() && !declaringClass.isInterface();
 
-    // declaring class of dynamic invocations not known at compile time, treat as 
+    // declaring class of dynamic invocations not known at compile time, treat as
     // phantom class regardless if phantom classes are enabled
     treatAsPhantomClass = treatAsPhantomClass || declaringClass.getName().equals(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME);
 
@@ -237,7 +260,7 @@ public class SootMethodRefImpl implements SootMethodRef {
     if (trace == null) {
       ClassResolutionFailedException e = new ClassResolutionFailedException();
       if (Options.v().ignore_resolution_errors()) {
-        logger.debug("" + e.getMessage());
+        logger.debug(e.getMessage());
       } else {
         throw e;
       }


### PR DESCRIPTION
The method names are based on the one from SootMethod -
where there was a mismatch to the names in SootMethodRef the relevant
methods has been created. The old methods exists for backwards
compatibility, they are marked deprecated.

Some JavaDoc annotations improved + some minor logging changes.