### PR TITLE
fix error in ASM backend when emitting bytecode for java.lang.Object

### DIFF
--- a/src/main/java/soot/AbstractASMBackend.java
+++ b/src/main/java/soot/AbstractASMBackend.java
@@ -499,9 +499,9 @@ public abstract class AbstractASMBackend {
   /**
    * Emits the bytecode for all attributes of a method
    *
-   * @param fv
+   * @param mv
    *          The MethodVisitor to emit the bytecode to
-   * @param f
+   * @param m
    *          The SootMethod the bytecode is to be emitted for
    */
   protected void generateAttributes(MethodVisitor mv, SootMethod m) {
@@ -671,9 +671,10 @@ public abstract class AbstractASMBackend {
       signature = ((SignatureTag) sc.getTag("SignatureTag")).getSignature();
     }
     /*
-     * Retrieve super-class If no super-class is explicitly given, the default is java.lang.Object.
+     * Retrieve super-class. If no super-class is explicitly given, the default is java.lang.Object,
+     * except for the class java.lang.Object itself, which does not have any super classes.
      */
-    String superClass = "java/lang/Object";
+    String superClass = className.equals("java/lang/Object") ? null : "java/lang/Object";
     SootClass csuperClass = sc.getSuperclassUnsafe();
     if (csuperClass != null) {
       superClass = slashify(csuperClass.getName());


### PR DESCRIPTION
The ASM backend always assumes that `java.lang.Object` is the super-class of any given class, which is true, except for `java.lang.Object` itself.

Therefore, we need to set the value of the super-class for `java.lang.Object` to `null`, such that ASM will write `0` for the super-class in the generated class file. Otherwise, ASM will create a cycle in the class hierarchy by setting the super-class of `java.lang.Object` to itself.

Although this error does not lead to any exceptions, it generates illegal bytecode, and it will not be verified using BCEL and, consequently, the JVM itself if we were to run it.

P.S. I've also fixed a minor typo in the javadocs for generateAttributes()