### PR TITLE
Removes uses of unordered data structures.

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -22,9 +22,9 @@ package soot.jimple.toolkits.callgraph;
  * #L%
  */
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,12 +43,12 @@ import soot.util.queue.QueueReader;
  * @author Ondrej Lhotak
  */
 public class CallGraph implements Iterable<Edge> {
-  protected Set<Edge> edges = new HashSet<Edge>();
+  protected Set<Edge> edges = new LinkedHashSet<Edge>();
   protected ChunkedQueue<Edge> stream = new ChunkedQueue<Edge>();
   protected QueueReader<Edge> reader = stream.reader();
-  protected Map<MethodOrMethodContext, Edge> srcMethodToEdge = new HashMap<MethodOrMethodContext, Edge>();
-  protected Map<Unit, Edge> srcUnitToEdge = new HashMap<Unit, Edge>();
-  protected Map<MethodOrMethodContext, Edge> tgtToEdge = new HashMap<MethodOrMethodContext, Edge>();
+  protected Map<MethodOrMethodContext, Edge> srcMethodToEdge = new LinkedHashMap<MethodOrMethodContext, Edge>();
+  protected Map<Unit, Edge> srcUnitToEdge = new LinkedHashMap<Unit, Edge>();
+  protected Map<MethodOrMethodContext, Edge> tgtToEdge = new LinkedHashMap<MethodOrMethodContext, Edge>();
   protected Edge dummy = new Edge(null, null, null, Kind.INVALID);
 
   /**

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
@@ -31,8 +31,8 @@ import heros.solver.IDESolver;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +88,7 @@ public abstract class AbstractJimpleBasedICFG implements BiDiInterproceduralCFG<
   }
 
   protected Map<Unit, Body> createUnitToOwnerMap() {
-    return new HashMap<Unit, Body>();
+    return new LinkedHashMap<Unit, Body>();
   }
 
   public AbstractJimpleBasedICFG(boolean enableExceptions) {

--- a/src/main/java/soot/toolkits/graph/UnitGraph.java
+++ b/src/main/java/soot/toolkits/graph/UnitGraph.java
@@ -24,8 +24,8 @@ package soot.toolkits.graph;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -195,7 +195,7 @@ public abstract class UnitGraph implements DirectedGraph<Unit> {
    */
   protected Map<Unit, List<Unit>> combineMapValues(Map<Unit, List<Unit>> mapA, Map<Unit, List<Unit>> mapB) {
     // The duplicate screen
-    Map<Unit, List<Unit>> result = new HashMap<Unit, List<Unit>>(mapA.size() * 2 + 1, 0.7f);
+    Map<Unit, List<Unit>> result = new LinkedHashMap<Unit, List<Unit>>(mapA.size() * 2 + 1, 0.7f);
     for (Unit unit : unitChain) {
       List<Unit> listA = mapA.get(unit);
       if (listA == null) {


### PR DESCRIPTION
This PR migrates a few unordered data structures to ordered variants so that iterations over their entires becomes deterministic.