### PR TITLE
fix: bugfix for #1060

### DIFF
--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -84,6 +84,8 @@ public class SootClass extends AbstractHost implements Numberable {
 
   public final static String INVOKEDYNAMIC_DUMMY_CLASS_NAME = "soot.dummy.InvokeDynamic";
 
+  public final static String JAVA_LANG_OBJECT = "java.lang.Object";
+  
   /**
    * Constructs an empty SootClass with the given name and modifiers.
    */


### PR DESCRIPTION
Instead of isPhantom() we now use !hasSuperclass() || "java.lang.Object".equals(sootClass.getName())

For further details please see issue #1060