### PR TITLE
ConcurrentModificationException in SootClass.getMethodUnsafe

### DIFF
--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -548,7 +548,7 @@ public class SootClass extends AbstractHost implements Numberable {
       return null;
     }
 
-    for (SootMethod method : methodList) {
+    for (SootMethod method : new ArrayList<>(methodList)) {
       if (method.getName().equals(name) && parameterTypes.equals(method.getParameterTypes())
           && returnType.equals(method.getReturnType())) {
         return method;

--- a/src/main/java/soot/jimple/toolkits/typing/integer/ClassHierarchy.java
+++ b/src/main/java/soot/jimple/toolkits/typing/integer/ClassHierarchy.java
@@ -149,7 +149,7 @@ public class ClassHierarchy {
     TypeNode typeNode = typeNodeMap.get(type);
 
     if (typeNode == null) {
-      throw new InternalTypingException();
+      throw new InternalTypingException(type);
     }
 
     return typeNode;

--- a/src/main/java/soot/jimple/toolkits/typing/integer/InternalTypingException.java
+++ b/src/main/java/soot/jimple/toolkits/typing/integer/InternalTypingException.java
@@ -44,8 +44,9 @@ class InternalTypingException extends RuntimeException {
   }
 
   @Override
-  public String toString() {
-    return "Unexpected type " + this.unexpectedType;
+  public String getMessage() {
+    return String.format("Unexpected type %s (%s)", unexpectedType,
+        unexpectedType == null ? "-" : unexpectedType.getClass().getSimpleName());
   }
 
 }


### PR DESCRIPTION
Using the latest Soot version I often encountered with certain apps a ConcurrentModificationException in 
`public SootMethod getMethodUnsafe(String name, List<Type> parameterTypes, Type returnType)`

This pull request fixes that problem.
Additionally it includes a small non-related fix for a missing exception message in `soot.jimple.toolkits.typing.integer.InternalTypingException` which was always null instead of the actual message. 