### PR TITLE
Fix ClassConstant value passed to Jasmin

### DIFF
--- a/src/main/java/soot/baf/JasminClass.java
+++ b/src/main/java/soot/baf/JasminClass.java
@@ -441,7 +441,7 @@ public class JasminClass extends AbstractJasminClass {
         } else if (i.getConstant() instanceof StringConstant) {
           emit("ldc " + i.getConstant().toString());
         } else if (i.getConstant() instanceof ClassConstant) {
-          emit("ldc_w " + ((ClassConstant) i.getConstant()).getValue());
+          emit("ldc " + ((ClassConstant) i.getConstant()).toInternalString());
         } else if (i.getConstant() instanceof DoubleConstant) {
           DoubleConstant v = (DoubleConstant) (i.getConstant());
 

--- a/src/main/java/soot/jimple/ClassConstant.java
+++ b/src/main/java/soot/jimple/ClassConstant.java
@@ -134,6 +134,27 @@ public class ClassConstant extends Constant {
     return numDimensions > 0 ? ArrayType.v(baseType, numDimensions) : baseType;
   }
 
+  /**
+   * Gets an internal representation of the class used in Java bytecode.
+   * The returned string is similar to the fully qualified name but with '/' instead of '.'.
+   * Example: "java/lang/Object".
+   * See https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.2.1
+   */
+  public String toInternalString() {
+    String internal = value;
+    while (internal.startsWith("[")) {
+      internal = internal.substring(1);
+    }
+    if (internal.endsWith(";")) {
+      internal = internal.substring(0, internal.length() - 1);
+      if (internal.startsWith("L")) {
+        internal = internal.substring(1);
+      }
+    }
+
+    return internal;
+  }
+
   // In this case, equals should be structural equality.
   @Override
   public boolean equals(Object c) {

--- a/src/main/java/soot/jimple/JasminClass.java
+++ b/src/main/java/soot/jimple/JasminClass.java
@@ -2538,7 +2538,7 @@ public class JasminClass extends AbstractJasminClass {
       }
 
       public void caseClassConstant(ClassConstant v) {
-        emit("ldc_w " + v.getValue(), 1);
+        emit("ldc " + v.toInternalString(), 1);
       }
 
       public void caseSubExpr(SubExpr v) {


### PR DESCRIPTION
Fixes #1167 
This is needed for Java 9 conformance with Jasmin.
Please review the ClassConstant.toInternalString(). Although it works, it seems not perfect.
In details, classes are represented as 'java/lang/Object' instead of 'Ljava/lang/Object;'.
The patch is inspired from AsmUtil https://github.com/Sable/soot/blob/master/src/main/java/soot/asm/AsmUtil.java#L72 .
Bytecode is now corresponding between ASM, javac and Jasmin (some corner cases may remains different).