### PR TITLE
fix: java.lang.ArrayIndexOutOfBoundsException in DexAnnotation.addAnnotation

### DIFF
--- a/src/main/java/soot/dexpler/DexAnnotation.java
+++ b/src/main/java/soot/dexpler/DexAnnotation.java
@@ -55,6 +55,8 @@ import org.jf.dexlib2.iface.value.MethodEncodedValue;
 import org.jf.dexlib2.iface.value.ShortEncodedValue;
 import org.jf.dexlib2.iface.value.StringEncodedValue;
 import org.jf.dexlib2.iface.value.TypeEncodedValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import soot.ArrayType;
 import soot.RefType;
@@ -96,6 +98,8 @@ import soot.toDex.SootToDexUtils;
  *
  */
 public class DexAnnotation {
+  
+  private static final Logger logger = LoggerFactory.getLogger(DexAnnotation.class);
 
   public static final String JAVA_DEPRECATED = "java.lang.Deprecated";
   public static final String DALVIK_ANNOTATION_THROWS = "dalvik.annotation.Throws";
@@ -520,6 +524,10 @@ public class DexAnnotation {
         }
         AnnotationStringElem e = (AnnotationStringElem) getElements(a.getElements()).get(0);
         String[] split1 = e.getValue().split("\\ \\|");
+        if (split1.length < 4) {
+          logger.debug("Invalid or unsupported dalvik EnclosingMethod annotation value: \"{}\"", e.getValue());
+          break;
+        }
         String classString = split1[0];
         String methodString = split1[1];
         String parameters = split1[2];


### PR DESCRIPTION
I encountered an exception in relation to dex-related annotations.

The main problem is that the processed `AnnotationStringElemt` has `value = "()V"`.
An the code tries to split this string into several parts which fails:

        String[] split1 = e.getValue().split("\\ \\|");
        String classString = split1[0];
        String methodString = split1[1]; // <<--- exception origin
        String parameters = split1[2];
        String returnType = split1[3];

On smali level the relevant annotation is: 

```
.annotation system Ldalvik/annotation/EnclosingMethod;
    value = "()V"
.end annotation
```

I don't have experience with this annotation, but the usual format seems to be different, at least Soot expects it to be different. Therefore I implemented this workaround that checks and skips the annotation in case it doe snot have the expected format.

APK: https://apkpure.com/de/car-net/de.volkswagen.carnet.eu.eremote/download/1902071630-APK?from=versions%2Fversion

Processed class: Lde/idnow/sdk/Activities_EntryActivity$3;

The full stack trace is:
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at soot.dexpler.DexAnnotation.addAnnotation(DexAnnotation.java:524) ~[classes/:na]
	at soot.dexpler.DexAnnotation.handleAnnotation(DexAnnotation.java:443) ~[classes/:na]
	at soot.dexpler.DexAnnotation.handleClassAnnotation(DexAnnotation.java:137) ~[classes/:na]
	at soot.dexpler.DexClassLoader.makeSootClass(DexClassLoader.java:129) ~[classes/:na]
	at soot.dexpler.DexlibWrapper.makeSootClass(DexlibWrapper.java:162) ~[classes/:na]
	at soot.dexpler.DexResolver.resolveFromFile(DexResolver.java:63) ~[classes/:na]
	at soot.DexClassSource.resolve(DexClassSource.java:63) ~[classes/:na]
	at soot.SootResolver.bringToHierarchyUnchecked(SootResolver.java:240) ~[classes/:na]
	at soot.SootResolver.bringToHierarchy(SootResolver.java:214) ~[classes/:na]
	at soot.SootResolver.bringToSignatures(SootResolver.java:279) ~[classes/:na]
	at soot.SootResolver.bringToBodies(SootResolver.java:319) ~[classes/:na]
	at soot.SootResolver.processResolveWorklist(SootResolver.java:164) ~[classes/:na]
	at soot.SootResolver.resolveClass(SootResolver.java:134) ~[classes/:na]
	at soot.dexpler.DexlibWrapper.initialize(DexlibWrapper.java:150) ~[classes/:na]
	at soot.dexpler.DexResolver.initializeDexFile(DexResolver.java:81) ~[classes/:na]
	at soot.dexpler.DexResolver.resolveFromFile(DexResolver.java:62) ~[classes/:na]
	at soot.DexClassSource.resolve(DexClassSource.java:63) ~[classes/:na]
	at soot.SootResolver.bringToHierarchyUnchecked(SootResolver.java:240) ~[classes/:na]
	at soot.SootResolver.bringToHierarchy(SootResolver.java:214) ~[classes/:na]
	at soot.SootResolver.bringToSignatures(SootResolver.java:279) ~[classes/:na]
	at soot.SootResolver.bringToBodies(SootResolver.java:319) ~[classes/:na]
	at soot.SootResolver.processResolveWorklist(SootResolver.java:164) ~[classes/:na]
	at soot.SootResolver.resolveClass(SootResolver.java:134) ~[classes/:na]
	at soot.Scene.loadClass(Scene.java:942) ~[classes/:na]
	at soot.Scene.loadClassAndSupport(Scene.java:927) ~[classes/:na]
	at soot.Scene.loadNecessaryClasses(Scene.java:1753) ~[classes/:na]
```

