### PR TITLE
Fixed the FastHierarchy to properly treat phantom classes

### DIFF
--- a/src/main/java/soot/FastHierarchy.java
+++ b/src/main/java/soot/FastHierarchy.java
@@ -91,6 +91,14 @@ public class FastHierarchy {
     int lower;
     int upper;
 
+    public Interval() {
+    }
+
+    public Interval(int lower, int upper) {
+      this.lower = lower;
+      this.upper = upper;
+    }
+
     public boolean isSubrange(Interval potentialSubrange) {
       if (potentialSubrange == null) {
         return false;
@@ -141,14 +149,14 @@ public class FastHierarchy {
     buildInverseMaps();
 
     /* Now do a dfs traversal to get the Interval numbers. */
-    dfsVisit(0, sc.getSootClass("java.lang.Object"));
+    int r = dfsVisit(0, sc.getSootClass("java.lang.Object"));
     /*
      * also have to traverse for all phantom classes because they also can be roots of the type hierarchy
      */
     for (final Iterator<SootClass> phantomClassIt = sc.getPhantomClasses().snapshotIterator(); phantomClassIt.hasNext();) {
       SootClass phantomClass = phantomClassIt.next();
       if (!phantomClass.isInterface()) {
-        dfsVisit(0, phantomClass);
+        r = dfsVisit(r, phantomClass);
       }
     }
   }


### PR DESCRIPTION
phantom classes are roots of their own hierarchy. They do not share cast-compatibility relationships with elements of other phantom hierarchies, nor the "normal" class hierarchy rooted in java.lang.Object. Otherwise, we assume that all children of java.lang.Object also immediate children of each phantom class, which isn't accurate. Worse, the "first" child of Object (whatever happens to get number 1) is assumed to be cast-compatible to the (again, whatever gets that number) first child of the phantom. That may even change between Soot runs.

We never properly defined the semantics of cast-compatibility on phantoms. Still, everything that isn't random and that is somewhat reasonable is better than the old version. This change should achieve this minimum goal.