### PR TITLE
Make the fresh-local-variable separator configurable.

### DIFF
--- a/src/main/java/soot/shimple/internal/ShimpleBodyBuilder.java
+++ b/src/main/java/soot/shimple/internal/ShimpleBodyBuilder.java
@@ -396,7 +396,7 @@ public class ShimpleBodyBuilder {
 
     // If the name already exists, makeUniqueLocalNames() will
     // take care of it.
-    String name = oldLocal.getName() + "_" + subscript;
+    String name = oldLocal.getName() + freshSeparator + subscript;
 
     Local newLocal = newLocals.get(name);
 
@@ -463,9 +463,14 @@ public class ShimpleBodyBuilder {
     String newName = dupName;
 
     while (localNames.contains(newName)) {
-      newName = dupName + "_" + counter++;
+      newName = dupName + freshSeparator + counter++;
     }
 
     return newName;
+  }
+
+  static String freshSeparator = "_";
+  public static void setSeparator(String sep) {
+    freshSeparator = sep;
   }
 }


### PR DESCRIPTION
Having "_" as a delimiter for fresh locals created internally by Soot may be confusing when trying to connect Shimple locals with original Java sources. For example, if Soot creates "x_3" for some "x" and for some reason "x_3" was also a source variable, whose name was not preserved, the fresh local may be mistaken for the source local.

This pull request makes the `"_"` separator configurable, so that it can be set to something that cannot appear in the sources (e.g., `'_$_'`).
