### PR TITLE
Fix ClassCastException: ArrayType cannot be cast to RefType

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -384,6 +384,10 @@ public class OnFlyCallGraphBuilder {
           && (!invokeArgsToSize.containsKey(ics.argArray()) || !reachingArgTypes.containsKey(ics.argArray())))) {
         for (Type bType : resolveToClasses(s)) {
           assert bType instanceof RefType;
+          // do not handle array reflection
+          if (bType instanceof ArrayType) {
+        	  continue;
+          }
           SootClass baseClass = ((RefType) bType).getSootClass();
           assert !baseClass.isInterface();
           Iterator<SootMethod> mIt = getPublicNullaryMethodIterator(baseClass);
@@ -433,6 +437,10 @@ public class OnFlyCallGraphBuilder {
   private void resolveStaticTypes(Set<Type> s, InvokeCallSite ics) {
     ArrayTypes at = ics.reachingTypes();
     for (Type bType : resolveToClasses(s)) {
+      // do not handle array reflection
+      if (bType instanceof ArrayType) {
+    	  continue;
+      }
       SootClass baseClass = ((RefType) bType).getSootClass();
       Iterator<SootMethod> mIt = getPublicMethodIterator(baseClass, at);
       while (mIt.hasNext()) {


### PR DESCRIPTION
When running the latest version of FlowDroid on some real-world apps, which is built on top of Soot with reflection handling enabled, FlowDroid throws the following exception:

```
java.lang.ClassCastException: soot.ArrayType cannot be cast to soot.RefType
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.resolveStaticTypes(OnFlyCallGraphBuilder.java:436)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.resolveInvoke(OnFlyCallGraphBuilder.java:376)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.addBaseType(OnFlyCallGraphBuilder.java:288)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.addType(OnFlyCallGraphBuilder.java:608)
	at soot.jimple.spark.solver.OnFlyCallGraph$2.visit(OnFlyCallGraph.java:139)
	at soot.jimple.spark.sets.HybridPointsToSet.forall(HybridPointsToSet.java:108)
	at soot.jimple.spark.solver.OnFlyCallGraph.updatedNode(OnFlyCallGraph.java:136)
	at soot.jimple.spark.solver.PropWorklist.handleVarNode(PropWorklist.java:158)
	at soot.jimple.spark.solver.PropWorklist.propagate(PropWorklist.java:81)
	at soot.jimple.spark.SparkTransformer.propagatePAG(SparkTransformer.java:238)
	at soot.jimple.spark.SparkTransformer.internalTransform(SparkTransformer.java:155)
	at soot.SceneTransformer.transform(SceneTransformer.java:36)
	at soot.Transform.apply(Transform.java:102)
	at soot.RadioScenePack.internalApply(RadioScenePack.java:68)
	at soot.jimple.toolkits.callgraph.CallGraphPack.internalApply(CallGraphPack.java:58)
	at soot.Pack.apply(Pack.java:117)
	at soot.jimple.infoflow.android.SetupApplication.constructCallgraphInternal(SetupApplication.java:569)
	at soot.jimple.infoflow.android.SetupApplication.calculateCallbackMethods(SetupApplication.java:681)
	at soot.jimple.infoflow.android.SetupApplication.calculateCallbacks(SetupApplication.java:480)
	at soot.jimple.infoflow.android.SetupApplication.calculateCallbacks(SetupApplication.java:450)
	at soot.jimple.infoflow.android.SetupApplication.processEntryPoint(SetupApplication.java:1448)
	at soot.jimple.infoflow.android.SetupApplication.runInfoflow(SetupApplication.java:1414)
	at soot.jimple.infoflow.android.SetupApplication.runInfoflow(SetupApplication.java:1361)
	at soot.jimple.infoflow.cmd.MainClass.run(MainClass.java:341)
	at soot.jimple.infoflow.cmd.MainClass.main(MainClass.java:239)
```

I further figure out the bug actually comes from Soot, when resolving reflective calls in the stage of building call graph. Such process needs to resolve the object instance on which the direct call should be invoked. This object theoretically should not be an array.

In the original `OnFlyCallGraphBuilder.java` before applying modifications of this pull request, there are three places that try to cast a `Type` into `RefType`. Only in one place (line 414-419), the variable of `Type` is checked to ensure it is an instance of `RefType`. The other two places (line 386-387 and line 436) do not have such protection. Thus, when the variable is actually a `ArrayType`, it cannot be casted to `RefType`, leading to exceptions. This patch adds protection at those two places to ensure the instance must be `RefType`.

In the following I provide an example to reproduce this bug.
[ReflectionWrongArrType.zip](https://github.com/Sable/soot/files/4322450/ReflectionWrongArrType.zip)

I notice the bug is actually related to how Java compiler handles generic types and how Spark in Soot collects points-to information. In the following example, the generic type is set to an array (`Object[]`) in the declaration of `ObjectArr`. For every actual implementation of the generic methods like `returnT()`, Java compiler generates a bridge method to convert the actual type to Object in order to perform [type erasure](https://docs.oracle.com/javase/tutorial/java/generics/bridgeMethods.html). When Spark collects points-to information inside the bridge method, it wrongly connects objects with two different types, e. g., `Object[]` to `Object` in my example. In the end, when the returned instance (`recArr`) is used in the reflective call, as it can be an `ArrayType`, the exception is triggered.

```
public interface Generic<T> {
    T returnT();
}

public class ObjectArr implements Generic<Object[]> {
    @Override
    public Object[] returnT() {
        return new Object[]{MainActivity.this};
    }

    // a synthetic method is generated for the above method, in the form of Jimple
    public volatile java.lang.Object returnT()
    {
        junbin.ubc.MainActivity$ObjectArr $r0;
        java.lang.Object[] $r1;
        $r0 := @this: junbin.ubc.MainActivity$ObjectArr;
        $r1 = virtualinvoke $r0.<junbin.ubc.MainActivity$ObjectArr: java.lang.Object[] returnT()>();
        return $r1;
    }
}

public class MainActivity extends Activity {
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        // invoke generic method
        Generic obj = new ObjectArr();
        Object recArr = obj.returnT();

        // reflective call
        Method m = getClass().getMethod("leak");
        m.invoke(((Object[]) recArr)[0]);
    }
}
```

Unfortunately I am not able to provide command line options for Soot to trigger the bug, but I can provide the options for FlowDroid to reproduce the issue. Note that `-r` is a must to enable reflection handling.

```
-a /path/to/ReflectionWrongArrType.apk -p /path/to/android-platforms -s /path/to/sourcesandsinks  -r
``` 