### PR TITLE
Implement parameter adaptation in LambdaMetaFactory

### DIFF
--- a/src/main/java/soot/LambdaMetaFactory.java
+++ b/src/main/java/soot/LambdaMetaFactory.java
@@ -23,42 +23,64 @@ package soot;
  * #L%
  */
 
-import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import soot.javaToJimple.LocalGenerator;
 import soot.jimple.ClassConstant;
-import soot.jimple.IdentityStmt;
 import soot.jimple.IntConstant;
 import soot.jimple.InvokeExpr;
+import soot.jimple.InvokeStmt;
 import soot.jimple.Jimple;
 import soot.jimple.JimpleBody;
 import soot.jimple.MethodHandle;
 import soot.jimple.MethodType;
-import soot.jimple.VirtualInvokeExpr;
+import soot.jimple.NewExpr;
+import soot.jimple.ParameterRef;
+import soot.jimple.SpecialInvokeExpr;
+import soot.jimple.toolkits.scalar.LocalNameStandardizer;
+import soot.util.Chain;
+import soot.util.HashChain;
 
 public final class LambdaMetaFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(LambdaMetaFactory.class);
 
   private static int uniq;
 
-  public static SootMethodRef makeLambdaHelper(List<? extends Value> bootstrapArgs, int tag, String name, Type[] types) {
+  /**
+   * 
+   * @param bootstrapArgs
+   * @param tag
+   * @param name
+   * @param invokedType
+   *          types of captured arguments, the last element is always the type of the FunctionalInterface
+   * @param enclosingClassname
+   * @return
+   */
+  // FIXME: synchronized to work around concurrency errors; possibly covering up actual problems
+  public synchronized static SootMethodRef makeLambdaHelper(List<? extends Value> bootstrapArgs, int tag, String name,
+      Type[] invokedType, SootClass enclosingClass) {
     if (bootstrapArgs.size() < 3 || !(bootstrapArgs.get(0) instanceof MethodType)
         || !(bootstrapArgs.get(1) instanceof MethodHandle) || !(bootstrapArgs.get(2) instanceof MethodType)
         || (bootstrapArgs.size() > 3 && !(bootstrapArgs.get(3) instanceof IntConstant))) {
-      LOGGER.warn("LambdaMetaFactory: unexpected arguments for LambdaMetaFactor.metaFactory: {}", bootstrapArgs);
+      LOGGER.warn("LambdaMetaFactory: unexpected arguments for LambdaMetaFactory.metaFactory: {}", bootstrapArgs);
       return null;
     }
-
+    /** implemented method type */
     MethodType samMethodType = ((MethodType) bootstrapArgs.get(0));
-    SootMethodRef implMethod = ((MethodHandle) bootstrapArgs.get(1)).getMethodRef();
+
+    /** the MethodHandle providing the implementation */
+    MethodHandle implMethod = ((MethodHandle) bootstrapArgs.get(1));
+
+    /** allows restrictions on invocation */
     MethodType instantiatedMethodType = ((MethodType) bootstrapArgs.get(2));
 
     int flags = 0;
@@ -111,20 +133,40 @@ public final class LambdaMetaFactory {
       }
     }
 
-    List<Type> capTypes = Arrays.asList(types).subList(0, types.length - 1);
-    if (!(types[types.length - 1] instanceof RefType)) {
-      LOGGER.warn("unexpected interface type: " + types[types.length - 1]);
+    List<Type> capTypes = Arrays.asList(invokedType).subList(0, invokedType.length - 1);
+    if (!(invokedType[invokedType.length - 1] instanceof RefType)) {
+      LOGGER.warn("unexpected interface type: " + invokedType[invokedType.length - 1]);
       return null;
     }
-    SootClass iface = ((RefType) types[types.length - 1]).getSootClass();
+    SootClass functionalInterfaceToImplement = ((RefType) invokedType[invokedType.length - 1]).getSootClass();
 
     // Our thunk class implements the functional interface
-    String className = "soot.dummy." + implMethod.name() + "$" + uniqSupply();
+    String enclosingClassname = enclosingClass.getName();
+    String enclosingClassnamePrefix = null;
+    if (enclosingClassname == null || enclosingClassname.equals("")) {
+      enclosingClassnamePrefix = "soot.dummy.";
+    } else {
+      enclosingClassnamePrefix = enclosingClassname + "$";
+    }
+
+    String className;
+    final boolean readableClassnames = true;
+    if (readableClassnames) {
+      // class names cannot contain <>
+      String implMethodName = implMethod.getMethodRef().name();
+      String dummyName = "<init>".equals(implMethodName) ? "init" : implMethodName;
+      // XXX: $ causes confusion in inner class inference; remove for now
+      dummyName = dummyName.replaceAll("\\$", "_");
+      className = enclosingClassnamePrefix + dummyName + "__" + uniqSupply();
+    } else {
+      className = "soot.dummy.lambda" + uniqSupply();
+    }
     SootClass tclass = new SootClass(className);
-
+    tclass.setModifiers(Modifier.PUBLIC | Modifier.FINAL);
     tclass.setSuperclass(Scene.v().getObjectType().getSootClass());
-    tclass.addInterface(iface);
+    tclass.addInterface(functionalInterfaceToImplement);
 
+    // additions from altMetafactory
     if (serializable) {
       tclass.addInterface(RefType.v("java.io.Serializable").getSootClass());
     }
@@ -140,39 +182,45 @@ public final class LambdaMetaFactory {
       tclass.addField(f);
     }
 
-    List<Type> typedParameterTypes = instantiatedMethodType.getParameterTypes();
-    Type retType = instantiatedMethodType.getReturnType();
-    ThunkMethodSource ms = new ThunkMethodSource(capFields, typedParameterTypes, retType, implMethod);
+    // if the implMethod is a new private static in the enclosing class, make it public access so
+    // it can be invoked from the thunk class
+    if (MethodHandle.Kind.REF_INVOKE_STATIC.getValue() == implMethod.getKind()) {
+      if (implMethod.getMethodRef().declaringClass().getName().equals(enclosingClassname)) {
+        SootMethod method
+            = implMethod.getMethodRef().declaringClass().getMethod(implMethod.getMethodRef().getSubSignature());
+        int modifiers = method.getModifiers() & ~Modifier.PRIVATE;
+        modifiers = modifiers | Modifier.PUBLIC;
+        method.setModifiers(modifiers);
+      }
+    }
 
-    // create a method with the concrete, non-erased types first
-    SootMethod apply = new SootMethod(name, typedParameterTypes, retType);
-    tclass.addMethod(apply);
-    apply.setSource(ms);
+    MethodSource ms = new ThunkMethodSource(capFields, samMethodType, implMethod, instantiatedMethodType);
 
     // Bootstrap method creates a new instance of this class
-    SootMethod tboot = new SootMethod("bootstrap$", capTypes, iface.getType(), Modifier.STATIC);
+    SootMethod tboot = new SootMethod("bootstrap$", capTypes, functionalInterfaceToImplement.getType(),
+        Modifier.PUBLIC | Modifier.STATIC);
     tclass.addMethod(tboot);
     tboot.setSource(ms);
 
     // Constructor just copies the captures
-    SootMethod tctor = new SootMethod("<init>", capTypes, VoidType.v());
+    SootMethod tctor = new SootMethod("<init>", capTypes, VoidType.v(), Modifier.PUBLIC);
     tclass.addMethod(tctor);
     tctor.setSource(ms);
 
-    boolean isGeneric = !samMethodType.equals(instantiatedMethodType);
-    if (isGeneric) {
-      // if the functional interface is generic in it' return-/parameter-types, we have to create bridging method which can
-      // work with plain objects and re-routes the call to the actual thunk method
-      addBridge(name, tclass, samMethodType, instantiatedMethodType, apply);
-    }
+    // Dispatch runs the 'real' method implementing the body of the lambda
+    addDispatch(name, tclass, samMethodType, instantiatedMethodType, capFields, implMethod);
 
+    // For each bridge MethodType, add another dispatch method which calls the 'real' method
     for (int i = 0; i < bridges.size(); i++) {
       final MethodType bridgeType = bridges.get(i);
-      addBridge(name, tclass, bridgeType, instantiatedMethodType, apply);
+      addDispatch(name, tclass, bridgeType, instantiatedMethodType, capFields, implMethod);
     }
 
     Scene.v().addClass(tclass);
-    // The hierarchy has to be rebuild after adding the MetaFactory implementation
+    if (enclosingClass.isApplicationClass())
+      tclass.setApplicationClass();
+
+    // The hierarchy has to be rebuilt after adding the MetaFactory implementation
     // soot.FastHierarchy.canStoreClass will otherwise fail due to not having an interval set for the class which eventually
     // leads to the MetaFactory not being accepted as implementation of the functional interface it actually implements
     // which, in turn, lead to missing edges in the call graph
@@ -181,14 +229,12 @@ public final class LambdaMetaFactory {
     return tboot.makeRef();
   }
 
-  private static void addBridge(String name, SootClass tclass, MethodType bridgeType, MethodType targetType,
-      SootMethod apply) {
-    final List<Type> bridgeParams = bridgeType.getParameterTypes();
-    final Type bridgeReturn = bridgeType.getReturnType();
-    SootMethod genericBridge = new SootMethod(name, bridgeParams, bridgeReturn);
-    tclass.addMethod(genericBridge);
-    genericBridge.setSource(new BridgeMethodSource(bridgeParams, targetType.getParameterTypes(), bridgeReturn,
-        targetType.getReturnType(), apply.makeRef()));
+  private static void addDispatch(String name, SootClass tclass, MethodType implMethodType,
+      MethodType instantiatedMethodType, List<SootField> capFields, MethodHandle implMethod) {
+    ThunkMethodSource ms = new ThunkMethodSource(capFields, implMethodType, implMethod, instantiatedMethodType);
+    SootMethod m = new SootMethod(name, implMethodType.getParameterTypes(), implMethodType.getReturnType(), Modifier.PUBLIC);
+    tclass.addMethod(m);
+    m.setSource(ms);
   }
 
   private static synchronized long uniqSupply() {
@@ -196,16 +242,23 @@ public final class LambdaMetaFactory {
   }
 
   private static class ThunkMethodSource implements MethodSource {
+    /**
+     * fields storing capture variables, in the order they appear in invokedType; to be prepended at target invocation site
+     */
     private List<SootField> capFields;
-    private List<Type> paramTypes;
-    private Type retType;
-    private SootMethodRef implMethod;
+    /** MethodType of method to implemented by function object; either samMethodType or bridgeMethodType **/
+    private MethodType implMethodType;
+    /** implMethod - the MethodHandle providing the implementation */
+    private MethodHandle implMethod;
+    /** allows restrictions on invocation */
+    private MethodType instantiatedMethodType;
 
-    public ThunkMethodSource(List<SootField> capFields, List<Type> paramTypes, Type retType, SootMethodRef implMethod) {
+    public ThunkMethodSource(List<SootField> capFields, MethodType implMethodType, MethodHandle implMethod,
+        MethodType instantiatedMethodType) {
       this.capFields = capFields;
-      this.paramTypes = paramTypes;
-      this.retType = retType;
+      this.implMethodType = implMethodType;
       this.implMethod = implMethod;
+      this.instantiatedMethodType = instantiatedMethodType;
     }
 
     public Body getBody(SootMethod m, String phaseName) {
@@ -215,139 +268,427 @@ public final class LambdaMetaFactory {
 
       SootClass tclass = m.getDeclaringClass();
       JimpleBody jb = Jimple.v().newBody(m);
-      PatchingChain<Unit> us = jb.getUnits();
-      LocalGenerator lc = new LocalGenerator(jb);
 
       if (m.getName().equals("<init>")) {
-        Local l = lc.generateLocal(tclass.getType());
-        us.add(Jimple.v().newIdentityStmt(l, Jimple.v().newThisRef(tclass.getType())));
-        us.add(Jimple.v()
-            .newInvokeStmt(Jimple.v().newSpecialInvokeExpr(l,
-                Scene.v().makeConstructorRef(Scene.v().getObjectType().getSootClass(), Collections.<Type>emptyList()),
-                Collections.<Value>emptyList())));
-        for (SootField f : capFields) {
-          int i = us.size() - 2;
-          Local l2 = lc.generateLocal(f.getType());
-          us.add(Jimple.v().newIdentityStmt(l2, Jimple.v().newParameterRef(f.getType(), i)));
-          us.add(Jimple.v().newAssignStmt(Jimple.v().newInstanceFieldRef(l, f.makeRef()), l2));
-        }
-        us.add(Jimple.v().newReturnVoidStmt());
+        getInitBody(tclass, jb);
       } else if (m.getName().equals("bootstrap$")) {
-        Local l = lc.generateLocal(tclass.getType());
-        Value val = Jimple.v().newNewExpr(tclass.getType());
-        us.add(Jimple.v().newAssignStmt(l, val));
-        us.add(Jimple.v().newInvokeStmt(Jimple.v().newSpecialInvokeExpr(l,
-            Scene.v().makeConstructorRef(tclass, Collections.<Type>emptyList()), Collections.<Value>emptyList())));
-        us.add(Jimple.v().newReturnStmt(l));
+        getBootstrapBody(tclass, jb);
       } else {
-        Local this_ = lc.generateLocal(tclass.getType());
-        us.add(Jimple.v().newIdentityStmt(this_, Jimple.v().newThisRef(tclass.getType())));
-
-        List<Local> args = new ArrayList<Local>();
-
-        for (SootField f : capFields) {
-          Local l = lc.generateLocal(f.getType());
-          us.add(Jimple.v().newAssignStmt(l, Jimple.v().newInstanceFieldRef(l, f.makeRef())));
-          args.add(l);
-        }
-
-        for (int i = 0; i < paramTypes.size(); i++) {
-          final Type ty = paramTypes.get(i);
-          Local l = lc.generateLocal(ty);
-          us.add(Jimple.v().newIdentityStmt(l, Jimple.v().newParameterRef(ty, i)));
-          args.add(l);
-        }
-
-        // distinguish between static and instance invocations of the lambda body
-        final InvokeExpr invoke;
-        if (implMethod.isStatic()) {
-          invoke = Jimple.v().newStaticInvokeExpr(implMethod, args);
-        } else {
-          // in case of instance invoke, the first argument is the actual receiver of the call
-          final Local base = args.remove(0);
-
-          if (implMethod.declaringClass().isInterface()) {
-            invoke = Jimple.v().newInterfaceInvokeExpr(base, implMethod, args);
-          } else {
-            invoke = Jimple.v().newVirtualInvokeExpr(base, implMethod, args);
-          }
-        }
-
-        if (retType == VoidType.v()) {
-          us.add(Jimple.v().newInvokeStmt(invoke));
-          us.add(Jimple.v().newReturnVoidStmt());
-        } else {
-          Local ret = lc.generateLocal(retType);
-          us.add(Jimple.v().newAssignStmt(ret, invoke));
-          us.add(Jimple.v().newReturnStmt(ret));
-        }
+        getInvokeBody(tclass, jb);
       }
+
+      // rename locals consistent with JimpleBodyPack
+      LocalNameStandardizer.v().transform(jb);
       return jb;
     }
-  }
 
-  private static class BridgeMethodSource implements MethodSource {
-    private final List<Type> paramTypes;
-    private final List<Type> targetTypes;
-    private final Type retType;
-    private final SootMethodRef apply;
-    private final Type targetRetType;
-
-    public BridgeMethodSource(List<Type> paramTypes, List<Type> targetTypes, Type retType, Type targetRetType,
-        SootMethodRef apply) {
-      Preconditions.checkArgument(paramTypes.size() == targetTypes.size());
-      this.paramTypes = paramTypes;
-      this.targetTypes = targetTypes;
-      this.retType = retType;
-      this.targetRetType = targetRetType;
-      this.apply = apply;
-    }
-
-    @Override
-    public Body getBody(SootMethod m, String phaseName) {
-      if (!phaseName.equals("jb")) {
-        throw new Error("unsupported body type: " + phaseName);
-      }
-
-      SootClass tclass = m.getDeclaringClass();
-      JimpleBody jb = Jimple.v().newBody(m);
+    /**
+     * Thunk class init (constructor)
+     * 
+     * @param tclass
+     *          thunk class
+     * @param jb
+     */
+    private void getInitBody(SootClass tclass, JimpleBody jb) {
       PatchingChain<Unit> us = jb.getUnits();
       LocalGenerator lc = new LocalGenerator(jb);
 
+      // @this
+      Local l = lc.generateLocal(tclass.getType());
+      us.add(Jimple.v().newIdentityStmt(l, Jimple.v().newThisRef(tclass.getType())));
+
+      // @parameters
+      Chain<Local> capLocals = new HashChain<>();
+      int i = 0;
+      for (SootField f : capFields) {
+        Local l2 = lc.generateLocal(f.getType());
+        us.add(Jimple.v().newIdentityStmt(l2, Jimple.v().newParameterRef(f.getType(), i)));
+        capLocals.add(l2);
+        i++;
+      }
+
+      // super java.lang.Object.<init>
+      us.add(Jimple.v()
+          .newInvokeStmt(Jimple.v().newSpecialInvokeExpr(l,
+              Scene.v().makeConstructorRef(Scene.v().getObjectType().getSootClass(), Collections.<Type>emptyList()),
+              Collections.<Value>emptyList())));
+
+      // assign parameters to fields
+      Iterator<Local> localItr = capLocals.iterator();
+      for (SootField f : capFields) {
+        Local l2 = localItr.next();
+        us.add(Jimple.v().newAssignStmt(Jimple.v().newInstanceFieldRef(l, f.makeRef()), l2));
+      }
+
+      us.add(Jimple.v().newReturnVoidStmt());
+    }
+
+    private void getBootstrapBody(SootClass tclass, JimpleBody jb) {
+      PatchingChain<Unit> us = jb.getUnits();
+      LocalGenerator lc = new LocalGenerator(jb);
+
+      List<Value> capValues = new ArrayList<Value>();
+      List<Type> capTypes = new ArrayList<Type>();
+      int i = 0;
+      for (SootField capField : capFields) {
+        Type type = capField.getType();
+        capTypes.add(type);
+        Local p = lc.generateLocal(type);
+        ParameterRef pref = Jimple.v().newParameterRef(type, i);
+        us.add(Jimple.v().newIdentityStmt(p, pref));
+        capValues.add(p);
+        i++;
+      }
+      Local l = lc.generateLocal(tclass.getType());
+      Value val = Jimple.v().newNewExpr(tclass.getType());
+      us.add(Jimple.v().newAssignStmt(l, val));
+      us.add(Jimple.v()
+          .newInvokeStmt(Jimple.v().newSpecialInvokeExpr(l, Scene.v().makeConstructorRef(tclass, capTypes), capValues)));
+      us.add(Jimple.v().newReturnStmt(l));
+    }
+
+    /**
+     * Adds method which implements functional interface and invokes target implementation.
+     * 
+     * @param tclass
+     * @param jb
+     */
+    private void getInvokeBody(SootClass tclass, JimpleBody jb) {
+      PatchingChain<Unit> us = jb.getUnits();
+      LocalGenerator lc = new LocalGenerator(jb);
+
+      // @this
       Local this_ = lc.generateLocal(tclass.getType());
-      final IdentityStmt thisIdentity = Jimple.v().newIdentityStmt(this_, Jimple.v().newThisRef(tclass.getType()));
-      us.addFirst(thisIdentity);
+      us.add(Jimple.v().newIdentityStmt(this_, Jimple.v().newThisRef(tclass.getType())));
+
+      // @parameter for direct arguments
+      Chain<Local> samParamLocals = new HashChain<>();
+      int i = 0;
+      for (Type ty : implMethodType.getParameterTypes()) {
+        Local l = lc.generateLocal(ty);
+        us.add(Jimple.v().newIdentityStmt(l, Jimple.v().newParameterRef(ty, i)));
+        samParamLocals.add(l);
+        i++;
+      }
+
+      // narrowing casts to match instantiatedMethodType
+      Iterator<Type> iptItr = instantiatedMethodType.getParameterTypes().iterator();
+      Chain<Local> instParamLocals = new HashChain<>();
+      for (Local l : samParamLocals) {
+        Type ipt = iptItr.next();
+        Local l2 = narrowingReferenceConversion(l, ipt, jb, us, lc);
+        instParamLocals.add(l2);
+      }
 
       List<Local> args = new ArrayList<Local>();
 
-      for (int i = 0; i < paramTypes.size(); i++) {
-        final Type paramType = paramTypes.get(i);
-        final Type targetType = targetTypes.get(i);
-
-        Local paramLocal = lc.generateLocal(paramType);
-        us.insertAfter(Jimple.v().newIdentityStmt(paramLocal, Jimple.v().newParameterRef(paramType, i)), thisIdentity);
-
-        final Local targetLocal = lc.generateLocal(targetType);
-        us.add(Jimple.v().newAssignStmt(targetLocal, Jimple.v().newCastExpr(paramLocal, targetType)));
-
-        args.add(targetLocal);
+      // captured arguments
+      for (SootField f : capFields) {
+        Local l = lc.generateLocal(f.getType());
+        us.add(Jimple.v().newAssignStmt(l, Jimple.v().newInstanceFieldRef(this_, f.makeRef())));
+        args.add(l);
       }
 
-      final VirtualInvokeExpr invoke = Jimple.v().newVirtualInvokeExpr(this_, apply, args);
+      // direct arguments
 
-      if (retType == VoidType.v()) {
-        us.add(Jimple.v().newInvokeStmt(invoke));
+      // The MethodHandle's first argument is the receiver, if it has one.
+      // If there are no captured arguments, use the first parameter as the receiver.
+      int kind = implMethod.getKind();
+      boolean needsReceiver = false;
+      if (MethodHandle.Kind.REF_INVOKE_INTERFACE.getValue() == kind
+          || MethodHandle.Kind.REF_INVOKE_VIRTUAL.getValue() == kind
+          || MethodHandle.Kind.REF_INVOKE_SPECIAL.getValue() == kind) {
+        // NOTE: for a method reference to a constructor, the receiver is not needed because it's the new object
+        needsReceiver = true;
+      }
+      Iterator<Local> iplItr = instParamLocals.iterator();
+      if (capFields.size() == 0 && iplItr.hasNext() && needsReceiver) {
+        RefType receiverType = implMethod.getMethodRef().declaringClass().getType();
+        Local l = adapt(iplItr.next(), receiverType, jb, us, lc);
+        args.add(l);
+      }
+
+      int j = args.size();
+      if (needsReceiver) {
+        // assert: if there is a receiver, it is already filled, but the alignment to parameters is off by 1
+        j = args.size() - 1;
+      }
+      while (iplItr.hasNext()) {
+        Local pl = iplItr.next();
+
+        Type to = implMethod.getMethodRef().parameterType(j);
+
+        Local l = adapt(pl, to, jb, us, lc);
+        args.add(l);
+        j++;
+      }
+
+      invokeImplMethod(jb, us, lc, args);
+    }
+
+    private Local adapt(Local fromLocal, Type to, JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc) {
+
+      Type from = fromLocal.getType();
+
+      // Implements JLS 5.3 Method Invocation Context for adapting arguments from lambda expression to
+      // formal arguments of target implementation
+
+      // an identity conversion (§5.1.1)
+      if (from.equals(to)) {
+        return fromLocal;
+      }
+
+      if (from instanceof ArrayType) {
+        return wideningReferenceConversion(fromLocal);
+      }
+
+      if (from instanceof RefType && to instanceof RefType) {
+        return wideningReferenceConversion(fromLocal);
+      }
+
+      if (from instanceof PrimType) {
+        if (to instanceof PrimType) {
+          // a widening primitive conversion (§5.1.2)
+          return wideningPrimitiveConversion(fromLocal, to, jb, us, lc);
+        } else {
+          // a boxing conversion (§5.1.7)
+          // a boxing conversion followed by widening reference conversion
+
+          // from is PrimType
+          // to is RefType
+          Local boxed = box(fromLocal, jb, us, lc);
+          return wideningReferenceConversion(boxed);
+        }
+      } else {
+        // an unboxing conversion (§5.1.8)
+        // an unboxing conversion followed by a widening primitive conversion
+
+        // from is RefType
+        // to is PrimType
+        if (!(to instanceof PrimType)) {
+          throw new IllegalArgumentException("Expected 'to' to be a PrimType");
+        }
+
+        Local unboxed = unbox(fromLocal, jb, us, lc);
+        return wideningPrimitiveConversion(unboxed, to, jb, us, lc);
+      }
+    }
+
+    /**
+     * P box = P.valueOf(fromLocal);
+     * 
+     * @param fromLocal
+     *          primitive
+     * @param jb
+     * @param us
+     * @return
+     */
+    private Local box(Local fromLocal, JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc) {
+      PrimType primitiveType = (PrimType) fromLocal.getType();
+      RefType wrapperType = primitiveType.boxedType();
+
+      SootMethod valueOfMethod = Wrapper.valueOf.get(primitiveType);
+
+      Local lBox = lc.generateLocal(wrapperType);
+      us.add(Jimple.v().newAssignStmt(lBox, Jimple.v().newStaticInvokeExpr(valueOfMethod.makeRef(), fromLocal)));
+
+      return lBox;
+    }
+
+    /**
+     * p unbox = fromLocal.pValue();
+     * 
+     * @param fromLocal
+     *          boxed
+     * @param jb
+     * @param us
+     * @return
+     */
+    private Local unbox(Local fromLocal, JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc) {
+      RefType wrapperType = (RefType) fromLocal.getType();
+      PrimType primitiveType = Wrapper.wrapperTypes.get(wrapperType);
+
+      SootMethod primitiveValueMethod = Wrapper.primitiveValue.get(wrapperType);
+
+      Local lUnbox = lc.generateLocal(primitiveType);
+      us.add(Jimple.v().newAssignStmt(lUnbox, Jimple.v().newVirtualInvokeExpr(fromLocal, primitiveValueMethod.makeRef())));
+
+      return lUnbox;
+    }
+
+    private Local wideningReferenceConversion(Local fromLocal) {
+      // a widening reference conversion (JLS §5.1.5)
+      // TODO: confirm that 'from' is a subtype of 'to'
+      return fromLocal;
+    }
+
+    /**
+     * T t = (T) fromLocal;
+     * 
+     * @param fromLocal
+     * @param to
+     * @param jb
+     * @param us
+     * @return
+     */
+    private Local narrowingReferenceConversion(Local fromLocal, Type to, JimpleBody jb, PatchingChain<Unit> us,
+        LocalGenerator lc) {
+      if (fromLocal.getType().equals(to)) {
+        return fromLocal;
+      }
+
+      if (!(fromLocal.getType() instanceof RefType || fromLocal.getType() instanceof ArrayType)) {
+        return fromLocal;
+      }
+      // throw new IllegalArgumentException("Expected source to have reference type");
+      if (!(to instanceof RefType || to instanceof ArrayType)) {
+        return fromLocal;
+        // throw new IllegalArgumentException("Expected target to have reference type");
+      }
+
+      Local l2 = lc.generateLocal(to);
+      us.add(Jimple.v().newAssignStmt(l2, Jimple.v().newCastExpr(fromLocal, to)));
+      return l2;
+    }
+
+    /**
+     * T t = (T) fromLocal;
+     * 
+     * @param fromLocal
+     * @param to
+     * @param jb
+     * @param us
+     * @return
+     */
+    private Local wideningPrimitiveConversion(Local fromLocal, Type to, JimpleBody jb, PatchingChain<Unit> us,
+        LocalGenerator lc) {
+      if (!(fromLocal.getType() instanceof PrimType)) {
+        throw new IllegalArgumentException("Expected source to have primitive type");
+      }
+      if (!(to instanceof PrimType)) {
+        throw new IllegalArgumentException("Expected target to have primitive type");
+      }
+
+      Local l2 = lc.generateLocal(to);
+      us.add(Jimple.v().newAssignStmt(l2, Jimple.v().newCastExpr(fromLocal, to)));
+      return l2;
+    }
+
+    /**
+     * Invocation of target implementation method.
+     * 
+     * @param jb
+     * @param us
+     * @param args
+     */
+    private void invokeImplMethod(JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc, List<Local> args) {
+      Value value = _invokeImplMethod(jb, us, lc, args);
+
+      if (value instanceof InvokeExpr && soot.VoidType.v().equals(implMethod.getMethodRef().returnType())) {
+        // implementation method is void
+        us.add(Jimple.v().newInvokeStmt(value));
+        us.add(Jimple.v().newReturnVoidStmt());
+      } else if (soot.VoidType.v().equals(implMethodType.getReturnType())) {
+        // dispatch method is void
+        us.add(Jimple.v().newInvokeStmt(value));
         us.add(Jimple.v().newReturnVoidStmt());
       } else {
-        final Local nonCastRet = lc.generateLocal(targetRetType);
-        us.add(Jimple.v().newAssignStmt(nonCastRet, invoke));
+        // neither is void, must pass through return value
 
-        final Local ret = lc.generateLocal(retType);
-        us.add(Jimple.v().newAssignStmt(ret, Jimple.v().newCastExpr(nonCastRet, retType)));
-        us.add(Jimple.v().newReturnStmt(ret));
+        Local ret = lc.generateLocal(value.getType());
+        us.add(Jimple.v().newAssignStmt(ret, value));
+
+        // adapt return value
+        Local retAdapted = adapt(ret, implMethodType.getReturnType(), jb, us, lc);
+        us.add(Jimple.v().newReturnStmt(retAdapted));
       }
+    }
 
-      return jb;
+    private Value _invokeImplMethod(JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc, List<Local> args) {
+      // A lambda capturing 'this' may be implemented by a private instance method.
+      // A method reference to an instance method may be implemented by the instance method itself.
+      // To use the correct invocation style, resolve the method and determine how the compiler
+      // implemented the lambda or method reference.
+
+      SootMethodRef methodRef = implMethod.getMethodRef();
+      MethodHandle.Kind k = MethodHandle.Kind.getKind(implMethod.getKind());
+      switch (k) {
+        case REF_INVOKE_STATIC:
+          return Jimple.v().newStaticInvokeExpr(methodRef, args);
+        case REF_INVOKE_INTERFACE:
+          return Jimple.v().newInterfaceInvokeExpr(args.get(0), methodRef, rest(args));
+        case REF_INVOKE_VIRTUAL:
+          return Jimple.v().newVirtualInvokeExpr(args.get(0), methodRef, rest(args));
+        case REF_INVOKE_SPECIAL:
+          // e.g. private
+          return Jimple.v().newSpecialInvokeExpr(args.get(0), methodRef, rest(args));
+        case REF_INVOKE_CONSTRUCTOR:
+          RefType type = methodRef.declaringClass().getType();
+          NewExpr newRef = Jimple.v().newNewExpr(type);
+          Local newLocal = lc.generateLocal(type);
+          us.add(Jimple.v().newAssignStmt(newLocal, newRef));
+          // NOTE: args does not include the receiver
+          SpecialInvokeExpr specialInvokeExpr = Jimple.v().newSpecialInvokeExpr(newLocal, methodRef, args);
+          InvokeStmt invokeStmt = Jimple.v().newInvokeStmt(specialInvokeExpr);
+          us.add(invokeStmt);
+
+          return newLocal;
+        case REF_GET_FIELD:
+        case REF_GET_FIELD_STATIC:
+        case REF_PUT_FIELD:
+        case REF_PUT_FIELD_STATIC:
+        default:
+      }
+      throw new IllegalArgumentException("Unexpected MethodHandle.Kind " + implMethod.getKind());
+    }
+
+    private List<Local> rest(List<Local> args) {
+      int first = 1;
+      int last = args.size();
+      if (last < first) {
+        return Collections.<Local>emptyList();
+      }
+      return args.subList(first, last);
     }
   }
+
+  private static class Wrapper {
+
+    private static boolean isWrapper(Type t) {
+      return wrapperTypes.containsKey(t);
+    }
+
+    private static Map<RefType, PrimType> wrapperTypes;
+    /** valueOf(primitive) method signature */
+    private static Map<PrimType, SootMethod> valueOf;
+    /** primitiveValue() method signature */
+    private static Map<RefType, SootMethod> primitiveValue;
+    static {
+      PrimType[] tmp = { BooleanType.v(), ByteType.v(), CharType.v(), DoubleType.v(), FloatType.v(), IntType.v(),
+          LongType.v(), ShortType.v() };
+      wrapperTypes = new HashMap<>();
+      valueOf = new HashMap<>();
+      primitiveValue = new HashMap<>();
+      for (PrimType primType : tmp) {
+        RefType wrapperType = primType.boxedType();
+        String cn = wrapperType.getClassName();
+
+        wrapperTypes.put(wrapperType, primType);
+
+        String valueOfMethodSignature = cn + " valueOf(" + primType.toString() + ")";
+        SootMethod valueOfMethod = wrapperType.getSootClass().getMethod(valueOfMethodSignature);
+        valueOf.put(primType, valueOfMethod);
+
+        String primitiveValueMethodSignature = primType.toString() + " " + primType.toString() + "Value()";
+        SootMethod primitiveValueMethod = wrapperType.getSootClass().getMethod(primitiveValueMethodSignature);
+        primitiveValue.put(wrapperType, primitiveValueMethod);
+      }
+      wrapperTypes = Collections.unmodifiableMap(wrapperTypes);
+      valueOf = Collections.unmodifiableMap(valueOf);
+      primitiveValue = Collections.unmodifiableMap(primitiveValue);
+
+    }
+
+  }
+
 }

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -1414,7 +1414,9 @@ final class AsmMethodSource implements MethodSource {
 
       String bsmMethodRefStr = bsmMethodRef.toString();
       if (bsmMethodRefStr.equals(METAFACTORY_SIGNATURE) || bsmMethodRefStr.equals(ALT_METAFACTORY_SIGNATURE)) {
-        bootstrap_model = LambdaMetaFactory.makeLambdaHelper(bsmMethodArgs, insn.bsm.getTag(), insn.name, types);
+        SootClass enclosingClass = body.getMethod().getDeclaringClass();
+        bootstrap_model
+            = LambdaMetaFactory.makeLambdaHelper(bsmMethodArgs, insn.bsm.getTag(), insn.name, types, enclosingClass);
       }
 
       InvokeExpr indy;

--- a/src/main/java/soot/jimple/toolkits/annotation/LineNumberAdder.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/LineNumberAdder.java
@@ -48,7 +48,9 @@ public class LineNumberAdder extends SceneTransformer {
 
   public void internalTransform(String phaseName, Map opts) {
 
-    Iterator it = Scene.v().getApplicationClasses().iterator();
+    // using a snapshot iterator because Application classes may change if LambdaMetaFactory translates invokedynamic to new
+    // classes; no need to visit new classes
+    Iterator it = Scene.v().getApplicationClasses().snapshotIterator();
     while (it.hasNext()) {
       SootClass sc = (SootClass) it.next();
       // make map of first line to each method


### PR DESCRIPTION
This is based on work started in #701, and has been rebased on #1056 to incorporate additional fixes.

Summary:

1) Implemented modeling of parameter adaptation. This is required to handle conversion of primitives to their wrapper types (boxing and unboxing).

2) Enabled writing generated classes to another format, such as .class.

3) Generated class names follow naming pattern based on the class enclosing the original invoke dynamic instruction.

4) Removed BridgeMethodSource; ThunkMethodSource handles all cases. The implementation follows #701: samMethodType and the bridges are signatures to be implemented by the functional object, and each one delegates to the implMethod. Bridge methods should only be necessary for the altMetaFactory, and in practice we have found no cases in the wild from the OpenJDK compiler (and only one from the Eclipse compiler).

5) Although #1056 contains fixes for invocation style handling, this may add even more fixes (this was implemented prior to #1056, and I have not performed a detailed comparison).


Why these changes are needed:

The following class contains a method reference which requires a parameter adaptation from int to Integer. This conversion has to be implemented within the thunk class; it cannot be performed at the call site in parameterBoxing().  See the LambdaMetaFactory javadoc and JLS 5.1.7 for details.

```
public class Adapt1 {
	interface IntInterfaceParam {
		public void adapt(int p);
	}
	interface IntegerInterfaceParam {
		public void adapt(Integer p);
	}
	public void parameterBoxing(IntegerInterfaceParam I1param) {
		// JLS 5.1.7
		// int -> Integer
		IntInterfaceParam I0var = I1param::adapt;
		I0var.adapt(1);
	}
};

```

Testing:

For dynamic testing, we converted the JavaPoet library (which uses lambdas), and all JUnits continued to pass.

In addition, we wrote some tests which we converted to Jimple text format and visually inspected.  These include enumerated cases for parameter adaptation (Adapt.java), and a method reference to an array constructor (ArrayConstructorReference.java). These may be worth turning into test cases, I have included them in the zip file.


Additional observations:

1) Synchronization issues persist in #1056. Added synchronization to LambdaMetaFactory.makeLambdaHelper() as a workaround, but this is likely the wrong way to fix the race conditions. Two distinct stack traces are included in the zip file which result if the method is unsynchronized. Perhaps the data structures in Scene are not properly synchronized with respect to whatever operations the LambdaMetaFactory performs?

2) Before integration, consider making this feature optional. When writing transformed class files, the invokedynamic instructions will have been replaced (by design). This might be undesirable for some use cases.

3) The names of generated classes are potentially non-deterministic because a single counter is used to name the classes, and method conversion may occur in parallel. This issue need not block integration, but it might complicate creating test cases.

[LMF-attachments.zip](https://github.com/Sable/soot/files/2659207/LMF-attachments.zip)



