### PR TITLE
Performance Fix in a CallGraph method

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -116,13 +116,11 @@ public class CallGraph implements Iterable<Edge> {
    */
   public boolean swapEdgesOutOf(Stmt out, Stmt in) {
     boolean hasSwapped = false;
-    for (QueueReader<Edge> edgeRdr = listener(); edgeRdr.hasNext();) {
+    for (Iterator<Edge> edgeRdr = edgesOutOf(out); edgeRdr.hasNext();) {
       Edge e = edgeRdr.next();
-      if (e.srcUnit() == out) {
-        removeEdge(e);
-        addEdge(new Edge(e.getSrc(), in, e.getTgt()));
-        hasSwapped = true;
-      }
+      removeEdge(e);
+      addEdge(new Edge(e.getSrc(), in, e.getTgt()));
+      hasSwapped = true;
     }
     return hasSwapped;
   }


### PR DESCRIPTION
The method `swapEdgesOutOf()` causes a performance bottleneck when used with a larger call graph (CHA on a real world program). It iterates over *all edges* of the call graph to swap edges of a specific call statement. 

It is only necessary to iterate over the edges out of a specific call statement, which is implemented in this fix.