### PR TITLE
Improve error message in FieldRefValidator

### DIFF
--- a/src/main/java/soot/jimple/validation/FieldRefValidator.java
+++ b/src/main/java/soot/jimple/validation/FieldRefValidator.java
@@ -75,7 +75,8 @@ public enum FieldRefValidator implements BodyValidator {
                 .add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
           }
         } catch (ResolutionFailedException e) {
-          exceptions.add(new UnitValidationException(unit, body, "Trying to get a static field which is non-static: " + v));
+	  exceptions.add(new UnitValidationException(unit, body, "Processing field ref: " +
+						       v + ", encountered ResolutionFailedException: " + e.getMessage()));
         }
       } else if (fr instanceof InstanceFieldRef) {
         InstanceFieldRef v = (InstanceFieldRef) fr;
@@ -88,7 +89,8 @@ public enum FieldRefValidator implements BodyValidator {
             exceptions.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
           }
         } catch (ResolutionFailedException e) {
-          exceptions.add(new UnitValidationException(unit, body, "Trying to get an instance field which is static: " + v));
+	  exceptions.add(new UnitValidationException(unit, body, "Processing field ref: " +
+						       v + ", encountered ResolutionFailedException: " + e.getMessage()));
         }
       } else {
         throw new RuntimeException("unknown field ref");


### PR DESCRIPTION
Previously in exception handling the error message
printed was incorrect (looks like copy paste code mistake to me). 
Previously, in the jimple field validation step, 
when a field reference in jimple was failed to be resolved, it
would print some error message that was unrelated to the cause of the problem.

Now FieldRefValidator reports the actual message
in the cases that an exception occurred.

This is an enhancement,

This change will improve the ability to debug programatically constructed jimple.