### PR TITLE
Add class soot.util.WeakMapNumberer

### DIFF
--- a/doc/soot_options.htm
+++ b/doc/soot_options.htm
@@ -508,6 +508,10 @@
             <td><tt>-ignore-resolving-levels </tt><br></td>
             <td colspan="2">Ignore mismatching resolving levels</td>
          </tr>
+         <tr>
+            <td><tt>-weak-map-structures </tt><br></td>
+            <td colspan="2">Use weak references in Scene to prevent memory leakage when removing many classes/methods/locals</td>
+         </tr>
       </table>
       <H2><A name="section_2">Input Options</A></H2>
       <table border="3">

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -1072,6 +1072,12 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		if (boolRes != defBoolRes) {
 			getConfig().put(getGeneral_Optionsignore_resolving_levels_widget().getAlias(), new Boolean(boolRes));
 		}
+		boolRes = getGeneral_Optionsweak_map_structures_widget().getButton().getSelection();
+		defBoolRes = false;
+
+		if (boolRes != defBoolRes) {
+			getConfig().put(getGeneral_Optionsweak_map_structures_widget().getAlias(), new Boolean(boolRes));
+		}
 		stringRes = getGeneral_Optionsphase_help_widget().getText().getText();
 		defStringRes = "";
 
@@ -4567,6 +4573,16 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 	
 	public BooleanOptionWidget getGeneral_Optionsignore_resolving_levels_widget() {
 		return General_Optionsignore_resolving_levels_widget;
+	}	
+	
+	private BooleanOptionWidget General_Optionsweak_map_structures_widget;
+	
+	private void setGeneral_Optionsweak_map_structures_widget(BooleanOptionWidget widget) {
+		General_Optionsweak_map_structures_widget = widget;
+	}
+	
+	public BooleanOptionWidget getGeneral_Optionsweak_map_structures_widget() {
+		return General_Optionsweak_map_structures_widget;
 	}	
 	
 
@@ -8501,6 +8517,17 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		}
 
 		setGeneral_Optionsignore_resolving_levels_widget(new BooleanOptionWidget(editGroupGeneral_Options, SWT.NONE, new OptionData("Ignore Resolving Levels", "", "","ignore-resolving-levels", "\nIf this option is set, Soot will not check whether the current \nclass' resolving level is sufficiently high for the operation \nattempted on the class. This allows you to perform any operation \non a class even if the class has not been fully loaded, which \ncan lead to inconsistencies between your Soot scene and the \noriginal classes you loaded. Use this option at your own risk.", defaultBool)));
+
+		defKey = ""+" "+""+" "+"weak-map-structures";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultBool = getBoolDef(defKey);	
+		} else {
+			defaultBool = false;
+		}
+
+		setGeneral_Optionsweak_map_structures_widget(new BooleanOptionWidget(editGroupGeneral_Options, SWT.NONE, new OptionData("Weak Map Structures", "", "","weak-map-structures", "\nIf this option is set, Soot will use Maps with weak references \nto lower memory usage when performing many additions and \ndeletions of classes/methods/locals. Without this option, all \ncreated objects are kept in memory. This has a bit larger memory \nfootprint if only a small amount of deletions are conducted.", defaultBool)));
 
 		defKey = ""+" "+""+" "+"ph phase-help";
 		defKey = defKey.trim();

--- a/src/main/generated/options/soot/AntTask.java
+++ b/src/main/generated/options/soot/AntTask.java
@@ -186,6 +186,10 @@ public class AntTask extends MatchingTask {
             if(arg) addArg("-ignore-resolving-levels");
         }
   
