### PR TITLE
Fix the Lambda newinvokespecial exception

### DIFF
--- a/src/main/java/soot/LambdaMetaFactory.java
+++ b/src/main/java/soot/LambdaMetaFactory.java
@@ -645,14 +645,15 @@ public final class LambdaMetaFactory {
     private void invokeImplMethod(JimpleBody jb, PatchingChain<Unit> us, LocalGenerator lc, List<Local> args) {
       Value value = _invokeImplMethod(jb, us, lc, args);
 
-      if (value instanceof InvokeExpr && soot.VoidType.v().equals(implMethod.getMethodRef().getReturnType())) {
-        // implementation method is void
-        us.add(Jimple.v().newInvokeStmt(value));
-        us.add(Jimple.v().newReturnVoidStmt());
-      } else if (soot.VoidType.v().equals(implMethodType.getReturnType())) {
-        // dispatch method is void
-        us.add(Jimple.v().newInvokeStmt(value));
-        us.add(Jimple.v().newReturnVoidStmt());
+      if ( soot.VoidType.v().equals(implMethodType.getReturnType()) || soot.VoidType.v().equals(implMethod.getMethodRef().getReturnType())) {
+          // implementation method is void
+      	if(value instanceof Local) {
+      		Local ret = lc.generateLocal(value.getType());
+              us.add(Jimple.v().newAssignStmt(ret, value));
+      	} else {
+      		us.add(Jimple.v().newInvokeStmt(value));
+      	}
+      	us.add(Jimple.v().newReturnVoidStmt());
       } else {
         // neither is void, must pass through return value
 

--- a/src/main/java/soot/asm/MethodBuilder.java
+++ b/src/main/java/soot/asm/MethodBuilder.java
@@ -1,5 +1,9 @@
 package soot.asm;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +31,7 @@ import org.objectweb.asm.Attribute;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypePath;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
 
 import soot.ArrayType;
@@ -37,6 +42,7 @@ import soot.tagkit.AnnotationConstants;
 import soot.tagkit.AnnotationDefaultTag;
 import soot.tagkit.AnnotationTag;
 import soot.tagkit.VisibilityAnnotationTag;
+import soot.tagkit.VisibilityLocalVariableAnnotationTag;
 import soot.tagkit.VisibilityParameterAnnotationTag;
 
 /**
@@ -49,6 +55,8 @@ class MethodBuilder extends JSRInlinerAdapter {
   private TagBuilder tb;
   private VisibilityAnnotationTag[] visibleParamAnnotations;
   private VisibilityAnnotationTag[] invisibleParamAnnotations;
+  private List<VisibilityAnnotationTag> visibleLocalVarAnnotations;
+  private List<VisibilityAnnotationTag> invisibleLocalVarAnnotations;
   private final SootMethod method;
   private final SootClassBuilder scb;
 
@@ -86,6 +94,56 @@ class MethodBuilder extends JSRInlinerAdapter {
     getTagBuilder().visitAttribute(attr);
   }
 
+  private static Field lineNumberField;
+  static {
+	try {
+		lineNumberField = Label.class.getDeclaredField("lineNumber");
+	} catch (Exception e) {
+			// Ingore the exception
+	}
+  }
+  
+  @Override
+  public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef, final TypePath typePath,
+			final Label[] start, final Label[] end, final int[] index, final String descriptor, final boolean visible) {
+	final VisibilityAnnotationTag vat;
+	if (start != null && index != null && start.length == index.length && start.length == 1) {
+		short line = 0;
+		if (lineNumberField != null) {
+			lineNumberField.setAccessible(true);
+			try {
+				line = lineNumberField.getShort(start[0]);
+			} catch (Exception e) {
+				line = 0;
+			}
+			lineNumberField.setAccessible(false);
+		}
+		vat = new VisibilityAnnotationTag(
+					visible ? AnnotationConstants.RUNTIME_VISIBLE : AnnotationConstants.RUNTIME_INVISIBLE, line,
+					index[0]);
+	} else {
+		vat = null;
+	}
+	if (visible) {
+		if (visibleLocalVarAnnotations == null) {
+			visibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(5);
+		}
+		visibleLocalVarAnnotations.add(vat);
+	} else {
+		if (invisibleLocalVarAnnotations == null) {
+			invisibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(5);
+		}
+		invisibleLocalVarAnnotations.add(vat);
+	}
+	return new AnnotationElemBuilder() {
+		@Override
+		public void visitEnd() {
+			AnnotationTag annotTag = new AnnotationTag(desc, elems);
+			vat.addAnnotation(annotTag);
+		}
+	};
+  }
+	
   @Override
   public AnnotationVisitor visitParameterAnnotation(int parameter, final String desc, boolean visible) {
     VisibilityAnnotationTag vat, vats[];
@@ -201,6 +259,22 @@ class MethodBuilder extends JSRInlinerAdapter {
       }
       method.addTag(tag);
     }
+    if (visibleLocalVarAnnotations != null) { 
+      VisibilityLocalVariableAnnotationTag tag 
+          = new VisibilityLocalVariableAnnotationTag(AnnotationConstants.RUNTIME_VISIBLE);
+	  for (VisibilityAnnotationTag vat : visibleLocalVarAnnotations) {
+			tag.addVisibilityAnnotation(vat);
+	  }
+	  method.addTag(tag);
+	}
+	if (invisibleLocalVarAnnotations != null) {
+	  VisibilityLocalVariableAnnotationTag tag 
+	      = new VisibilityLocalVariableAnnotationTag(AnnotationConstants.RUNTIME_INVISIBLE);
+	  for (VisibilityAnnotationTag vat : invisibleLocalVarAnnotations) {
+			tag.addVisibilityAnnotation(vat);
+	  }
+	  method.addTag(tag);
+	}
     if (method.isConcrete()) {
       method.setSource(new AsmMethodSource(maxLocals, instructions, localVariables, tryCatchBlocks));
     }

--- a/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
@@ -33,7 +33,15 @@ public class VisibilityAnnotationTag implements Tag {
 
   private int visibility;
   private ArrayList<AnnotationTag> annotations = null;
+  private short lineNumber = -1;
+  private int localIndex = -1;
 
+  public VisibilityAnnotationTag(int vis, short lineNumber, int localIndex) {
+	this(vis);
+	this.lineNumber = lineNumber;
+	this.localIndex = localIndex;
+  }
+  
   public VisibilityAnnotationTag(int vis) {
     this.visibility = vis;
   }
@@ -52,6 +60,12 @@ public class VisibilityAnnotationTag implements Tag {
         sb.append("SOURCE");
         break;
     }
+    if (lineNumber >= 0) {
+		sb.append(" Line:" + lineNumber);
+	}
+	if (localIndex >= 0) {
+		sb.append(" Line var index:" + localIndex);
+	}
     sb.append("\n Annotations:");
     if (annotations != null) {
       for (AnnotationTag tag : annotations) {

--- a/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
@@ -1,0 +1,89 @@
+package soot.tagkit;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2005 Jennifer Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.ArrayList;
+
+/**
+ * Represents the visibility of an annotation attribute attatched to a class,
+ * field, method, method param or method local variable (only one of these each) has one or more
+ * annotations for Java 1.5.
+ */
+
+public class VisibilityLocalVariableAnnotationTag implements Tag {
+
+	private int kind;
+	private ArrayList<VisibilityAnnotationTag> visibilityAnnotations;
+
+	public VisibilityLocalVariableAnnotationTag(int kind) {
+		this.kind = kind;
+	}
+
+	// should also print here number of annotations and perhaps the annotations
+	// themselves
+	public String toString() {
+		StringBuffer sb = new StringBuffer(
+				"Visibility LocalVariable Annotation: num Annotation: " + visibilityAnnotations != null
+						? String.valueOf(visibilityAnnotations.size())
+						: 0 + " kind: " + kind);
+		if (visibilityAnnotations != null) {
+			for (VisibilityAnnotationTag tag : visibilityAnnotations) {
+				sb.append("\n");
+				if (tag != null) {
+					sb.append(tag.toString());
+				}
+			}
+		}
+		sb.append("\n");
+		return sb.toString();
+	}
+
+	/** Returns the tag name. */
+	public String getName() {
+		return "VisibilityLocalVariableAnnotationTag";
+	}
+
+	public String getInfo() {
+		return "VisibilityLocalVariableAnnotation";
+	}
+
+	/** Returns the tag raw data. */
+	public byte[] getValue() {
+		throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
+	}
+
+	public void addVisibilityAnnotation(VisibilityAnnotationTag a) {
+		if (visibilityAnnotations == null) {
+			visibilityAnnotations = new ArrayList<VisibilityAnnotationTag>();
+		}
+		visibilityAnnotations.add(a);
+	}
+
+	public ArrayList<VisibilityAnnotationTag> getVisibilityAnnotations() {
+		return visibilityAnnotations;
+	}
+
+	public int getKind() {
+		return kind;
+	}
+}


### PR DESCRIPTION
Fix the Lambda newinvokespecial exception, Issue class:

```
import java.util.List;

public class testLambdaNew {
	class test {
		public test(String s) {
			System.out.println("Hello " + s);
		}
	}
	public void go(List<String> list){
		list.stream().forEach(test::new);
	}
}
```

```
Caused by: java.lang.RuntimeException: Box InvokeExprBox(null) cannot contain value: $r4(class soot.jimple.internal.JimpleLocal)
	at soot.AbstractValueBox.setValue(AbstractValueBox.java:41)
	at soot.jimple.internal.InvokeExprBox.<init>(InvokeExprBox.java:31)
	at soot.jimple.Jimple.newInvokeExprBox(Jimple.java:728)
	at soot.jimple.internal.JInvokeStmt.<init>(JInvokeStmt.java:46)
	at soot.jimple.Jimple.newInvokeStmt(Jimple.java:608)
	at soot.LambdaMetaFactory$ThunkMethodSource.invokeImplMethod(LambdaMetaFactory.java:672)
	at soot.LambdaMetaFactory$ThunkMethodSource.getInvokeBody(LambdaMetaFactory.java:486)
	at soot.LambdaMetaFactory$ThunkMethodSource.getBody(LambdaMetaFactory.java:337)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:402)
	at soot.LambdaMetaFactory.makeLambdaHelper(LambdaMetaFactory.java:239)
	at soot.asm.AsmMethodSource.convertInvokeDynamicInsn(AsmMethodSource.java:1420)
	at soot.asm.AsmMethodSource.convert(AsmMethodSource.java:1791)
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2038)
```