+        public void setweak_map_structures(boolean arg) {
+            if(arg) addArg("-weak-map-structures");
+        }
+  
         public void setsoot_classpath(String arg) {
             addArg("-soot-classpath");
             addArg(arg);

--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -221,6 +221,10 @@ public class Options extends OptionsBase {
             )
                 ignore_resolving_levels = true;
             else if (false
+                    || option.equals("weak-map-structures")
+            )
+                weak_map_structures = true;
+            else if (false
                     || option.equals("cp")
                     || option.equals("soot-class-path")
                     || option.equals("soot-classpath")
@@ -1363,6 +1367,10 @@ public class Options extends OptionsBase {
     private boolean ignore_resolving_levels = false;
     public void set_ignore_resolving_levels(boolean setting) { ignore_resolving_levels = setting; }
 
+    public boolean weak_map_structures() { return weak_map_structures; }
+    private boolean weak_map_structures = false;
+    public void set_weak_map_structures(boolean setting) { weak_map_structures = setting; }
+
     public String soot_classpath() { return soot_classpath; }
     public void set_soot_classpath(String setting) { soot_classpath = setting; }
     private String soot_classpath = "";
@@ -1645,6 +1653,7 @@ public class Options extends OptionsBase {
                 + padOpt("-debug", "Print various Soot debugging info")
                 + padOpt("-debug-resolver", "Print debugging info from SootResolver")
                 + padOpt("-ignore-resolving-levels", "Ignore mismatching resolving levels")
+                + padOpt("-weak-map-structures", "Use weak references in Scene to prevent memory leakage when removing many classes/methods/locals")
                 + "\nInput Options:\n"
                 + padOpt("-cp ARG -soot-class-path ARG -soot-classpath ARG", "Use ARG as the classpath for finding classes.")
                 + padOpt("-pp, -prepend-classpath", "Prepend the given soot classpath to the default classpath.")

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -73,9 +73,11 @@ import soot.toolkits.exceptions.UnitThrowAnalysis;
 import soot.util.ArrayNumberer;
 import soot.util.Chain;
 import soot.util.HashChain;
+import soot.util.IterableNumberer;
 import soot.util.MapNumberer;
 import soot.util.Numberer;
 import soot.util.StringNumberer;
+import soot.util.WeakMapNumberer;
 
 /** Manages the SootClasses of the application being analyzed. */
 public class Scene // extends AbstractHost
@@ -99,6 +101,13 @@ public class Scene // extends AbstractHost
     kindNumberer = new ArrayNumberer<Kind>(
         new Kind[] { Kind.INVALID, Kind.STATIC, Kind.VIRTUAL, Kind.INTERFACE, Kind.SPECIAL, Kind.CLINIT, Kind.THREAD,
             Kind.EXECUTOR, Kind.ASYNCTASK, Kind.FINALIZE, Kind.INVOKE_FINALIZE, Kind.PRIVILEGED, Kind.NEWINSTANCE });
+
+    if (Options.v().weak_map_structures()) {
+      methodNumberer = new WeakMapNumberer<SootMethod>();
+      fieldNumberer = new WeakMapNumberer<SparkField>();
+      classNumberer = new WeakMapNumberer<SootClass>();
+      localNumberer = new WeakMapNumberer<Local>();
+    }
 
     addSootBasicClasses();
 
@@ -139,14 +148,14 @@ public class Scene // extends AbstractHost
   private final Map<String, RefType> nameToClass = new HashMap<String, RefType>();
 
   protected final ArrayNumberer<Kind> kindNumberer;
-  protected ArrayNumberer<Type> typeNumberer = new ArrayNumberer<Type>();
-  protected ArrayNumberer<SootMethod> methodNumberer = new ArrayNumberer<SootMethod>();
+  protected IterableNumberer<Type> typeNumberer = new ArrayNumberer<Type>();
+  protected IterableNumberer<SootMethod> methodNumberer = new ArrayNumberer<SootMethod>();
   protected Numberer<Unit> unitNumberer = new MapNumberer<Unit>();
   protected Numberer<Context> contextNumberer = null;
   protected Numberer<SparkField> fieldNumberer = new ArrayNumberer<SparkField>();
-  protected ArrayNumberer<SootClass> classNumberer = new ArrayNumberer<SootClass>();
+  protected IterableNumberer<SootClass> classNumberer = new ArrayNumberer<SootClass>();
   protected StringNumberer subSigNumberer = new StringNumberer();
-  protected ArrayNumberer<Local> localNumberer = new ArrayNumberer<Local>();
+  protected IterableNumberer<Local> localNumberer = new ArrayNumberer<Local>();
 
   protected Hierarchy activeHierarchy;
   protected FastHierarchy activeFastHierarchy;
@@ -1436,11 +1445,11 @@ public class Scene // extends AbstractHost
     return kindNumberer;
   }
 
-  public ArrayNumberer<Type> getTypeNumberer() {
+  public IterableNumberer<Type> getTypeNumberer() {
     return typeNumberer;
   }
 
-  public ArrayNumberer<SootMethod> getMethodNumberer() {
+  public IterableNumberer<SootMethod> getMethodNumberer() {
     return methodNumberer;
   }
 
@@ -1456,7 +1465,7 @@ public class Scene // extends AbstractHost
     return fieldNumberer;
   }
 
-  public ArrayNumberer<SootClass> getClassNumberer() {
+  public IterableNumberer<SootClass> getClassNumberer() {
     return classNumberer;
   }
 
@@ -1464,7 +1473,7 @@ public class Scene // extends AbstractHost
     return subSigNumberer;
   }
 
-  public ArrayNumberer<Local> getLocalNumberer() {
+  public IterableNumberer<Local> getLocalNumberer() {
     return localNumberer;
   }
 

--- a/src/main/java/soot/jimple/internal/JimpleLocal.java
+++ b/src/main/java/soot/jimple/internal/JimpleLocal.java
@@ -35,7 +35,7 @@ import soot.baf.Baf;
 import soot.jimple.ConvertToBaf;
 import soot.jimple.JimpleToBafContext;
 import soot.jimple.JimpleValueSwitch;
-import soot.util.ArrayNumberer;
+import soot.util.Numberer;
 import soot.util.Switch;
 
 public class JimpleLocal implements Local, ConvertToBaf {
@@ -46,7 +46,7 @@ public class JimpleLocal implements Local, ConvertToBaf {
   public JimpleLocal(String name, Type type) {
     setName(name);
     setType(type);
-    ArrayNumberer<Local> numberer = Scene.v().getLocalNumberer();
+    Numberer<Local> numberer = Scene.v().getLocalNumberer();
     if (numberer != null) {
       numberer.add(this);
     }

--- a/src/main/java/soot/util/LargeNumberedMap.java
+++ b/src/main/java/soot/util/LargeNumberedMap.java
@@ -33,7 +33,7 @@ import java.util.NoSuchElementException;
  */
 
 public final class LargeNumberedMap<K extends Numberable, V> {
-  public LargeNumberedMap(ArrayNumberer<K> universe) {
+  public LargeNumberedMap(IterableNumberer<K> universe) {
     this.universe = universe;
     int newsize = universe.size();
     if (newsize < 8) {
@@ -98,5 +98,5 @@ public final class LargeNumberedMap<K extends Numberable, V> {
   /* Private stuff. */
 
   private Object[] values;
-  private ArrayNumberer<K> universe;
+  private IterableNumberer<K> universe;
 }

--- a/src/main/java/soot/util/NumberedSet.java
+++ b/src/main/java/soot/util/NumberedSet.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
  */
 
 public final class NumberedSet<N extends Numberable> {
-  public NumberedSet(ArrayNumberer<N> universe) {
+  public NumberedSet(IterableNumberer<N> universe) {
     this.universe = universe;
   }
 
@@ -195,6 +195,6 @@ public final class NumberedSet<N extends Numberable> {
   private Numberable[] array = new Numberable[8];
   private BitVector bits;
   private int size = 0;
-  private ArrayNumberer<N> universe;
+  private IterableNumberer<N> universe;
 
 }

--- a/src/main/java/soot/util/WeakMapNumberer.java
+++ b/src/main/java/soot/util/WeakMapNumberer.java
@@ -1,0 +1,111 @@
+package soot.util;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2019 William Bonnaventure
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * A class that numbers objects but keeps weak references for garbage collection
+ *
+ * @author William Bonnaventure
+ *
+ * @param <T>
+ */
+public class WeakMapNumberer<T extends Numberable> implements IterableNumberer<T> {
+  Map<T, Integer> map = new WeakHashMap<T, Integer>();
+  Map<Integer, WeakReference<T>> rmap = new WeakHashMap<Integer, WeakReference<T>>();
+  int nextIndex = 1;
+
+  public WeakMapNumberer() {
+
+  }
+
+  @Override
+  public synchronized void add(T o) {
+    if (o.getNumber() != 0) {
+      return;
+    }
+    if (!map.containsKey(o)) {
+      Integer key = new Integer(nextIndex);
+      map.put(o, key);
+      rmap.put(key, new WeakReference<T>(o));
+      o.setNumber(nextIndex++);
+    }
+  }
+
+  @Override
+  public boolean remove(T o) {
+    if (o == null) {
+      return false;
+    }
+    int num = o.getNumber();
+    if (num == 0) {
+      return false;
+    }
+    o.setNumber(0);
+    Integer i = map.remove(o);
+    if (i == null) {
+      return false;
+    }
+    rmap.remove(i);
+    return true;
+  }
+
+  @Override
+  public long get(T o) {
+    if (o == null) {
+      return 0;
+    }
+    Integer i = map.get(o);
+    if (i == null) {
+      throw new RuntimeException("couldn't find " + o);
+    }
+    return i.intValue();
+  }
+
+  @Override
+  public T get(long number) {
+    if (number == 0) {
+      return null;
+    }
+    return rmap.get(new Integer((int)number)).get();
+  }
+
+  @Override
+  public int size() {
+    return nextIndex - 1;
+  }
+
+  public boolean contains(T o) {
+    return map.containsKey(o);
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return map.keySet().iterator();
+  }
+
+}

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -405,6 +405,16 @@
                 and the original classes you loaded. Use this option at your own risk.
             </long_desc>
         </boolopt>
+        <boolopt>
+            <name>Weak Map Structures</name>
+            <alias>weak-map-structures</alias>
+            <short_desc>Use weak references in Scene to prevent memory leakage when removing many classes/methods/locals</short_desc>
+            <long_desc>
+                If this option is set, Soot will use Maps with weak references to lower memory usage when performing
+                many additions and deletions of classes/methods/locals. Without this option, all created objects
+                are kept in memory. This has a bit larger memory footprint if only a small amount of deletions are conducted.
+            </long_desc>
+        </boolopt>
     </section>
     <section>
         <name>Input Options</name>


### PR DESCRIPTION
Work in progress
Useful for #1174 .

Inspired by ArrayNumberer and MapNumberer with weak references to reduce memory consumption.
For performance reasons we create 2 WeakHashMap each one is the reverse of the other.
Even if it is 2x more consuming memory it is definitively a win when removing a lot of objects during execution.